### PR TITLE
[FEAT] LoginArgumentResolver 기능 구현 및 테스트

### DIFF
--- a/server/src/main/java/moment/auth/application/AuthService.java
+++ b/server/src/main/java/moment/auth/application/AuthService.java
@@ -1,10 +1,11 @@
 package moment.auth.application;
 
 import lombok.RequiredArgsConstructor;
-import moment.auth.dto.LoginRequest;
+import moment.auth.dto.request.LoginRequest;
 import moment.global.exception.ErrorCode;
 import moment.global.exception.MomentException;
 import moment.user.domain.User;
+import moment.user.dto.request.LoginUser;
 import moment.user.infrastructure.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,5 +27,15 @@ public class AuthService {
         }
 
         return tokenManager.createToken(user.getId(), user.getEmail());
+    }
+
+    public LoginUser getLoginUserByToken(String token) {
+        LoginUser loginUser = tokenManager.getLoginUserByToken(token);
+
+        if(!userRepository.existsById(loginUser.id())) {
+            throw new MomentException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        return loginUser;
     }
 }

--- a/server/src/main/java/moment/auth/application/AuthService.java
+++ b/server/src/main/java/moment/auth/application/AuthService.java
@@ -5,7 +5,7 @@ import moment.auth.dto.request.LoginRequest;
 import moment.global.exception.ErrorCode;
 import moment.global.exception.MomentException;
 import moment.user.domain.User;
-import moment.user.dto.request.LoginUser;
+import moment.user.dto.request.Authentication;
 import moment.user.infrastructure.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,13 +29,13 @@ public class AuthService {
         return tokenManager.createToken(user.getId(), user.getEmail());
     }
 
-    public LoginUser getLoginUserByToken(String token) {
-        LoginUser loginUser = tokenManager.getLoginUserByToken(token);
+    public Authentication getAuthenticationByToken(String token) {
+        Authentication authentication = tokenManager.extractAuthentication(token);
 
-        if(!userRepository.existsById(loginUser.id())) {
+        if(!userRepository.existsById(authentication.id())) {
             throw new MomentException(ErrorCode.USER_NOT_FOUND);
         }
 
-        return loginUser;
+        return authentication;
     }
 }

--- a/server/src/main/java/moment/auth/application/TokenManager.java
+++ b/server/src/main/java/moment/auth/application/TokenManager.java
@@ -1,10 +1,13 @@
 package moment.auth.application;
 
 import io.jsonwebtoken.Claims;
+import moment.user.dto.request.LoginUser;
 
 public interface TokenManager {
 
     String createToken(Long id, String email);
 
     Claims extractClaims(String token);
+
+    LoginUser getLoginUserByToken(String token);
 }

--- a/server/src/main/java/moment/auth/application/TokenManager.java
+++ b/server/src/main/java/moment/auth/application/TokenManager.java
@@ -1,7 +1,7 @@
 package moment.auth.application;
 
 import io.jsonwebtoken.Claims;
-import moment.user.dto.request.LoginUser;
+import moment.user.dto.request.Authentication;
 
 public interface TokenManager {
 
@@ -9,5 +9,5 @@ public interface TokenManager {
 
     Claims extractClaims(String token);
 
-    LoginUser getLoginUserByToken(String token);
+    Authentication extractAuthentication(String token);
 }

--- a/server/src/main/java/moment/auth/dto/request/LoginRequest.java
+++ b/server/src/main/java/moment/auth/dto/request/LoginRequest.java
@@ -1,4 +1,4 @@
-package moment.auth.dto;
+package moment.auth.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/server/src/main/java/moment/auth/infrastructure/JwtTokenManager.java
+++ b/server/src/main/java/moment/auth/infrastructure/JwtTokenManager.java
@@ -14,7 +14,7 @@ import javax.crypto.spec.SecretKeySpec;
 import moment.auth.application.TokenManager;
 import moment.global.exception.ErrorCode;
 import moment.global.exception.MomentException;
-import moment.user.dto.request.LoginUser;
+import moment.user.dto.request.Authentication;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -66,7 +66,7 @@ public class JwtTokenManager implements TokenManager {
     }
 
     @Override
-    public LoginUser getLoginUserByToken(String token) {
+    public Authentication extractAuthentication(String token) {
         Jws<Claims> verifiedJwt = Jwts.parser()
                 .verifyWith(new SecretKeySpec(secretKey.getBytes(), "HmacSHA256"))
                 .build()
@@ -74,6 +74,6 @@ public class JwtTokenManager implements TokenManager {
 
         Long id = Long.valueOf(verifiedJwt.getPayload().getSubject());
 
-        return LoginUser.from(id);
+        return Authentication.from(id);
     }
 }

--- a/server/src/main/java/moment/auth/infrastructure/JwtTokenManager.java
+++ b/server/src/main/java/moment/auth/infrastructure/JwtTokenManager.java
@@ -4,6 +4,7 @@ import static io.jsonwebtoken.Jwts.SIG.HS256;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
@@ -13,6 +14,7 @@ import javax.crypto.spec.SecretKeySpec;
 import moment.auth.application.TokenManager;
 import moment.global.exception.ErrorCode;
 import moment.global.exception.MomentException;
+import moment.user.dto.request.LoginUser;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -61,5 +63,17 @@ public class JwtTokenManager implements TokenManager {
         } catch (JwtException jwtException) {
             throw new MomentException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
+    }
+
+    @Override
+    public LoginUser getLoginUserByToken(String token) {
+        Jws<Claims> verifiedJwt = Jwts.parser()
+                .verifyWith(new SecretKeySpec(secretKey.getBytes(), "HmacSHA256"))
+                .build()
+                .parseSignedClaims(token);
+
+        Long id = Long.valueOf(verifiedJwt.getPayload().getSubject());
+
+        return LoginUser.from(id);
     }
 }

--- a/server/src/main/java/moment/auth/presentation/AuthController.java
+++ b/server/src/main/java/moment/auth/presentation/AuthController.java
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import moment.auth.application.AuthService;
-import moment.auth.dto.LoginRequest;
+import moment.auth.dto.request.LoginRequest;
 import moment.global.dto.response.ErrorResponse;
 import moment.global.dto.response.SuccessResponse;
 import org.springframework.http.HttpHeaders;

--- a/server/src/main/java/moment/auth/presentation/AuthenticationPrincipal.java
+++ b/server/src/main/java/moment/auth/presentation/AuthenticationPrincipal.java
@@ -1,0 +1,12 @@
+package moment.auth.presentation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthenticationPrincipal {
+    boolean required() default true;
+}

--- a/server/src/main/java/moment/auth/presentation/LoginUserArgumentResolver.java
+++ b/server/src/main/java/moment/auth/presentation/LoginUserArgumentResolver.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 import moment.auth.application.AuthService;
 import moment.global.exception.ErrorCode;
 import moment.global.exception.MomentException;
-import moment.user.dto.request.LoginUser;
+import moment.user.dto.request.Authentication;
 import org.springframework.core.MethodParameter;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -21,7 +21,7 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        return parameter.getParameterType().equals(LoginUser.class)
+        return parameter.getParameterType().equals(Authentication.class)
                 && parameter.hasParameterAnnotation(AuthenticationPrincipal.class);
     }
 
@@ -30,7 +30,7 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
                                   NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         String token = getToken(request);
-        return authService.getLoginUserByToken(token);
+        return authService.getAuthenticationByToken(token);
     }
 
     private String getToken(HttpServletRequest request) throws MomentException {

--- a/server/src/main/java/moment/auth/presentation/LoginUserArgumentResolver.java
+++ b/server/src/main/java/moment/auth/presentation/LoginUserArgumentResolver.java
@@ -1,0 +1,49 @@
+package moment.auth.presentation;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
+import moment.auth.application.AuthService;
+import moment.global.exception.ErrorCode;
+import moment.global.exception.MomentException;
+import moment.user.dto.request.LoginUser;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@RequiredArgsConstructor
+public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final AuthService authService;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(LoginUser.class)
+                && parameter.hasParameterAnnotation(AuthenticationPrincipal.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        String token = getToken(request);
+        return authService.getLoginUserByToken(token);
+    }
+
+    private String getToken(HttpServletRequest request) throws MomentException {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            throw new MomentException(ErrorCode.TOKEN_NOT_FOUND);
+        }
+
+        return Arrays.stream(cookies)
+                .filter(cookie -> cookie.getName()
+                        .equals("token"))
+                .findFirst()
+                .orElseThrow(() -> new MomentException(ErrorCode.TOKEN_NOT_FOUND))
+                .getValue();
+    }
+}

--- a/server/src/main/java/moment/global/config/WebConfig.java
+++ b/server/src/main/java/moment/global/config/WebConfig.java
@@ -1,0 +1,21 @@
+package moment.global.config;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import moment.auth.application.AuthService;
+import moment.auth.presentation.LoginUserArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthService authService;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new LoginUserArgumentResolver(authService));
+    }
+}

--- a/server/src/main/java/moment/global/exception/ErrorCode.java
+++ b/server/src/main/java/moment/global/exception/ErrorCode.java
@@ -19,7 +19,8 @@ public enum ErrorCode {
     TOKEN_INVALID("T-001", "유효하지 않은 토큰입니다." , HttpStatus.UNAUTHORIZED),
     TOKEN_EXPIRED("T-002", "만료된 토큰입니다." , HttpStatus.UNAUTHORIZED),
     TOKEN_EMPTY("T-003", "빈 토큰입니다." , HttpStatus.UNAUTHORIZED),
-    TOKEN_NOT_SIGNED("T-004", "서명되지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED);
+    TOKEN_NOT_SIGNED("T-004", "서명되지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
+    TOKEN_NOT_FOUND("T-005", "토큰을 찾을 수 없습니다.", HttpStatus.UNAUTHORIZED);
 
     ErrorCode(String code, String message, HttpStatus status) {
         this.code = code;

--- a/server/src/main/java/moment/user/application/UserService.java
+++ b/server/src/main/java/moment/user/application/UserService.java
@@ -4,7 +4,9 @@ import lombok.RequiredArgsConstructor;
 import moment.global.exception.ErrorCode;
 import moment.global.exception.MomentException;
 import moment.user.domain.User;
+import moment.user.dto.request.LoginUser;
 import moment.user.dto.request.UserCreateRequest;
+import moment.user.dto.response.UserProfileResponse;
 import moment.user.infrastructure.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,5 +42,11 @@ public class UserService {
         if (userRepository.existsByNickname(request.nickname())) {
             throw new MomentException(ErrorCode.USER_NICKNAME_CONFLICT);
         }
+    }
+
+    public UserProfileResponse getUserProfile(LoginUser loginUser) {
+        User user = userRepository.findById(loginUser.id())
+                .orElseThrow(() -> new MomentException(ErrorCode.USER_NOT_FOUND));
+        return UserProfileResponse.from(user);
     }
 }

--- a/server/src/main/java/moment/user/application/UserService.java
+++ b/server/src/main/java/moment/user/application/UserService.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import moment.global.exception.ErrorCode;
 import moment.global.exception.MomentException;
 import moment.user.domain.User;
-import moment.user.dto.request.LoginUser;
+import moment.user.dto.request.Authentication;
 import moment.user.dto.request.UserCreateRequest;
 import moment.user.dto.response.UserProfileResponse;
 import moment.user.infrastructure.UserRepository;
@@ -44,8 +44,8 @@ public class UserService {
         }
     }
 
-    public UserProfileResponse getUserProfile(LoginUser loginUser) {
-        User user = userRepository.findById(loginUser.id())
+    public UserProfileResponse getUserProfile(Authentication authentication) {
+        User user = userRepository.findById(authentication.id())
                 .orElseThrow(() -> new MomentException(ErrorCode.USER_NOT_FOUND));
         return UserProfileResponse.from(user);
     }

--- a/server/src/main/java/moment/user/dto/request/Authentication.java
+++ b/server/src/main/java/moment/user/dto/request/Authentication.java
@@ -1,0 +1,8 @@
+package moment.user.dto.request;
+
+public record Authentication(Long id) {
+
+    public static Authentication from(Long id) {
+        return new Authentication(id);
+    }
+}

--- a/server/src/main/java/moment/user/dto/request/LoginUser.java
+++ b/server/src/main/java/moment/user/dto/request/LoginUser.java
@@ -1,8 +1,0 @@
-package moment.user.dto.request;
-
-public record LoginUser(Long id) {
-
-    public static LoginUser from(Long id) {
-        return new LoginUser(id);
-    }
-}

--- a/server/src/main/java/moment/user/dto/request/LoginUser.java
+++ b/server/src/main/java/moment/user/dto/request/LoginUser.java
@@ -1,0 +1,8 @@
+package moment.user.dto.request;
+
+public record LoginUser(Long id) {
+
+    public static LoginUser from(Long id) {
+        return new LoginUser(id);
+    }
+}

--- a/server/src/main/java/moment/user/dto/response/UserProfileResponse.java
+++ b/server/src/main/java/moment/user/dto/response/UserProfileResponse.java
@@ -1,0 +1,15 @@
+package moment.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import moment.user.domain.User;
+
+@Schema(description = "유저 프로필 응답")
+public record UserProfileResponse(
+        @Schema(description = "사용자 닉네임", example = "mimi")
+        String nickname
+) {
+
+    public static UserProfileResponse from(User user) {
+        return new UserProfileResponse(user.getNickname());
+    }
+}

--- a/server/src/main/java/moment/user/presentation/UserController.java
+++ b/server/src/main/java/moment/user/presentation/UserController.java
@@ -11,7 +11,7 @@ import moment.auth.presentation.AuthenticationPrincipal;
 import moment.global.dto.response.ErrorResponse;
 import moment.global.dto.response.SuccessResponse;
 import moment.user.application.UserService;
-import moment.user.dto.request.LoginUser;
+import moment.user.dto.request.Authentication;
 import moment.user.dto.request.UserCreateRequest;
 import moment.user.dto.response.UserProfileResponse;
 import org.springframework.http.HttpStatus;
@@ -73,9 +73,9 @@ public class UserController {
     })
     @GetMapping("/me")
     public ResponseEntity<SuccessResponse<UserProfileResponse>> readUserProfile(
-            @AuthenticationPrincipal LoginUser loginUser
+            @AuthenticationPrincipal Authentication authentication
     ) {
-        UserProfileResponse response = userService.getUserProfile(loginUser);
+        UserProfileResponse response = userService.getUserProfile(authentication);
         HttpStatus status = HttpStatus.OK;
         return ResponseEntity.status(status).body(SuccessResponse.of(status,response));
     }

--- a/server/src/main/java/moment/user/presentation/UserController.java
+++ b/server/src/main/java/moment/user/presentation/UserController.java
@@ -7,12 +7,16 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import moment.auth.presentation.AuthenticationPrincipal;
 import moment.global.dto.response.ErrorResponse;
 import moment.global.dto.response.SuccessResponse;
 import moment.user.application.UserService;
+import moment.user.dto.request.LoginUser;
 import moment.user.dto.request.UserCreateRequest;
+import moment.user.dto.response.UserProfileResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -52,5 +56,27 @@ public class UserController {
         userService.addUser(request);
         HttpStatus status = HttpStatus.CREATED;
         return ResponseEntity.status(status).body(SuccessResponse.of(status, null));
+    }
+
+    @Operation(summary = "프로필 조회", description = "사용자가 프로필을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인 성공"),
+            @ApiResponse(responseCode = "401", description = """
+                    - [T-005] 토큰을 찾을 수 없습니다.
+                    """,
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(responseCode = "404", description = """
+                    - [U-002] 존재하지 않는 사용자입니다.
+                    """,
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+    })
+    @GetMapping("/me")
+    public ResponseEntity<SuccessResponse<UserProfileResponse>> readUserProfile(
+            @AuthenticationPrincipal LoginUser loginUser
+    ) {
+        UserProfileResponse response = userService.getUserProfile(loginUser);
+        HttpStatus status = HttpStatus.OK;
+        return ResponseEntity.status(status).body(SuccessResponse.of(status,response));
     }
 }

--- a/server/src/test/java/moment/auth/application/AuthServiceTest.java
+++ b/server/src/test/java/moment/auth/application/AuthServiceTest.java
@@ -10,7 +10,7 @@ import moment.auth.dto.request.LoginRequest;
 import moment.global.exception.ErrorCode;
 import moment.global.exception.MomentException;
 import moment.user.domain.User;
-import moment.user.dto.request.LoginUser;
+import moment.user.dto.request.Authentication;
 import moment.user.infrastructure.UserRepository;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -76,29 +76,29 @@ class AuthServiceTest {
     }
 
     @Test
-    void 토큰으로_유저를_조회할_수_있다() {
+    void 토큰에서_인증정보를_추출할_수_있다() {
         // given
         String token = "validToken";
-        LoginUser loginUser = new LoginUser(1L);
+        Authentication authentication = new Authentication(1L);
 
-        given(tokenManager.getLoginUserByToken(token)).willReturn(loginUser);
+        given(tokenManager.extractAuthentication(token)).willReturn(authentication);
         given(userRepository.existsById(1L)).willReturn(true);
 
         // when & then
-        assertThat(authService.getLoginUserByToken(token)).isEqualTo(loginUser);
+        assertThat(authService.getAuthenticationByToken(token)).isEqualTo(authentication);
     }
 
     @Test
     void 토큰에서_추출한_유저의_ID가_존재하지_않을_경우_예외가_발생한다() {
         // given
         String token = "invalidToken";
-        LoginUser loginUser = new LoginUser(1L);
+        Authentication authentication = new Authentication(1L);
 
-        given(tokenManager.getLoginUserByToken(token)).willReturn(loginUser);
+        given(tokenManager.extractAuthentication(token)).willReturn(authentication);
         given(userRepository.existsById(1L)).willReturn(false);
 
         // when & then
-        assertThatThrownBy(() -> authService.getLoginUserByToken(token))
+        assertThatThrownBy(() -> authService.getAuthenticationByToken(token))
                 .isInstanceOf(MomentException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
     }

--- a/server/src/test/java/moment/auth/application/AuthServiceTest.java
+++ b/server/src/test/java/moment/auth/application/AuthServiceTest.java
@@ -6,10 +6,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 import java.util.Optional;
-import moment.auth.dto.LoginRequest;
+import moment.auth.dto.request.LoginRequest;
 import moment.global.exception.ErrorCode;
 import moment.global.exception.MomentException;
 import moment.user.domain.User;
+import moment.user.dto.request.LoginUser;
 import moment.user.infrastructure.UserRepository;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -70,6 +71,34 @@ class AuthServiceTest {
 
         // when & then
         assertThatThrownBy(() -> authService.login(request))
+                .isInstanceOf(MomentException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    void 토큰으로_유저를_조회할_수_있다() {
+        // given
+        String token = "validToken";
+        LoginUser loginUser = new LoginUser(1L);
+
+        given(tokenManager.getLoginUserByToken(token)).willReturn(loginUser);
+        given(userRepository.existsById(1L)).willReturn(true);
+
+        // when & then
+        assertThat(authService.getLoginUserByToken(token)).isEqualTo(loginUser);
+    }
+
+    @Test
+    void 토큰에서_추출한_유저의_ID가_존재하지_않을_경우_예외가_발생한다() {
+        // given
+        String token = "invalidToken";
+        LoginUser loginUser = new LoginUser(1L);
+
+        given(tokenManager.getLoginUserByToken(token)).willReturn(loginUser);
+        given(userRepository.existsById(1L)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> authService.getLoginUserByToken(token))
                 .isInstanceOf(MomentException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
     }

--- a/server/src/test/java/moment/auth/presentation/AuthControllerTest.java
+++ b/server/src/test/java/moment/auth/presentation/AuthControllerTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import io.jsonwebtoken.Claims;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
-import moment.auth.dto.LoginRequest;
+import moment.auth.dto.request.LoginRequest;
 import moment.auth.infrastructure.JwtTokenManager;
 import moment.user.domain.User;
 import moment.user.infrastructure.UserRepository;


### PR DESCRIPTION
# 📋 연관 이슈

- close #61 

# 🚀 작업 내용

- 1. LoginArumentResolver를 구현하였습니다.
- 2. 관련된 테스트 코드를 작성하였습니다.
- 3. 토큰을 기반으로 사용자의 프로필을 조회할 수 있는 api를 생성하였습니다.

# 💬 리뷰 중점 사항
- 현재 LoginUser는 id만 필드로 가지고 있는데, 혹시 더 필요한 값이 있을까요?
- 3번 작업은 api 테스트 겸 사용할 것이라고 예측되어 작성해보았습니다! (아니면 유감..) 
   현재 nickname만 반환하도록 설정하였는데, 추가 필드가 필요할까요 ? 🤔
- 클래스가 각각 적절한 패키지에 분리되었을까요 ?
- 추가된 기능에 알맞은 테스트가 추가되었을까요 ? !