### PR TITLE
[REFACTOR] 회원가입 페이지에서 다음 버튼에 엔터 핸들링 추가

### DIFF
--- a/client/src/features/auth/ui/SignupForm.tsx
+++ b/client/src/features/auth/ui/SignupForm.tsx
@@ -33,13 +33,23 @@ export const SignupForm = () => {
       <S.SignupFormContent>
         <Funnel>
           <Step name="step1">
-            <SignupStep1 signupData={signupData} errors={errors} handleChange={handleChange} />
+            <SignupStep1
+              signupData={signupData}
+              errors={errors}
+              handleChange={handleChange}
+              onNext={!nextStep || isDisabled ? undefined : handleNextStep}
+            />
           </Step>
           <Step name="step2">
-            <SignupStep2 signupData={signupData} errors={errors} handleChange={handleChange} />
+            <SignupStep2
+              signupData={signupData}
+              errors={errors}
+              handleChange={handleChange}
+              onNext={!nextStep || isDisabled ? undefined : handleNextStep}
+            />
           </Step>
           <Step name="step3">
-            <SignupStep3 signupData={signupData} handleClick={handleClick} />
+            <SignupStep3 signupData={signupData} handleClick={handleClick} onEnter={handleClick} />
           </Step>
         </Funnel>
       </S.SignupFormContent>

--- a/client/src/pages/home/index.tsx
+++ b/client/src/pages/home/index.tsx
@@ -1,18 +1,8 @@
 import { Hero } from '@/widgets/hero';
 import * as S from './index.styles';
 import { Button } from '@/shared/ui/button/Button';
-import { useEffect } from 'react';
-import { api } from '@/app/lib/api';
 
 export default function HomePage() {
-  // 프로필 조회 테스트
-  useEffect(() => {
-    const getProfile = async () => {
-      const response = await api.get('/users/me');
-      console.log(response);
-    };
-    getProfile();
-  }, []);
 
   return (
     <S.HomePageWrapper>

--- a/client/src/shared/hooks/useEnterKeyHandler.ts
+++ b/client/src/shared/hooks/useEnterKeyHandler.ts
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+
+export const useEnterKeyHandler = (callback?: () => void) => {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Enter' && callback) {
+        e.preventDefault();
+        callback();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [callback]);
+};

--- a/client/src/widgets/signup/SignupStep1.tsx
+++ b/client/src/widgets/signup/SignupStep1.tsx
@@ -1,14 +1,28 @@
 import { SignupErrors, SignupFormData } from '@/features/auth/types/signup';
 import { Input } from '@/shared/ui/input/Input';
+import { useEffect } from 'react';
 import * as S from './SignupStep.styles';
 
 interface SignupStep1Props {
   signupData: SignupFormData;
   errors: SignupErrors;
   handleChange: (field: keyof SignupFormData) => (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onNext?: () => void;
 }
 
-export const SignupStep1 = ({ signupData, errors, handleChange }: SignupStep1Props) => {
+export const SignupStep1 = ({ signupData, errors, handleChange, onNext }: SignupStep1Props) => {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Enter' && onNext) {
+        e.preventDefault();
+        onNext();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onNext]);
+
   return (
     <S.StepContainer>
       <S.InputGroup>

--- a/client/src/widgets/signup/SignupStep1.tsx
+++ b/client/src/widgets/signup/SignupStep1.tsx
@@ -1,6 +1,6 @@
 import { SignupErrors, SignupFormData } from '@/features/auth/types/signup';
 import { Input } from '@/shared/ui/input/Input';
-import { useEffect } from 'react';
+import { useEnterKeyHandler } from '@/shared/hooks/useEnterKeyHandler';
 import * as S from './SignupStep.styles';
 
 interface SignupStep1Props {
@@ -11,17 +11,7 @@ interface SignupStep1Props {
 }
 
 export const SignupStep1 = ({ signupData, errors, handleChange, onNext }: SignupStep1Props) => {
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Enter' && onNext) {
-        e.preventDefault();
-        onNext();
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [onNext]);
+  useEnterKeyHandler(onNext);
 
   return (
     <S.StepContainer>

--- a/client/src/widgets/signup/SignupStep2.tsx
+++ b/client/src/widgets/signup/SignupStep2.tsx
@@ -1,6 +1,6 @@
 import { SignupErrors, SignupFormData } from '@/features/auth/types/signup';
 import { Input } from '@/shared/ui/input/Input';
-import { useEffect } from 'react';
+import { useEnterKeyHandler } from '@/shared/hooks/useEnterKeyHandler';
 import * as S from './SignupStep.styles';
 
 interface SignupStep2Props {
@@ -11,17 +11,7 @@ interface SignupStep2Props {
 }
 
 export const SignupStep2 = ({ signupData, errors, handleChange, onNext }: SignupStep2Props) => {
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Enter' && onNext) {
-        e.preventDefault();
-        onNext();
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [onNext]);
+  useEnterKeyHandler(onNext);
 
   return (
     <S.StepContainer>

--- a/client/src/widgets/signup/SignupStep2.tsx
+++ b/client/src/widgets/signup/SignupStep2.tsx
@@ -1,14 +1,28 @@
 import { SignupErrors, SignupFormData } from '@/features/auth/types/signup';
 import { Input } from '@/shared/ui/input/Input';
+import { useEffect } from 'react';
 import * as S from './SignupStep.styles';
 
 interface SignupStep2Props {
   signupData: SignupFormData;
   errors: SignupErrors;
   handleChange: (field: keyof SignupFormData) => (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onNext?: () => void;
 }
 
-export const SignupStep2 = ({ signupData, errors, handleChange }: SignupStep2Props) => {
+export const SignupStep2 = ({ signupData, errors, handleChange, onNext }: SignupStep2Props) => {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Enter' && onNext) {
+        e.preventDefault();
+        onNext();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onNext]);
+
   return (
     <S.StepContainer>
       <S.InputGroup>

--- a/client/src/widgets/signup/SignupStep3.tsx
+++ b/client/src/widgets/signup/SignupStep3.tsx
@@ -1,6 +1,6 @@
 import { SignupFormData } from '@/features/auth/types/signup';
 import { Button } from '@/shared/ui/button/Button';
-import { useEffect } from 'react';
+import { useEnterKeyHandler } from '@/shared/hooks/useEnterKeyHandler';
 import * as S from './SignupStep3.styles';
 
 interface SignupStep3Props {
@@ -10,17 +10,7 @@ interface SignupStep3Props {
 }
 
 export const SignupStep3 = ({ signupData, handleClick, onEnter }: SignupStep3Props) => {
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Enter' && onEnter) {
-        e.preventDefault();
-        onEnter();
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [onEnter]);
+  useEnterKeyHandler(onEnter);
 
   return (
     <S.StepContainer>

--- a/client/src/widgets/signup/SignupStep3.tsx
+++ b/client/src/widgets/signup/SignupStep3.tsx
@@ -1,13 +1,27 @@
 import { SignupFormData } from '@/features/auth/types/signup';
 import { Button } from '@/shared/ui/button/Button';
+import { useEffect } from 'react';
 import * as S from './SignupStep3.styles';
 
 interface SignupStep3Props {
   signupData: SignupFormData;
   handleClick: () => void;
+  onEnter?: () => void;
 }
 
-export const SignupStep3 = ({ signupData, handleClick }: SignupStep3Props) => {
+export const SignupStep3 = ({ signupData, handleClick, onEnter }: SignupStep3Props) => {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Enter' && onEnter) {
+        e.preventDefault();
+        onEnter();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onEnter]);
+
   return (
     <S.StepContainer>
       <S.InfoContainer>


### PR DESCRIPTION
# 📋 연관 이슈

- close #

# 🚀 작업 내용

## `useEnterKeyHandler` hook 구현
- Enter 키 이벤트를 감지하고 콜백 함수를 실행하는 로직을 캡슐화
- shared/hooks 디렉토리에 위치하여 전역적으로 재사용 가능

## SignupStep 컴포넌트 리팩터링
- SignupStep1.tsx, SignupStep2.tsx, SignupStep3.tsx에서 중복된 useEffect 로직 제거
- 각 컴포넌트에서 useEnterKeyHandler(callback) 한 줄로 대체

## 개선 효과
- 코드 중복 제거: 36줄의 중복 코드를 3줄로 단축
- 재사용성 향상: 다른 컴포넌트에서도 쉽게 Enter 키 처리 기능 활용 가능
- 유지보수성 개선: Enter 키 처리 로직 변경 시 한 곳에서만 수정하면 됨
- 가독성 향상: 각 컴포넌트의 핵심 로직에 집중할 수 있음
