### PR TITLE
[FEAT] 오늘의 모멘트 페이지 구현

### DIFF
--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -50,10 +50,10 @@ importers:
         version: 9.0.16(@types/react@19.1.8)(storybook@9.0.17(@testing-library/dom@10.4.0)(prettier@3.6.2))
       '@storybook/addon-webpack5-compiler-swc':
         specifier: 3.0.0
-        version: 3.0.0(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1))
+        version: 3.0.0(webpack@5.100.1)
       '@storybook/react-webpack5':
         specifier: ^9.0.16
-        version: 9.0.16(@swc/core@1.12.14)(esbuild@0.25.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.17(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(webpack-cli@6.0.1(webpack-dev-server@5.2.2)(webpack@5.100.1))
+        version: 9.0.16(@swc/core@1.12.14)(esbuild@0.25.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.17(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(webpack-cli@6.0.1)
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -77,10 +77,10 @@ importers:
         version: 30.0.4(@babel/core@7.28.0)
       babel-loader:
         specifier: ^10.0.0
-        version: 10.0.0(@babel/core@7.28.0)(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1))
+        version: 10.0.0(@babel/core@7.28.0)(webpack@5.100.1)
       css-loader:
         specifier: ^7.1.2
-        version: 7.1.2(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1))
+        version: 7.1.2(webpack@5.100.1)
       eslint:
         specifier: ^9.31.0
         version: 9.31.0
@@ -92,10 +92,10 @@ importers:
         version: 9.0.16(eslint@9.31.0)(storybook@9.0.17(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)
       fork-ts-checker-webpack-plugin:
         specifier: ^9.1.0
-        version: 9.1.0(typescript@5.8.3)(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1))
+        version: 9.1.0(typescript@5.8.3)(webpack@5.100.1)
       html-webpack-plugin:
         specifier: ^5.6.3
-        version: 5.6.3(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1))
+        version: 5.6.3(webpack@5.100.1)
       jest:
         specifier: ^30.0.4
         version: 30.0.4(@types/node@24.0.14)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.6))
@@ -113,7 +113,7 @@ importers:
         version: 9.0.17(@testing-library/dom@10.4.0)(prettier@3.6.2)
       style-loader:
         specifier: ^4.0.0
-        version: 4.0.0(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1))
+        version: 4.0.0(webpack@5.100.1)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -6221,30 +6221,30 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-webpack5-compiler-swc@3.0.0(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1))':
+  '@storybook/addon-webpack5-compiler-swc@3.0.0(webpack@5.100.1)':
     dependencies:
       '@swc/core': 1.12.14
-      swc-loader: 0.2.6(@swc/core@1.12.14)(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1))
+      swc-loader: 0.2.6(@swc/core@1.12.14)(webpack@5.100.1)
     transitivePeerDependencies:
       - '@swc/helpers'
       - webpack
 
-  '@storybook/builder-webpack5@9.0.16(@swc/core@1.12.14)(esbuild@0.25.6)(storybook@9.0.17(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(webpack-cli@6.0.1(webpack-dev-server@5.2.2)(webpack@5.100.1))':
+  '@storybook/builder-webpack5@9.0.16(@swc/core@1.12.14)(esbuild@0.25.6)(storybook@9.0.17(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(webpack-cli@6.0.1)':
     dependencies:
       '@storybook/core-webpack': 9.0.16(storybook@9.0.17(@testing-library/dom@10.4.0)(prettier@3.6.2))
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.4.3
-      css-loader: 6.11.0(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1))
+      css-loader: 6.11.0(webpack@5.100.1)
       es-module-lexer: 1.7.0
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.8.3)(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1))
-      html-webpack-plugin: 5.6.3(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1))
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.8.3)(webpack@5.100.1)
+      html-webpack-plugin: 5.6.3(webpack@5.100.1)
       magic-string: 0.30.17
       storybook: 9.0.17(@testing-library/dom@10.4.0)(prettier@3.6.2)
-      style-loader: 3.3.4(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1))
-      terser-webpack-plugin: 5.3.14(@swc/core@1.12.14)(esbuild@0.25.6)(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1))
+      style-loader: 3.3.4(webpack@5.100.1)
+      terser-webpack-plugin: 5.3.14(@swc/core@1.12.14)(esbuild@0.25.6)(webpack@5.100.1)
       ts-dedent: 2.2.0
       webpack: 5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1)
-      webpack-dev-middleware: 6.1.3(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1))
+      webpack-dev-middleware: 6.1.3(webpack@5.100.1)
       webpack-hot-middleware: 2.26.1
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
@@ -6273,10 +6273,10 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@storybook/preset-react-webpack@9.0.16(@swc/core@1.12.14)(esbuild@0.25.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.17(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(webpack-cli@6.0.1(webpack-dev-server@5.2.2)(webpack@5.100.1))':
+  '@storybook/preset-react-webpack@9.0.16(@swc/core@1.12.14)(esbuild@0.25.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.17(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(webpack-cli@6.0.1)':
     dependencies:
       '@storybook/core-webpack': 9.0.16(storybook@9.0.17(@testing-library/dom@10.4.0)(prettier@3.6.2))
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.8.3)(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1))
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.8.3)(webpack@5.100.1)
       '@types/semver': 7.7.0
       find-up: 7.0.0
       magic-string: 0.30.17
@@ -6297,7 +6297,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.8.3)(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1))':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.8.3)(webpack@5.100.1)':
     dependencies:
       debug: 4.4.1
       endent: 2.1.0
@@ -6317,10 +6317,10 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
       storybook: 9.0.17(@testing-library/dom@10.4.0)(prettier@3.6.2)
 
-  '@storybook/react-webpack5@9.0.16(@swc/core@1.12.14)(esbuild@0.25.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.17(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(webpack-cli@6.0.1(webpack-dev-server@5.2.2)(webpack@5.100.1))':
+  '@storybook/react-webpack5@9.0.16(@swc/core@1.12.14)(esbuild@0.25.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.17(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(webpack-cli@6.0.1)':
     dependencies:
-      '@storybook/builder-webpack5': 9.0.16(@swc/core@1.12.14)(esbuild@0.25.6)(storybook@9.0.17(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(webpack-cli@6.0.1(webpack-dev-server@5.2.2)(webpack@5.100.1))
-      '@storybook/preset-react-webpack': 9.0.16(@swc/core@1.12.14)(esbuild@0.25.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.17(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(webpack-cli@6.0.1(webpack-dev-server@5.2.2)(webpack@5.100.1))
+      '@storybook/builder-webpack5': 9.0.16(@swc/core@1.12.14)(esbuild@0.25.6)(storybook@9.0.17(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(webpack-cli@6.0.1)
+      '@storybook/preset-react-webpack': 9.0.16(@swc/core@1.12.14)(esbuild@0.25.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.17(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(webpack-cli@6.0.1)
       '@storybook/react': 9.0.16(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.17(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
@@ -6864,17 +6864,17 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
-  '@webpack-cli/configtest@3.0.1(webpack-cli@6.0.1(webpack-dev-server@5.2.2)(webpack@5.100.1))(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1))':
+  '@webpack-cli/configtest@3.0.1(webpack-cli@6.0.1)(webpack@5.100.1)':
     dependencies:
       webpack: 5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-dev-server@5.2.2)(webpack@5.100.1)
 
-  '@webpack-cli/info@3.0.1(webpack-cli@6.0.1(webpack-dev-server@5.2.2)(webpack@5.100.1))(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1))':
+  '@webpack-cli/info@3.0.1(webpack-cli@6.0.1)(webpack@5.100.1)':
     dependencies:
       webpack: 5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-dev-server@5.2.2)(webpack@5.100.1)
 
-  '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1(webpack-dev-server@5.2.2)(webpack@5.100.1))(webpack-dev-server@5.2.2(webpack-cli@6.0.1)(webpack@5.100.1))(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1))':
+  '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.2)(webpack@5.100.1)':
     dependencies:
       webpack: 5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-dev-server@5.2.2)(webpack@5.100.1)
@@ -6985,7 +6985,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@10.0.0(@babel/core@7.28.0)(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1)):
+  babel-loader@10.0.0(@babel/core@7.28.0)(webpack@5.100.1):
     dependencies:
       '@babel/core': 7.28.0
       find-up: 5.0.0
@@ -7308,7 +7308,7 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  css-loader@6.11.0(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1)):
+  css-loader@6.11.0(webpack@5.100.1):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -7321,7 +7321,7 @@ snapshots:
     optionalDependencies:
       webpack: 5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1)
 
-  css-loader@7.1.2(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1)):
+  css-loader@7.1.2(webpack@5.100.1):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -7915,7 +7915,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.8.3)(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1)):
+  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.8.3)(webpack@5.100.1):
     dependencies:
       '@babel/code-frame': 7.27.1
       chalk: 4.1.2
@@ -7932,7 +7932,7 @@ snapshots:
       typescript: 5.8.3
       webpack: 5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1)
 
-  fork-ts-checker-webpack-plugin@9.1.0(typescript@5.8.3)(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1)):
+  fork-ts-checker-webpack-plugin@9.1.0(typescript@5.8.3)(webpack@5.100.1):
     dependencies:
       '@babel/code-frame': 7.27.1
       chalk: 4.1.2
@@ -8075,7 +8075,7 @@ snapshots:
       relateurl: 0.2.7
       terser: 5.43.1
 
-  html-webpack-plugin@5.6.3(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1)):
+  html-webpack-plugin@5.6.3(webpack@5.100.1):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -9527,11 +9527,11 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  style-loader@3.3.4(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1)):
+  style-loader@3.3.4(webpack@5.100.1):
     dependencies:
       webpack: 5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1)
 
-  style-loader@4.0.0(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1)):
+  style-loader@4.0.0(webpack@5.100.1):
     dependencies:
       webpack: 5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1)
 
@@ -9547,7 +9547,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  swc-loader@0.2.6(@swc/core@1.12.14)(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1)):
+  swc-loader@0.2.6(@swc/core@1.12.14)(webpack@5.100.1):
     dependencies:
       '@swc/core': 1.12.14
       '@swc/counter': 0.1.3
@@ -9561,7 +9561,7 @@ snapshots:
 
   tapable@2.2.2: {}
 
-  terser-webpack-plugin@5.3.14(@swc/core@1.12.14)(esbuild@0.25.6)(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1)):
+  terser-webpack-plugin@5.3.14(@swc/core@1.12.14)(esbuild@0.25.6)(webpack@5.100.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.29
       jest-worker: 27.5.1
@@ -9783,9 +9783,9 @@ snapshots:
   webpack-cli@6.0.1(webpack-dev-server@5.2.2)(webpack@5.100.1):
     dependencies:
       '@discoveryjs/json-ext': 0.6.3
-      '@webpack-cli/configtest': 3.0.1(webpack-cli@6.0.1(webpack-dev-server@5.2.2)(webpack@5.100.1))(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1))
-      '@webpack-cli/info': 3.0.1(webpack-cli@6.0.1(webpack-dev-server@5.2.2)(webpack@5.100.1))(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1))
-      '@webpack-cli/serve': 3.0.1(webpack-cli@6.0.1(webpack-dev-server@5.2.2)(webpack@5.100.1))(webpack-dev-server@5.2.2(webpack-cli@6.0.1)(webpack@5.100.1))(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1))
+      '@webpack-cli/configtest': 3.0.1(webpack-cli@6.0.1)(webpack@5.100.1)
+      '@webpack-cli/info': 3.0.1(webpack-cli@6.0.1)(webpack@5.100.1)
+      '@webpack-cli/serve': 3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.2)(webpack@5.100.1)
       colorette: 2.0.20
       commander: 12.1.0
       cross-spawn: 7.0.6
@@ -9799,7 +9799,7 @@ snapshots:
     optionalDependencies:
       webpack-dev-server: 5.2.2(webpack-cli@6.0.1)(webpack@5.100.1)
 
-  webpack-dev-middleware@6.1.3(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1)):
+  webpack-dev-middleware@6.1.3(webpack@5.100.1):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
@@ -9809,7 +9809,7 @@ snapshots:
     optionalDependencies:
       webpack: 5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1)
 
-  webpack-dev-middleware@7.4.2(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1)):
+  webpack-dev-middleware@7.4.2(webpack@5.100.1):
     dependencies:
       colorette: 2.0.20
       memfs: 4.17.2
@@ -9848,7 +9848,7 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.2(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1))
+      webpack-dev-middleware: 7.4.2(webpack@5.100.1)
       ws: 8.18.3
     optionalDependencies:
       webpack: 5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1)
@@ -9899,7 +9899,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.2
       tapable: 2.2.2
-      terser-webpack-plugin: 5.3.14(@swc/core@1.12.14)(esbuild@0.25.6)(webpack@5.100.1(@swc/core@1.12.14)(esbuild@0.25.6)(webpack-cli@6.0.1))
+      terser-webpack-plugin: 5.3.14(@swc/core@1.12.14)(esbuild@0.25.6)(webpack@5.100.1)
       watchpack: 2.4.4
       webpack-sources: 3.3.3
     optionalDependencies:

--- a/client/src/app/routes/index.tsx
+++ b/client/src/app/routes/index.tsx
@@ -2,6 +2,7 @@ import { Layout } from '@/app/layout/ui';
 import { ROUTES } from '@/app/routes/routes';
 import HomePage from '@/pages/home';
 import SignupPage from '@/pages/signup';
+import TodayPage from '@/pages/today';
 import { createBrowserRouter, createRoutesFromElements, Route } from 'react-router';
 
 export const router = createBrowserRouter(
@@ -9,6 +10,7 @@ export const router = createBrowserRouter(
     <Route path={ROUTES.ROOT} element={<Layout />}>
       <Route index element={<HomePage />} />
       <Route path={ROUTES.SIGNUP} element={<SignupPage />} />
+      <Route path={ROUTES.TODAY} element={<TodayPage />} />
     </Route>,
   ),
 );

--- a/client/src/app/routes/routes.ts
+++ b/client/src/app/routes/routes.ts
@@ -1,4 +1,5 @@
 export const ROUTES = {
   ROOT: '/',
   SIGNUP: '/signup',
+  TODAY: '/today',
 };

--- a/client/src/features/auth/ui/TodayForm.tsx
+++ b/client/src/features/auth/ui/TodayForm.tsx
@@ -1,8 +1,20 @@
-import { Card, TextArea } from '@/shared/ui';
-import { Send, Star } from 'lucide-react';
-import { RequestButton } from './requestButton';
+import { Card } from '@/shared/ui';
+import { Star } from 'lucide-react';
+import { useCallback, useState } from 'react';
+import { TodaySuccessContent } from '@/widgets/today/TodaySuccessContent';
+import { TodayWriteContent } from '@/widgets/today/TodayWriteContent';
 
 export function TodayForm() {
+  const [isSubmitted, setIsSubmitted] = useState(false);
+
+  const handleSubmit = useCallback(() => {
+    setIsSubmitted(true);
+  }, []);
+
+  const handleBack = useCallback(() => {
+    setIsSubmitted(false);
+  }, []);
+
   return (
     <Card width="medium">
       <Card.TitleContainer
@@ -10,16 +22,11 @@ export function TodayForm() {
         title="모멘트 공유하기"
         subtitle="뿌듯한 순간, 위로받고 싶은 순간, 기쁜 순간 모든 모멘트를 자유롭게 적어보세요"
       ></Card.TitleContainer>
-      <Card.Content>
-        <TextArea
-          placeholder="오늘 어떤 모멘트를 경험하셨나요? 솔직한 마음을 들려주세요..."
-          height="medium"
-        />
-      </Card.Content>
-      <Card.Action position="space-between">
-        <p>0 / 100</p>
-        <RequestButton />
-      </Card.Action>
+      {!isSubmitted ? (
+        <TodayWriteContent onSubmit={handleSubmit} />
+      ) : (
+        <TodaySuccessContent onBack={handleBack} />
+      )}
     </Card>
   );
 }

--- a/client/src/features/auth/ui/TodayForm.tsx
+++ b/client/src/features/auth/ui/TodayForm.tsx
@@ -1,0 +1,25 @@
+import { Card, TextArea } from '@/shared/ui';
+import { Send, Star } from 'lucide-react';
+import { RequestButton } from './requestButton';
+
+export function TodayForm() {
+  return (
+    <Card width="medium">
+      <Card.TitleContainer
+        Icon={Star}
+        title="모멘트 공유하기"
+        subtitle="뿌듯한 순간, 위로받고 싶은 순간, 기쁜 순간 모든 모멘트를 자유롭게 적어보세요"
+      ></Card.TitleContainer>
+      <Card.Content>
+        <TextArea
+          placeholder="오늘 어떤 모멘트를 경험하셨나요? 솔직한 마음을 들려주세요..."
+          height="medium"
+        />
+      </Card.Content>
+      <Card.Action position="space-between">
+        <p>0 / 100</p>
+        <RequestButton />
+      </Card.Action>
+    </Card>
+  );
+}

--- a/client/src/features/auth/ui/requestButton.tsx
+++ b/client/src/features/auth/ui/requestButton.tsx
@@ -5,8 +5,11 @@ interface RequestButtonProps {
   Icon?: LucideIcon;
   title: string;
   onClick?: () => void;
+  disabled?: boolean;
 }
 
-export const RequestButton = ({ Icon, title, onClick }: RequestButtonProps) => {
-  return <Button Icon={Icon} title={title} variant="tertiary" onClick={onClick} />;
+export const RequestButton = ({ Icon, title, onClick, disabled }: RequestButtonProps) => {
+  return (
+    <Button Icon={Icon} title={title} variant="tertiary" onClick={onClick} disabled={disabled} />
+  );
 };

--- a/client/src/features/auth/ui/requestButton.tsx
+++ b/client/src/features/auth/ui/requestButton.tsx
@@ -1,0 +1,10 @@
+import { Button } from '@/shared/ui';
+import { LucideIcon, Send } from 'lucide-react';
+
+interface RequestButtonProps {
+  Icon?: LucideIcon;
+}
+
+export const RequestButton = ({ Icon }: RequestButtonProps) => {
+  return <Button Icon={Send} title="모멘트 공유하기" variant="tertiary" />;
+};

--- a/client/src/features/auth/ui/requestButton.tsx
+++ b/client/src/features/auth/ui/requestButton.tsx
@@ -3,8 +3,10 @@ import { LucideIcon, Send } from 'lucide-react';
 
 interface RequestButtonProps {
   Icon?: LucideIcon;
+  title: string;
+  onClick?: () => void;
 }
 
-export const RequestButton = ({ Icon }: RequestButtonProps) => {
-  return <Button Icon={Send} title="모멘트 공유하기" variant="tertiary" />;
+export const RequestButton = ({ Icon, title, onClick }: RequestButtonProps) => {
+  return <Button Icon={Icon} title={title} variant="tertiary" onClick={onClick} />;
 };

--- a/client/src/pages/today/index.styles.ts
+++ b/client/src/pages/today/index.styles.ts
@@ -1,0 +1,11 @@
+import styled from '@emotion/styled';
+
+export const TodayPageWrapper = styled.main`
+  width: 100%;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 20px;
+`;

--- a/client/src/pages/today/index.tsx
+++ b/client/src/pages/today/index.tsx
@@ -1,0 +1,15 @@
+import { TodayForm } from '@/features/auth/ui/TodayForm';
+import * as S from './index.styles';
+import { TitleContainer } from '@/shared/ui/titleContainer/TitleContainer';
+
+export default function TodayPage() {
+  return (
+    <S.TodayPageWrapper>
+      <TitleContainer
+        title="오늘의 모멘트"
+        subtitle="하루에 한 번, 당신의 특별한 모멘트를 공유해보세요"
+      />
+      <TodayForm />
+    </S.TodayPageWrapper>
+  );
+}

--- a/client/src/shared/ui/button/Button.styles.ts
+++ b/client/src/shared/ui/button/Button.styles.ts
@@ -1,7 +1,7 @@
 import { CustomTheme } from '@/app/styles/theme';
 import styled from '@emotion/styled';
 
-export type ButtonVariant = 'primary' | 'secondary';
+export type ButtonVariant = 'primary' | 'secondary' | 'tertiary';
 
 const buttonStyles = {
   primary: (theme: CustomTheme) => `
@@ -41,6 +41,34 @@ const buttonStyles = {
     @media (max-width: 480px) {
         padding: 14px 20px;
         font-size: 18px;
+    }
+
+    &:hover {
+        filter: brightness(1.1);
+        box-shadow: 0 0 20px rgba(255, 255, 255, 0.3);
+        transform: translateY(-2px);
+    }
+    `,
+  tertiary: (theme: CustomTheme) => `
+    background-color: ${theme.colors['yellow-500']};
+    color: black;
+    padding: 10px 20px;
+    border-radius: 5px;
+    font-size: 16px;
+    font-weight: bold;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    transition: all 0.3s ease;
+
+    @media (max-width: 768px) {
+        padding: 16px 24px;
+        font-size: 14px;
+    }
+
+    @media (max-width: 480px) {
+        padding: 14px 20px;
+        font-size: 12px;
     }
 
     &:hover {

--- a/client/src/shared/ui/button/Button.tsx
+++ b/client/src/shared/ui/button/Button.tsx
@@ -1,3 +1,4 @@
+import { LucideIcon } from 'lucide-react';
 import * as S from './Button.styles';
 import { ButtonVariant } from './Button.styles';
 
@@ -6,6 +7,7 @@ interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
   title: string;
   onClick?: () => void;
   disabled?: boolean;
+  Icon?: LucideIcon;
 }
 
 export const Button = ({
@@ -13,10 +15,12 @@ export const Button = ({
   title,
   onClick,
   disabled,
+  Icon,
   ...props
 }: ButtonProps) => {
   return (
     <S.Button variant={variant} onClick={onClick} disabled={disabled} {...props}>
+      {Icon && <Icon size={16} />}
       {title}
     </S.Button>
   );

--- a/client/src/shared/ui/card/CardSuccessContainer.styles.ts
+++ b/client/src/shared/ui/card/CardSuccessContainer.styles.ts
@@ -1,0 +1,33 @@
+import { CustomTheme } from '@/app/styles/theme';
+import styled from '@emotion/styled';
+
+export const CardSuccessTitleStyles = {
+  cardSuccessTitle: (theme: CustomTheme) => `
+    font-size: ${theme.typography.title.fontSize.small};
+    font-weight: ${theme.typography.fontWeight.large};
+    color: ${theme.colors.white};
+    `,
+};
+
+export const CardSuccessSubtitleStyles = {
+  cardSuccessSubtitle: (theme: CustomTheme) => `
+    font-size: ${theme.typography.subTitle.fontSize.medium};
+    color: ${theme.colors['gray-200']};
+    white-space: pre-line;
+    `,
+};
+
+export const CardSuccessContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+`;
+
+export const CardSuccessTitle = styled.span`
+  ${({ theme }) => CardSuccessTitleStyles.cardSuccessTitle(theme)}
+`;
+
+export const CardSuccessSubtitle = styled.span`
+  ${({ theme }) => CardSuccessSubtitleStyles.cardSuccessSubtitle(theme)}
+`;

--- a/client/src/shared/ui/card/CardSuccessContainer.tsx
+++ b/client/src/shared/ui/card/CardSuccessContainer.tsx
@@ -1,0 +1,19 @@
+import { theme } from '@/app/styles/theme';
+import { LucideIcon } from 'lucide-react';
+import * as S from './CardSuccessContainer.styles';
+
+interface CardSuccessContainerProps {
+  Icon?: LucideIcon;
+  title: string;
+  subtitle: string;
+}
+
+export const CardSuccessContainer = ({ Icon, title, subtitle }: CardSuccessContainerProps) => {
+  return (
+    <S.CardSuccessContainer>
+      {Icon && <Icon size={56} color={theme.colors['yellow-500']} />}
+      <S.CardSuccessTitle>{title}</S.CardSuccessTitle>
+      <S.CardSuccessSubtitle>{subtitle}</S.CardSuccessSubtitle>
+    </S.CardSuccessContainer>
+  );
+};

--- a/client/src/shared/ui/card/CardTitleContainer.tsx
+++ b/client/src/shared/ui/card/CardTitleContainer.tsx
@@ -1,5 +1,6 @@
 import { LucideIcon } from 'lucide-react';
 import * as S from './CardTitleContainer.styles';
+import { theme } from '@/app/styles/theme';
 
 interface CardTitleContainerProps {
   Icon?: LucideIcon;
@@ -11,7 +12,7 @@ export const CardTitleContainer = ({ Icon, title, subtitle }: CardTitleContainer
   return (
     <S.CardTitleContainer>
       <S.CardTitleWrapper>
-        {Icon && <Icon size={32} />}
+        {Icon && <Icon size={32} color={theme.colors['yellow-500']} />}
         <S.CardTitle>{title}</S.CardTitle>
       </S.CardTitleWrapper>
       <S.CardSubtitle>{subtitle}</S.CardSubtitle>

--- a/client/src/widgets/today/TodaySuccessContent.tsx
+++ b/client/src/widgets/today/TodaySuccessContent.tsx
@@ -1,0 +1,27 @@
+import { RequestButton } from '@/features/auth/ui/requestButton';
+import { Card, TextArea } from '@/shared/ui';
+import { CardSuccessContainer } from '@/shared/ui/card/CardSuccessContainer';
+import { CheckCircle, MessageSquare } from 'lucide-react';
+
+interface TodaySuccessContentProps {
+  onBack: () => void;
+}
+
+export const TodaySuccessContent = ({ onBack }: TodaySuccessContentProps) => {
+  return (
+    <>
+      <Card.Content>
+        <CardSuccessContainer
+          Icon={CheckCircle}
+          title="오늘의 모멘트를 공유했어요!"
+          subtitle={
+            '당신의 모멘트가 누군가에게 전달되었습니다.\n내일 또 다른 모멘트를 공유해보세요'
+          }
+        ></CardSuccessContainer>
+      </Card.Content>
+      <Card.Action position="center">
+        <RequestButton Icon={MessageSquare} title="받은 모멘트 보기" onClick={onBack} />
+      </Card.Action>
+    </>
+  );
+};

--- a/client/src/widgets/today/TodayWriteContent.tsx
+++ b/client/src/widgets/today/TodayWriteContent.tsx
@@ -1,23 +1,46 @@
 import { RequestButton } from '@/features/auth/ui/requestButton';
 import { Card, TextArea } from '@/shared/ui';
 import { Send } from 'lucide-react';
+import { useState } from 'react';
 
 interface TodayWriteContentProps {
   onSubmit: () => void;
 }
 
 export const TodayWriteContent = ({ onSubmit }: TodayWriteContentProps) => {
+  const [text, setText] = useState('');
+  const MAX_LENGTH = 300;
+
+  const handleTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const newText = e.target.value;
+    if (newText.length <= MAX_LENGTH) {
+      setText(newText);
+    }
+  };
+
+  const handleSubmit = () => {
+    onSubmit();
+  };
   return (
     <>
       <Card.Content>
         <TextArea
           placeholder="오늘 어떤 모멘트를 경험하셨나요? 솔직한 마음을 들려주세요..."
           height="medium"
+          value={text}
+          onChange={handleTextChange}
         />
       </Card.Content>
       <Card.Action position="space-between">
-        <p>0 / 100</p>
-        <RequestButton Icon={Send} title="모멘트 공유하기" onClick={onSubmit} />
+        <p>
+          {text.length} / {MAX_LENGTH}
+        </p>
+        <RequestButton
+          Icon={Send}
+          title="모멘트 공유하기"
+          onClick={handleSubmit}
+          disabled={text.trim().length === 0}
+        />
       </Card.Action>
     </>
   );

--- a/client/src/widgets/today/TodayWriteContent.tsx
+++ b/client/src/widgets/today/TodayWriteContent.tsx
@@ -1,0 +1,24 @@
+import { RequestButton } from '@/features/auth/ui/requestButton';
+import { Card, TextArea } from '@/shared/ui';
+import { Send } from 'lucide-react';
+
+interface TodayWriteContentProps {
+  onSubmit: () => void;
+}
+
+export const TodayWriteContent = ({ onSubmit }: TodayWriteContentProps) => {
+  return (
+    <>
+      <Card.Content>
+        <TextArea
+          placeholder="오늘 어떤 모멘트를 경험하셨나요? 솔직한 마음을 들려주세요..."
+          height="medium"
+        />
+      </Card.Content>
+      <Card.Action position="space-between">
+        <p>0 / 100</p>
+        <RequestButton Icon={Send} title="모멘트 공유하기" onClick={onSubmit} />
+      </Card.Action>
+    </>
+  );
+};


### PR DESCRIPTION
# 📋 연관 이슈

- close #70 

# 🚀 작업 내용

- 오늘의 모멘트 페이지 구현
    - 사용자 입력 부분
        - 글자수 UI 사용자 입력에 따라 실시간 동적 UI로 구현
        - TextArea 입력 없을 시 버튼 disabled
    - 모멘트 요청 성공 부분

# 💬 리뷰 중점 사항

- 전체적인 UI
- text, isSubmitted 상태 위치

## 📸 Test Screenshot

<!-- 테스트 결과나 UI 변경 사항의 스크린샷을 첨부하세요 -->
1. 오늘의 모멘트 - 사용자 입력 부분
<img width="1438" height="781" alt="image" src="https://github.com/user-attachments/assets/56079a7d-6d74-4f52-affc-c0eb665b6d96" />

2. 오늘의 모멘트 - 사용자 입력 시 글자수 실시간 동적 UI
<img width="1439" height="781" alt="image" src="https://github.com/user-attachments/assets/79569639-79bf-48d2-a917-3044b0cc2145" />

 
3,. 오늘의 모멘트 - 모멘트 요청 성공 부분
<img width="1439" height="777" alt="image" src="https://github.com/user-attachments/assets/1c783623-de61-462e-a4da-b20f476efc6c" />


## 📝 Additional Description

<!-- 추가적인 설명이나 고려사항이 있다면 작성하세요 -->
- 사용자 입력에서 모멘트 요청 성공 화면으로 전환할 때 UI 구현 방안을 고민했습니다. 기존에 작성한 useFunnel의 step을 활용할지, 새로운 상태를 만들어 조건부 렌더링으로 처리할지 고민했으나 현재 추가 진행되는 단계가 없으므로 조건부 렌더링 방식으로 구현했습니다.

- `TodayWriteContent` 컴포넌트의 `const [text, setText] = useState('')`는 해당 컴포넌트 내에 TextArea와 RequestButton이 함께 존재하기 때문에 상태를 상위로 올리지 않고 그대로 두는 것이 적절하다고 판단했습니다.

## 🔗 Related Links

<!-- 관련된 문서나 참고 자료 링크 -->

-
-
