### PR TITLE
[FEAT] 로그인 페이지 구현 

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -23,3 +23,7 @@ coverage/
 
 *storybook.log
 storybook-static
+
+# jest-cache
+.jest-cache/
+

--- a/client/src/app/routes/index.tsx
+++ b/client/src/app/routes/index.tsx
@@ -1,6 +1,7 @@
 import { Layout } from '@/app/layout/ui';
 import { ROUTES } from '@/app/routes/routes';
 import HomePage from '@/pages/home';
+import LoginPage from '@/pages/login';
 import SignupPage from '@/pages/signup';
 import { createBrowserRouter, createRoutesFromElements, Route } from 'react-router';
 
@@ -9,6 +10,7 @@ export const router = createBrowserRouter(
     <Route path={ROUTES.ROOT} element={<Layout />}>
       <Route index element={<HomePage />} />
       <Route path={ROUTES.SIGNUP} element={<SignupPage />} />
+      <Route path={ROUTES.LOGIN} element={<LoginPage />} />
     </Route>,
   ),
 );

--- a/client/src/app/routes/routes.ts
+++ b/client/src/app/routes/routes.ts
@@ -1,4 +1,5 @@
 export const ROUTES = {
   ROOT: '/',
   SIGNUP: '/signup',
+  LOGIN: '/login',
 };

--- a/client/src/app/styles/theme.ts
+++ b/client/src/app/styles/theme.ts
@@ -6,6 +6,7 @@ export const theme = {
     'slate-800': '#1E293B',
     'slate-700': '#334155',
     white: '#FFFFFF',
+    'yellow-600': '#92610a',
     'yellow-500': '#F1C40F',
     'yellow-300': '#F4D03F',
     'emerald-500': '#10B981',

--- a/client/src/features/auth/hooks/useLoginForm.ts
+++ b/client/src/features/auth/hooks/useLoginForm.ts
@@ -1,0 +1,36 @@
+import { LoginError, LoginFormData } from '@/features/auth/types/login';
+import { useEffect, useState } from 'react';
+
+export const useLoginForm = () => {
+  const [formData, setFormData] = useState<LoginFormData>({
+    email: '',
+    password: '',
+  });
+  const [error, setError] = useState<LoginError>({});
+  const [isLoading, setIsLoading] = useState(false);
+  const [isDisabled, setIsDisabled] = useState(true);
+
+  useEffect(() => {
+    setIsDisabled(formData.email === '' || formData.password === '' || isLoading);
+  }, [formData, isLoading]);
+
+  const handleInputChange =
+    (field: keyof LoginFormData) => (e: React.ChangeEvent<HTMLInputElement>) => {
+      setFormData({ ...formData, [field]: e.target.value });
+    };
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    // TODO: 로그인 로직 구현
+  };
+
+  return {
+    formData,
+    error,
+    isLoading,
+    isDisabled,
+    handleInputChange,
+    handleSubmit,
+  };
+};

--- a/client/src/features/auth/hooks/useLoginForm.ts
+++ b/client/src/features/auth/hooks/useLoginForm.ts
@@ -1,5 +1,5 @@
 import { LoginError, LoginFormData } from '@/features/auth/types/login';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 export const useLoginForm = () => {
   const [formData, setFormData] = useState<LoginFormData>({
@@ -8,11 +8,8 @@ export const useLoginForm = () => {
   });
   const [error, setError] = useState<LoginError>({});
   const [isLoading, setIsLoading] = useState(false);
-  const [isDisabled, setIsDisabled] = useState(true);
 
-  useEffect(() => {
-    setIsDisabled(formData.email === '' || formData.password === '' || isLoading);
-  }, [formData, isLoading]);
+  const isDisabled = formData.email === '' || formData.password === '' || isLoading;
 
   const handleInputChange =
     (field: keyof LoginFormData) => (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/client/src/features/auth/types/login.ts
+++ b/client/src/features/auth/types/login.ts
@@ -1,0 +1,19 @@
+export interface LoginFormData {
+  email: string;
+  password: string;
+}
+
+export interface LoginError {
+  email?: string;
+  password?: string;
+}
+
+export interface UseLoginReturn {
+  formData: LoginFormData;
+  error: LoginError;
+  isLoading: boolean;
+  handleInputChange: (
+    field: keyof LoginFormData,
+  ) => (e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleSubmit: (e: React.FormEvent<HTMLFormElement>) => Promise<void>;
+}

--- a/client/src/features/auth/ui/LoginButton.tsx
+++ b/client/src/features/auth/ui/LoginButton.tsx
@@ -1,5 +1,12 @@
 import { Button } from '@/shared/ui/button/Button';
+import { useNavigate } from 'react-router';
 
 export const LoginButton = () => {
-  return <Button title="로그인" onClick={() => {}} variant="primary" />;
+  const navigate = useNavigate();
+
+  const handleLoginClick = () => {
+    navigate('/login');
+  };
+
+  return <Button title="로그인" onClick={handleLoginClick} variant="primary" />;
 };

--- a/client/src/features/auth/ui/LoginForm.styles.ts
+++ b/client/src/features/auth/ui/LoginForm.styles.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-export const LoginFormWrapper = styled.div`
+export const LoginFormWrapper = styled.form`
   width: 80%;
   max-width: 500px;
   min-height: 550px;

--- a/client/src/features/auth/ui/LoginForm.styles.ts
+++ b/client/src/features/auth/ui/LoginForm.styles.ts
@@ -126,6 +126,10 @@ export const LoginButton = styled.button`
     background-color: ${({ theme }) => theme.colors['yellow-500']};
     color: ${({ theme }) => theme.colors['slate-800']};
   }
+
+  &:disabled {
+    cursor: not-allowed;
+  }
 `;
 
 export const LoginFooterContent = styled.div`

--- a/client/src/features/auth/ui/LoginForm.styles.ts
+++ b/client/src/features/auth/ui/LoginForm.styles.ts
@@ -1,0 +1,161 @@
+import styled from '@emotion/styled';
+
+export const LoginFormWrapper = styled.div`
+  width: 80%;
+  max-width: 500px;
+  min-height: 550px;
+  padding: 30px;
+  background-color: ${({ theme }) => theme.colors['slate-800_60']}; // #1E293B
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 25px;
+`;
+
+export const LoginFormTitleContainer = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+`;
+
+export const LoginLogoTitleContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+`;
+
+export const LogoImage = styled.img`
+  width: 60px;
+  height: 60px;
+`;
+
+export const LogoTitle = styled.span`
+  font-size: 38px;
+  font-weight: 600;
+  color: ${({ theme }) => theme.colors.white};
+`;
+
+export const LoginTitle = styled.h1`
+  font-size: 30px;
+  font-weight: 700;
+  color: ${({ theme }) => theme.colors['gray-200']};
+`;
+
+export const LoginDescription = styled.p`
+  font-size: 16px;
+  font-weight: 700;
+  color: ${({ theme }) => theme.colors['gray-200']};
+`;
+
+export const LoginFormContent = styled.div`
+  width: 100%;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+`;
+
+export const InputGroup = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+export const Label = styled.label`
+  font-size: 14px;
+  font-weight: 600;
+  color: ${({ theme }) => theme.colors.white};
+`;
+
+export const Input = styled.input`
+  width: 100%;
+  padding: 12px 16px;
+  border: 1px solid ${({ theme }) => theme.colors['slate-700']};
+  border-radius: 8px;
+  background-color: ${({ theme }) => theme.colors['gray-600_20']};
+  color: ${({ theme }) => theme.colors.white};
+  font-size: 16px;
+
+  &:focus {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors['yellow-500']};
+    box-shadow: 0 0 0 2px ${({ theme }) => theme.colors['yellow-300']}40; /* 40은 hex opacity */
+  }
+
+  &::placeholder {
+    color: ${({ theme }) => theme.colors['gray-400']};
+    opacity: 0.6;
+  }
+`;
+
+export const ErrorMessage = styled.span`
+  font-size: 12px;
+  color: ${({ theme }) => theme.colors['red-500']};
+  margin-top: 4px;
+`;
+
+export const LoginFooter = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 15px;
+`;
+
+export const LoginButton = styled.button`
+  width: 100%;
+  padding: 12px 16px;
+  border: 1px solid ${({ theme }) => theme.colors['yellow-500']};
+  border-radius: 8px;
+  background-color: transparent;
+  color: ${({ theme }) => theme.colors['yellow-500']};
+  font-size: 16px;
+  font-weight: 700;
+  cursor: pointer;
+  &:hover {
+    background-color: ${({ theme }) => theme.colors['yellow-500']};
+    color: ${({ theme }) => theme.colors['slate-800']};
+  }
+`;
+
+export const LoginFooterContent = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+`;
+
+export const LoginForgotPassword = styled.span`
+  color: ${({ theme }) => theme.colors['yellow-500']};
+  cursor: pointer;
+  &:hover {
+    color: ${({ theme }) => theme.colors['yellow-600']};
+  }
+`;
+
+export const LoginSignupContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+`;
+
+export const LoginSignupLink = styled.span`
+  color: ${({ theme }) => theme.colors['yellow-500']};
+  cursor: pointer;
+  &:hover {
+    color: ${({ theme }) => theme.colors['yellow-600']};
+  }
+`;

--- a/client/src/features/auth/ui/LoginForm.styles.ts
+++ b/client/src/features/auth/ui/LoginForm.styles.ts
@@ -76,27 +76,6 @@ export const Label = styled.label`
   color: ${({ theme }) => theme.colors.white};
 `;
 
-export const Input = styled.input`
-  width: 100%;
-  padding: 12px 16px;
-  border: 1px solid ${({ theme }) => theme.colors['slate-700']};
-  border-radius: 8px;
-  background-color: ${({ theme }) => theme.colors['gray-600_20']};
-  color: ${({ theme }) => theme.colors.white};
-  font-size: 16px;
-
-  &:focus {
-    outline: none;
-    border-color: ${({ theme }) => theme.colors['yellow-500']};
-    box-shadow: 0 0 0 2px ${({ theme }) => theme.colors['yellow-300']}40; /* 40은 hex opacity */
-  }
-
-  &::placeholder {
-    color: ${({ theme }) => theme.colors['gray-400']};
-    opacity: 0.6;
-  }
-`;
-
 export const ErrorMessage = styled.span`
   font-size: 12px;
   color: ${({ theme }) => theme.colors['red-500']};

--- a/client/src/features/auth/ui/LoginForm.styles.ts
+++ b/client/src/features/auth/ui/LoginForm.styles.ts
@@ -5,7 +5,7 @@ export const LoginFormWrapper = styled.form`
   max-width: 500px;
   min-height: 550px;
   padding: 30px;
-  background-color: ${({ theme }) => theme.colors['slate-800_60']}; // #1E293B
+  background-color: ${({ theme }) => theme.colors['slate-800_60']};
   border-radius: 12px;
   display: flex;
   flex-direction: column;

--- a/client/src/features/auth/ui/LoginForm.tsx
+++ b/client/src/features/auth/ui/LoginForm.tsx
@@ -1,0 +1,36 @@
+import * as S from './LoginForm.styles';
+
+export const LoginForm = () => {
+  return (
+    <S.LoginFormWrapper>
+      <S.LoginFormTitleContainer>
+        <S.LoginLogoTitleContainer>
+          <S.LogoImage src="/logo.webp" alt="Moment Logo Image" />
+          <S.LogoTitle>모멘트</S.LogoTitle>
+        </S.LoginLogoTitleContainer>
+        <S.LoginTitle>로그인</S.LoginTitle>
+        <S.LoginDescription>이메일과 비밀번호를 입력하여 로그인해주세요.</S.LoginDescription>
+      </S.LoginFormTitleContainer>
+      <S.LoginFormContent>
+        <S.InputGroup>
+          <S.Label htmlFor="email">이메일</S.Label>
+          <S.Input id="email" type="email" placeholder="이메일을 입력해주세요" />
+        </S.InputGroup>
+        <S.InputGroup>
+          <S.Label htmlFor="password">비밀번호</S.Label>
+          <S.Input id="password" type="password" placeholder="비밀번호를 입력해주세요" />
+        </S.InputGroup>
+      </S.LoginFormContent>
+      <S.LoginFooter>
+        <S.LoginButton>로그인</S.LoginButton>
+        <S.LoginFooterContent>
+          <S.LoginForgotPassword>비밀번호를 잊으셨나요?</S.LoginForgotPassword>
+          <S.LoginSignupContainer>
+            <span>아직 회원이 아니신가요?</span>
+            <S.LoginSignupLink>회원가입</S.LoginSignupLink>
+          </S.LoginSignupContainer>
+        </S.LoginFooterContent>
+      </S.LoginFooter>
+    </S.LoginFormWrapper>
+  );
+};

--- a/client/src/features/auth/ui/LoginForm.tsx
+++ b/client/src/features/auth/ui/LoginForm.tsx
@@ -1,6 +1,17 @@
+import { useNavigate } from 'react-router';
 import * as S from './LoginForm.styles';
 
 export const LoginForm = () => {
+  const navigate = useNavigate();
+
+  const handleLoginClick = () => {
+    // TODO: 로그인 로직 구현
+  };
+
+  const handleSignupClick = () => {
+    navigate('/signup');
+  };
+
   return (
     <S.LoginFormWrapper>
       <S.LoginFormTitleContainer>
@@ -22,12 +33,12 @@ export const LoginForm = () => {
         </S.InputGroup>
       </S.LoginFormContent>
       <S.LoginFooter>
-        <S.LoginButton>로그인</S.LoginButton>
+        <S.LoginButton onClick={handleLoginClick}>로그인</S.LoginButton>
         <S.LoginFooterContent>
           <S.LoginForgotPassword>비밀번호를 잊으셨나요?</S.LoginForgotPassword>
           <S.LoginSignupContainer>
             <span>아직 회원이 아니신가요?</span>
-            <S.LoginSignupLink>회원가입</S.LoginSignupLink>
+            <S.LoginSignupLink onClick={handleSignupClick}>회원가입</S.LoginSignupLink>
           </S.LoginSignupContainer>
         </S.LoginFooterContent>
       </S.LoginFooter>

--- a/client/src/features/auth/ui/LoginForm.tsx
+++ b/client/src/features/auth/ui/LoginForm.tsx
@@ -1,4 +1,5 @@
 import { useLoginForm } from '@/features/auth/hooks/useLoginForm';
+import { Input } from '@/shared/ui/input/Input';
 import { useNavigate } from 'react-router';
 import * as S from './LoginForm.styles';
 
@@ -28,7 +29,7 @@ export const LoginForm = () => {
       <S.LoginFormContent>
         <S.InputGroup>
           <S.Label htmlFor="email">이메일</S.Label>
-          <S.Input
+          <Input
             id="email"
             type="email"
             placeholder="이메일을 입력해주세요"
@@ -38,7 +39,7 @@ export const LoginForm = () => {
         </S.InputGroup>
         <S.InputGroup>
           <S.Label htmlFor="password">비밀번호</S.Label>
-          <S.Input
+          <Input
             id="password"
             type="password"
             placeholder="비밀번호를 입력해주세요"

--- a/client/src/features/auth/ui/LoginForm.tsx
+++ b/client/src/features/auth/ui/LoginForm.tsx
@@ -1,8 +1,11 @@
+import { useLoginForm } from '@/features/auth/hooks/useLoginForm';
 import { useNavigate } from 'react-router';
 import * as S from './LoginForm.styles';
 
 export const LoginForm = () => {
   const navigate = useNavigate();
+  const { formData, error, isLoading, handleInputChange, handleSubmit, isDisabled } =
+    useLoginForm();
 
   const handleLoginClick = () => {
     // TODO: 로그인 로직 구현
@@ -13,7 +16,7 @@ export const LoginForm = () => {
   };
 
   return (
-    <S.LoginFormWrapper>
+    <S.LoginFormWrapper onSubmit={handleSubmit}>
       <S.LoginFormTitleContainer>
         <S.LoginLogoTitleContainer>
           <S.LogoImage src="/logo.webp" alt="Moment Logo Image" />
@@ -25,15 +28,29 @@ export const LoginForm = () => {
       <S.LoginFormContent>
         <S.InputGroup>
           <S.Label htmlFor="email">이메일</S.Label>
-          <S.Input id="email" type="email" placeholder="이메일을 입력해주세요" />
+          <S.Input
+            id="email"
+            type="email"
+            placeholder="이메일을 입력해주세요"
+            value={formData.email}
+            onChange={handleInputChange('email')}
+          />
         </S.InputGroup>
         <S.InputGroup>
           <S.Label htmlFor="password">비밀번호</S.Label>
-          <S.Input id="password" type="password" placeholder="비밀번호를 입력해주세요" />
+          <S.Input
+            id="password"
+            type="password"
+            placeholder="비밀번호를 입력해주세요"
+            value={formData.password}
+            onChange={handleInputChange('password')}
+          />
         </S.InputGroup>
       </S.LoginFormContent>
       <S.LoginFooter>
-        <S.LoginButton onClick={handleLoginClick}>로그인</S.LoginButton>
+        <S.LoginButton type="submit" disabled={isDisabled}>
+          로그인
+        </S.LoginButton>
         <S.LoginFooterContent>
           <S.LoginForgotPassword>비밀번호를 잊으셨나요?</S.LoginForgotPassword>
           <S.LoginSignupContainer>

--- a/client/src/pages/login/index.styles.ts
+++ b/client/src/pages/login/index.styles.ts
@@ -1,0 +1,9 @@
+import styled from '@emotion/styled';
+
+export const LoginPageWrapper = styled.main`
+  width: 100%;
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;

--- a/client/src/pages/login/index.tsx
+++ b/client/src/pages/login/index.tsx
@@ -1,0 +1,10 @@
+import { LoginForm } from '@/features/auth/ui/LoginForm';
+import * as S from './index.styles';
+
+export default function LoginPage() {
+  return (
+    <S.LoginPageWrapper>
+      <LoginForm />
+    </S.LoginPageWrapper>
+  );
+}

--- a/client/src/shared/ui/input/Input.styles.ts
+++ b/client/src/shared/ui/input/Input.styles.ts
@@ -12,7 +12,8 @@ const InputStyles = {
     border: 1px solid ${theme.colors['gray-700']};
 
     &::placeholder {
-        color: ${theme.colors.white};
+        color: ${theme.colors['gray-400']};
+        opacity: 0.6;
     }
     `,
 };

--- a/client/src/widgets/signup/SignupStep.styles.ts
+++ b/client/src/widgets/signup/SignupStep.styles.ts
@@ -21,27 +21,6 @@ export const Label = styled.label`
   color: ${({ theme }) => theme.colors.white};
 `;
 
-export const Input = styled.input`
-  width: 100%;
-  padding: 12px 16px;
-  border: 1px solid ${({ theme }) => theme.colors['slate-700']};
-  border-radius: 8px;
-  background-color: ${({ theme }) => theme.colors['gray-600_20']};
-  color: ${({ theme }) => theme.colors.white};
-  font-size: 16px;
-
-  &:focus {
-    outline: none;
-    border-color: ${({ theme }) => theme.colors['yellow-500']};
-    box-shadow: 0 0 0 2px ${({ theme }) => theme.colors['yellow-300']}40; /* 40은 hex opacity */
-  }
-
-  &::placeholder {
-    color: ${({ theme }) => theme.colors['gray-400']};
-    opacity: 0.6;
-  }
-`;
-
 export const ErrorMessage = styled.span`
   font-size: 12px;
   color: ${({ theme }) => theme.colors['red-500']};

--- a/client/src/widgets/signup/SignupStep1.tsx
+++ b/client/src/widgets/signup/SignupStep1.tsx
@@ -1,4 +1,5 @@
 import { useUserContext } from '@/features/auth/context/useUserContext';
+import { Input } from '@/shared/ui/input/Input';
 import * as S from './SignupStep.styles';
 
 interface SignupStep1Props {
@@ -16,7 +17,7 @@ export const SignupStep1 = ({ password, setPassword }: SignupStep1Props) => {
     <S.StepContainer>
       <S.InputGroup>
         <S.Label htmlFor="username">이메일</S.Label>
-        <S.Input
+        <Input
           id="email"
           type="email"
           placeholder="이메일을 입력해주세요"
@@ -28,7 +29,7 @@ export const SignupStep1 = ({ password, setPassword }: SignupStep1Props) => {
 
       <S.InputGroup>
         <S.Label htmlFor="password">비밀번호</S.Label>
-        <S.Input
+        <Input
           id="password"
           type="password"
           placeholder="비밀번호를 입력해주세요"
@@ -41,7 +42,7 @@ export const SignupStep1 = ({ password, setPassword }: SignupStep1Props) => {
 
       <S.InputGroup>
         <S.Label htmlFor="rePassword">비밀번호 확인</S.Label>
-        <S.Input
+        <Input
           id="rePassword"
           type="password"
           placeholder="비밀번호를 다시 입력해주세요"

--- a/client/src/widgets/signup/SignupStep2.tsx
+++ b/client/src/widgets/signup/SignupStep2.tsx
@@ -1,4 +1,5 @@
 import { useUserContext } from '@/features/auth/context/useUserContext';
+import { Input } from '@/shared/ui/input/Input';
 import * as S from './SignupStep.styles';
 
 export const SignupStep2 = () => {
@@ -8,7 +9,7 @@ export const SignupStep2 = () => {
     <S.StepContainer>
       <S.InputGroup>
         <S.Label htmlFor="nickname">닉네임</S.Label>
-        <S.Input
+        <Input
           id="nickname"
           type="text"
           placeholder="닉네임을 입력해주세요"


### PR DESCRIPTION
# 📋 연관 이슈

- close #87 

# 🚀 작업 내용

### 1. `Login` 페이지 및 `LoginForm` UI 컴포넌트 구현 

### 2. `useLoginForm` 훅
- formData: 이메일, 비밀번호 입력값 관리
- error: 폼 에러 상태 관리 (향후 유효성 검사 확장 예정)
- isLoading: 로그인 요청 중 상태 관리
- isDisabled: 버튼 활성화/비활성화 상태 자동 계산
- handleInputChange: 입력 필드 변경 핸들러
- handleSubmit: 폼 제출 핸들러



# 📸 Test Screenshot

<img width="2878" height="1436" alt="image" src="https://github.com/user-attachments/assets/f04f0047-584e-4722-b239-6d9e71530a2f" />

## 📝 Additional Description
- 회원가입 및 로그인 Input 컴포넌트를 공용 컴포넌트로 대체하였습니다.
- Input 공용 컴포넌트 스타일 `input.styles.ts` 에서 placeholder color 색상 변경

## 추후 계획
- [ ] 1. API 연동
- [ ] 유효성 검사 구현
- [ ] 로딩 및 에러 메시지 표시 기능


