### PR TITLE
[FEAT] 나의 Comment 조회 기능 API 구현

### DIFF
--- a/server/src/main/java/moment/comment/application/CommentService.java
+++ b/server/src/main/java/moment/comment/application/CommentService.java
@@ -1,10 +1,14 @@
 package moment.comment.application;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import moment.comment.domain.Comment;
 import moment.comment.dto.request.CommentCreateRequest;
 import moment.comment.dto.response.CommentCreateResponse;
+import moment.comment.dto.response.MyCommentsResponse;
 import moment.comment.infrastructure.CommentRepository;
+import moment.global.exception.ErrorCode;
+import moment.global.exception.MomentException;
 import moment.moment.application.MomentQueryService;
 import moment.moment.domain.Moment;
 import moment.user.application.UserQueryService;
@@ -31,5 +35,17 @@ public class CommentService {
         Comment savedComment = commentRepository.save(comment);
 
         return CommentCreateResponse.from(savedComment);
+    }
+
+    public List<MyCommentsResponse> getCommentsOfUserId(Long commenterId) {
+        if (!userQueryService.existsById(commenterId)) {
+            throw new MomentException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        List<Comment> comments = commentRepository.findCommentsWithMomentAndEmojisByCommenterId(commenterId);
+
+        return comments.stream()
+                .map(MyCommentsResponse::from)
+                .toList();
     }
 }

--- a/server/src/main/java/moment/comment/domain/Comment.java
+++ b/server/src/main/java/moment/comment/domain/Comment.java
@@ -8,7 +8,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -18,6 +21,7 @@ import moment.global.domain.BaseEntity;
 import moment.global.exception.ErrorCode;
 import moment.global.exception.MomentException;
 import moment.moment.domain.Moment;
+import moment.reply.domain.Emoji;
 import moment.user.domain.User;
 
 @Entity(name = "comments")
@@ -42,6 +46,9 @@ public class Comment extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(nullable = false, name = "moment_id")
     private Moment moment;
+
+    @OneToMany(mappedBy = "comment")
+    private List<Emoji> emojis = new ArrayList<>();
 
     public Comment(String content, User commenter, Moment moment) {
         validate(content, commenter, moment);
@@ -75,6 +82,13 @@ public class Comment extends BaseEntity {
     private void validateMoment(Moment moment) {
         if (moment == null) {
             throw new MomentException(ErrorCode.COMMENT_INVALID);
+        }
+    }
+
+    public void addEmoji(Emoji emoji) {
+        emojis.add(emoji);
+        if (emoji.getComment() != this) {
+            emoji.setComment(this);
         }
     }
 }

--- a/server/src/main/java/moment/comment/dto/response/CommentCreateResponse.java
+++ b/server/src/main/java/moment/comment/dto/response/CommentCreateResponse.java
@@ -10,6 +10,8 @@ public record CommentCreateResponse(
 
         @Schema(description = "등록된 Comment 내용", example = "정말 멋진 하루군요!")
         String content
+
+        //todo 생성 후 반환값에 created_at 포함하기
 ) {
     public static CommentCreateResponse from(Comment comment) {
         return new CommentCreateResponse(comment.getId(), comment.getContent());

--- a/server/src/main/java/moment/comment/dto/response/EmojiDetailResponse.java
+++ b/server/src/main/java/moment/comment/dto/response/EmojiDetailResponse.java
@@ -1,0 +1,21 @@
+package moment.comment.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import moment.reply.domain.Emoji;
+import moment.reply.domain.EmojiType;
+
+@Schema(description = "Comment애 등록된 Emoji 상세 내용")
+public record EmojiDetailResponse(
+        @Schema(description = "Emoji 아이디", example = "1")
+        Long id,
+
+        @Schema(description = "Emoji 타입", example = "HEART")
+        EmojiType emojiType,
+
+        @Schema(description = "Emoji를 등록한 유저 아이디", example = "2")
+        Long userId
+) {
+    public static EmojiDetailResponse from(Emoji emoji) {
+        return new EmojiDetailResponse(emoji.getId(), emoji.getEmojiType(), emoji.getUser().getId());
+    }
+}

--- a/server/src/main/java/moment/comment/dto/response/MomentDetailResponse.java
+++ b/server/src/main/java/moment/comment/dto/response/MomentDetailResponse.java
@@ -1,0 +1,18 @@
+package moment.comment.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import moment.moment.domain.Moment;
+
+@Schema(description = "Comment가 등록된 Moment 상세 내용")
+public record MomentDetailResponse(
+        @Schema(description = "Moment 내용", example = "테스트를 겨우 통과했어요!")
+        String content,
+
+        @Schema(description = "Moment 등록 시간", example = "2025-07-21T10:57:08.926954")
+        LocalDateTime createdAt
+) {
+    public static MomentDetailResponse from(Moment moment) {
+        return new MomentDetailResponse(moment.getContent(), moment.getCreatedAt());
+    }
+}

--- a/server/src/main/java/moment/comment/dto/response/MyCommentsResponse.java
+++ b/server/src/main/java/moment/comment/dto/response/MyCommentsResponse.java
@@ -1,0 +1,38 @@
+package moment.comment.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+import moment.comment.domain.Comment;
+import moment.reply.domain.Emoji;
+
+@Schema(description = "나의 Comment 목록 조회 응답")
+public record MyCommentsResponse(
+        @Schema(description = "등록된 Comment 내용", example = "정말 멋진 하루군요!")
+        String content,
+
+        @Schema(description = "Comment 등록 시간", example = "2025-07-21T10:57:08.926954")
+        LocalDateTime createdAt,
+
+        @Schema(description = "Comment가 등록된 Moment")
+        MomentDetailResponse moment,
+
+        @Schema(description = "Comment에 등록된 이모지 목록")
+        List<EmojiDetailResponse> emojis
+) {
+    public static MyCommentsResponse from(Comment comment) {
+        MomentDetailResponse momentResponse = MomentDetailResponse.from(comment.getMoment());
+
+        List<Emoji> emojis = comment.getEmojis();
+        List<EmojiDetailResponse> emojisResponse = emojis.stream()
+                .map(EmojiDetailResponse::from)
+                .toList();
+
+        return new MyCommentsResponse(
+                comment.getContent(),
+                comment.getCreatedAt(),
+                momentResponse,
+                emojisResponse
+        );
+    }
+}

--- a/server/src/main/java/moment/comment/infrastructure/CommentRepository.java
+++ b/server/src/main/java/moment/comment/infrastructure/CommentRepository.java
@@ -1,7 +1,15 @@
 package moment.comment.infrastructure;
 
+import java.util.List;
 import moment.comment.domain.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    @Query("SELECT DISTINCT c FROM comments c " +
+            "JOIN FETCH c.moment m " +
+            "LEFT JOIN FETCH c.emojis e " +
+            "WHERE c.commenter.id = :commenterId")
+    List<Comment> findCommentsWithMomentAndEmojisByCommenterId(Long commenterId);
 }

--- a/server/src/main/java/moment/comment/presentation/CommentController.java
+++ b/server/src/main/java/moment/comment/presentation/CommentController.java
@@ -6,16 +6,19 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import moment.auth.presentation.AuthenticationPrincipal;
 import moment.comment.application.CommentService;
 import moment.comment.dto.request.CommentCreateRequest;
 import moment.comment.dto.response.CommentCreateResponse;
+import moment.comment.dto.response.MyCommentsResponse;
 import moment.global.dto.response.ErrorResponse;
 import moment.global.dto.response.SuccessResponse;
 import moment.user.dto.request.Authentication;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -56,5 +59,27 @@ public class CommentController {
         CommentCreateResponse response = commentService.addComment(request, userId);
         HttpStatus status = HttpStatus.CREATED;
         return ResponseEntity.status(status).body(SuccessResponse.of(status, response));
+    }
+
+    @Operation(summary = "나의 Comment 목록 조회", description = "내가 등록한 Comment 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "나의 Comment 목록 조회 성공"),
+            @ApiResponse(responseCode = "401", description = """
+                    - [T-005] 토큰을 찾을 수 없습니다.
+                    """,
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(responseCode = "404", description = """
+                    - [U-002] 존재하지 않는 사용자입니다.
+                    """,
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/me")
+    public ResponseEntity<SuccessResponse<List<MyCommentsResponse>>> readMyComments(
+            @AuthenticationPrincipal Authentication authentication) {
+        Long userId = authentication.id();
+        List<MyCommentsResponse> myComments = commentService.getCommentsOfUserId(userId);
+        HttpStatus status = HttpStatus.OK;
+        return ResponseEntity.status(status).body(SuccessResponse.of(status, myComments));
     }
 }

--- a/server/src/main/java/moment/global/dto/response/SuccessResponse.java
+++ b/server/src/main/java/moment/global/dto/response/SuccessResponse.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 public record SuccessResponse<T>(
         @Schema(description = "상태 코드", example = "200")
         int status,
-        @Schema(description = "응답 데이터", example = "json")
+        @Schema(description = "응답 데이터")
         T data
 ) {
 

--- a/server/src/main/java/moment/moment/application/DefaultMomentQueryService.java
+++ b/server/src/main/java/moment/moment/application/DefaultMomentQueryService.java
@@ -1,0 +1,13 @@
+package moment.moment.application;
+
+import moment.moment.domain.Moment;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DefaultMomentQueryService implements MomentQueryService {
+
+    @Override
+    public Moment getMomentById(Long id) {
+        return null;
+    }
+}

--- a/server/src/main/java/moment/reply/domain/Emoji.java
+++ b/server/src/main/java/moment/reply/domain/Emoji.java
@@ -68,4 +68,12 @@ public class Emoji extends BaseEntity {
             throw new MomentException(ErrorCode.COMMENT_INVALID);
         }
     }
+
+    public void setComment(Comment comment) {
+        this.comment = comment;
+
+        if (!comment.getEmojis().contains(this)) {
+            comment.getEmojis().add(this);
+        }
+    }
 }

--- a/server/src/main/java/moment/user/application/DefaultUserQueryService.java
+++ b/server/src/main/java/moment/user/application/DefaultUserQueryService.java
@@ -19,4 +19,9 @@ public class DefaultUserQueryService implements UserQueryService {
         return userRepository.findById(id)
                 .orElseThrow(() -> new MomentException(ErrorCode.USER_NOT_FOUND));
     }
+
+    @Override
+    public boolean existsById(Long id) {
+        return userRepository.existsById(id);
+    }
 }

--- a/server/src/main/java/moment/user/application/UserQueryService.java
+++ b/server/src/main/java/moment/user/application/UserQueryService.java
@@ -5,4 +5,6 @@ import moment.user.domain.User;
 public interface UserQueryService {
 
     User getUserById(Long id);
+
+    boolean existsById(Long id);
 }

--- a/server/src/test/java/moment/comment/application/CommentServiceTest.java
+++ b/server/src/test/java/moment/comment/application/CommentServiceTest.java
@@ -1,13 +1,16 @@
 package moment.comment.application;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 
+import java.util.List;
 import moment.comment.domain.Comment;
 import moment.comment.dto.request.CommentCreateRequest;
+import moment.comment.dto.response.MyCommentsResponse;
 import moment.comment.infrastructure.CommentRepository;
 import moment.global.exception.ErrorCode;
 import moment.global.exception.MomentException;
@@ -85,5 +88,38 @@ class CommentServiceTest {
         assertThatThrownBy(() -> commentService.addComment(request, 1L))
                 .isInstanceOf(MomentException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.COMMENT_INVALID);
+    }
+
+    @Test
+    void Commenter_ID가_일치하는_Comment_목록을_불러온다() {
+        // given
+        User momenter = new User("kiki@icloud.com", "1234", "kiki");
+        Moment moment = new Moment("오늘 하루는 힘든 하루~", true, momenter);
+
+        User commenter = new User("hippo@gmail.com", "1234", "hippo");
+        Comment comment = new Comment("첫 번째 댓글", commenter, moment);
+
+        List<Comment> expectedComments = List.of(comment);
+        given(commentRepository.findCommentsWithMomentAndEmojisByCommenterId(any(Long.class)))
+                .willReturn(expectedComments);
+        given(userQueryService.existsById(any(Long.class))).willReturn(true);
+
+        // when
+        List<MyCommentsResponse> actualComments = commentService.getCommentsOfUserId(1L);
+
+        // then
+        assertThat(actualComments).hasSize(1);
+        then(commentRepository).should(times(1)).findCommentsWithMomentAndEmojisByCommenterId(1L);
+    }
+
+    @Test
+    void 존재하지_않는_Commenter가_Comment_목록을_조회하는_경우_예외가_발생한다() {
+        // given
+        given(userQueryService.existsById(any(Long.class))).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> commentService.getCommentsOfUserId(1L))
+                .isInstanceOf(MomentException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
     }
 }

--- a/server/src/test/java/moment/comment/application/DefaultMomentQueryServiceTest.java
+++ b/server/src/test/java/moment/comment/application/DefaultMomentQueryServiceTest.java
@@ -24,7 +24,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayNameGeneration(ReplaceUnderscores.class)
-class DefaultCommentQueryServiceTest {
+class DefaultMomentQueryServiceTest {
 
     @InjectMocks
     private DefaultCommentQueryService defaultCommentQueryService;

--- a/server/src/test/java/moment/comment/infrastructure/CommentRepositoryTest.java
+++ b/server/src/test/java/moment/comment/infrastructure/CommentRepositoryTest.java
@@ -1,0 +1,67 @@
+package moment.comment.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.List;
+import moment.comment.domain.Comment;
+import moment.moment.domain.Moment;
+import moment.moment.infrastructure.MomentRepository;
+import moment.reply.domain.Emoji;
+import moment.reply.domain.EmojiType;
+import moment.reply.infrastructure.EmojiRepository;
+import moment.user.domain.User;
+import moment.user.infrastructure.UserRepository;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class CommentRepositoryTest {
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private EmojiRepository emojiRepository;
+
+    @Autowired
+    private MomentRepository momentRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void Comment_ID와_일치하는_Comment_목록을_조회한다() {
+        // given
+        User momenter = new User("kiki@icloud.com", "1234", "kiki");
+        userRepository.save(momenter);
+
+        User commenter = new User("hippo@gmail.com", "1234", "hippo");
+        User savedCommenter = userRepository.save(commenter);
+
+        Moment moment = new Moment("오늘 하루는 힘든 하루~", true, momenter);
+        Moment savedMoment = momentRepository.save(moment);
+
+        Comment comment = new Comment("첫 번째 댓글", commenter, moment);
+        Comment savedComment = commentRepository.save(comment);
+
+        Emoji emoji = new Emoji(EmojiType.HEART, momenter, comment);
+        Emoji savedEmoji = emojiRepository.save(emoji);
+        comment.getEmojis().add(savedEmoji);
+
+        // when
+        List<Comment> comments = commentRepository.findCommentsWithMomentAndEmojisByCommenterId(savedCommenter.getId());
+
+        // then
+        assertAll(
+                () -> assertThat(comments).hasSize(1),
+                () -> assertThat(comments.getFirst()).isEqualTo(savedComment),
+                () -> assertThat(comments.getFirst().getMoment()).isEqualTo(savedMoment),
+                () -> assertThat(comments.getFirst().getEmojis().getFirst()).isEqualTo(savedEmoji)
+        );
+    }
+}

--- a/server/src/test/java/moment/comment/presentation/CommentControllerTest.java
+++ b/server/src/test/java/moment/comment/presentation/CommentControllerTest.java
@@ -1,20 +1,27 @@
 package moment.comment.presentation;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import java.util.List;
 import moment.auth.infrastructure.JwtTokenManager;
+import moment.comment.domain.Comment;
 import moment.comment.dto.request.CommentCreateRequest;
 import moment.comment.dto.response.CommentCreateResponse;
+import moment.comment.dto.response.MyCommentsResponse;
 import moment.comment.infrastructure.CommentRepository;
 import moment.global.exception.ErrorCode;
 import moment.global.exception.MomentException;
 import moment.moment.domain.Moment;
 import moment.moment.infrastructure.MomentRepository;
+import moment.reply.domain.Emoji;
+import moment.reply.domain.EmojiType;
+import moment.reply.infrastructure.EmojiRepository;
 import moment.user.domain.User;
 import moment.user.infrastructure.UserRepository;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
@@ -30,7 +37,6 @@ import org.springframework.test.context.ActiveProfiles;
 @SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 @DisplayNameGeneration(ReplaceUnderscores.class)
-@Disabled
 class CommentControllerTest {
 
     @Autowired
@@ -43,6 +49,9 @@ class CommentControllerTest {
     private CommentRepository commentRepository;
 
     @Autowired
+    private EmojiRepository emojiRepository;
+
+    @Autowired
     private JwtTokenManager jwtTokenManager;
 
     @Test
@@ -51,13 +60,13 @@ class CommentControllerTest {
         String token = jwtTokenManager.createToken(1L, "hippo@gmail.com");
 
         User user1 = new User("hippo@gmail.com", "1234", "hippo");
-        userRepository.save(user1);
+        userRepository.saveAndFlush(user1);
 
         User user2 = new User("kiki@icloud.com", "1234", "kiki");
-        userRepository.save(user2);
+        userRepository.saveAndFlush(user2);
 
         Moment moment = new Moment("개발의 세계는 신비해요!", true, user2);
-        momentRepository.save(moment);
+        momentRepository.saveAndFlush(moment);
 
         CommentCreateRequest request = new CommentCreateRequest("정말 안타깝게 됐네요!", 1L);
 
@@ -77,5 +86,52 @@ class CommentControllerTest {
                 () -> commentRepository.findById(response.commentId())
                         .orElseThrow(() -> new MomentException(ErrorCode.COMMENT_NOT_FOUND)))
                 .doesNotThrowAnyException();
+    }
+
+    @Test
+    void 나의_Comment_목록을_조회한다() {
+        // given
+        User momenter = new User("kiki@icloud.com", "1234", "kiki");
+        User savedMomenter = userRepository.save(momenter);
+
+        User commenter = new User("hippo@gmail.com", "1234", "hippo");
+        User savedCommenter = userRepository.save(commenter);
+
+        String token = jwtTokenManager.createToken(savedCommenter.getId(), savedCommenter.getEmail());
+
+        Moment moment = new Moment("오늘 하루는 힘든 하루~", true, savedMomenter);
+        Moment savedMoment = momentRepository.save(moment);
+
+        Comment comment = new Comment("첫 번째 댓글", savedCommenter, savedMoment);
+        Comment savedComment = commentRepository.save(comment);
+
+        Emoji emoji = new Emoji(EmojiType.HEART, savedMomenter, savedComment);
+        savedComment.addEmoji(emoji);
+        Emoji savedEmoji = emojiRepository.save(emoji);
+
+        // when
+        List<MyCommentsResponse> response = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .cookie("token", token)
+                .when().get("/api/v1/comments/me")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .jsonPath()
+                .getList("data", MyCommentsResponse.class);
+
+        // then
+        MyCommentsResponse firstResponse = response.getFirst();
+
+        assertAll(
+                () -> assertThat(response).hasSize(1),
+                () -> assertThat(firstResponse.content()).isEqualTo(savedComment.getContent()),
+                () -> assertThat(firstResponse.createdAt()).isEqualTo(savedComment.getCreatedAt()),
+                () -> assertThat(firstResponse.content()).isEqualTo(savedComment.getContent()),
+                () -> assertThat(firstResponse.moment().content()).isEqualTo(savedMoment.getContent()),
+                () -> assertThat(firstResponse.moment().createdAt()).isEqualTo(savedMoment.getCreatedAt()),
+                () -> assertThat(firstResponse.emojis().getFirst().id()).isEqualTo(savedEmoji.getId()),
+                () -> assertThat(firstResponse.emojis().getFirst().emojiType()).isEqualTo(savedEmoji.getEmojiType())
+        );
     }
 }


### PR DESCRIPTION
# 📋 연관 이슈

- close #84 

# 🚀 작업 내용

- 1. 나의 Comment 목록 조회 API 구현
- 2. Swagger Docs 추가

# 💬 리뷰 중점 사항

- CommentRepository 내부에 findCommentsWithMomentAndEmojisByCommenterId() 의 JPQL 문법에 문제가 없는지 또는 개선 사항이 없는지 확인 부탁드립니다. (FETCH JOIN 을 중점으로 봐주세요)

- Swagger Docs 작성 시 성공 요청에 대한 데이터 세부 내용이 문서에 표기되지 않는 문제가 발생
  - SuccessResponse data의 example = "json"을 제거하여 해당 API의 상세 데이터가 Docs에 표기되도록 수정하였습니다.

<!-- 추가적인 설명이나 고려사항이 있다면 작성하세요 -->

MomentQueryService의 구체 클래스가 구현되지 않아 구현이 필요합니다.