### PR TITLE
[FIX] 모멘트에 이미 코멘트 존재하는 경우 코멘트 등록 시 예외 발생하도록 수정

### DIFF
--- a/server/src/main/java/moment/comment/application/CommentQueryService.java
+++ b/server/src/main/java/moment/comment/application/CommentQueryService.java
@@ -1,8 +1,11 @@
 package moment.comment.application;
 
 import moment.comment.domain.Comment;
+import moment.moment.domain.Moment;
 
 public interface CommentQueryService {
 
     Comment getCommentById(Long id);
+
+    boolean existsByMoment(Moment moment);
 }

--- a/server/src/main/java/moment/comment/application/CommentService.java
+++ b/server/src/main/java/moment/comment/application/CommentService.java
@@ -1,8 +1,5 @@
 package moment.comment.application;
 
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import moment.comment.domain.Comment;
 import moment.comment.dto.request.CommentCreateRequest;
@@ -20,6 +17,10 @@ import moment.user.domain.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -29,11 +30,16 @@ public class CommentService {
     private final MomentQueryService momentQueryService;
     private final CommentRepository commentRepository;
     private final EmojiRepository emojiRepository;
+    private final CommentQueryService commentQueryService;
 
     @Transactional
     public CommentCreateResponse addComment(CommentCreateRequest request, Long commenterId) {
         User commenter = userQueryService.getUserById(commenterId);
         Moment moment = momentQueryService.getMomentById(request.momentId());
+
+        if (commentQueryService.existsByMoment(moment)) {
+            throw new MomentException(ErrorCode.COMMENT_CONFLICT);
+        }
 
         Comment comment = request.toComment(commenter, moment);
 

--- a/server/src/main/java/moment/comment/application/DefaultCommentQueryService.java
+++ b/server/src/main/java/moment/comment/application/DefaultCommentQueryService.java
@@ -5,6 +5,7 @@ import moment.comment.domain.Comment;
 import moment.comment.infrastructure.CommentRepository;
 import moment.global.exception.ErrorCode;
 import moment.global.exception.MomentException;
+import moment.moment.domain.Moment;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,5 +20,10 @@ public class DefaultCommentQueryService implements CommentQueryService {
     public Comment getCommentById(Long id) {
         return commentRepository.findById(id)
                 .orElseThrow(() -> new MomentException(ErrorCode.COMMENT_NOT_FOUND));
+    }
+
+    @Override
+    public boolean existsByMoment(Moment moment) {
+        return commentRepository.existsByMoment(moment);
     }
 }

--- a/server/src/main/java/moment/comment/infrastructure/CommentRepository.java
+++ b/server/src/main/java/moment/comment/infrastructure/CommentRepository.java
@@ -13,4 +13,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @EntityGraph(attributePaths = {"moment"})
     List<Comment> findAllByMomentIn(List<Moment> moments);
+
+    boolean existsByMoment(Moment moment);
 }

--- a/server/src/main/java/moment/global/exception/ErrorCode.java
+++ b/server/src/main/java/moment/global/exception/ErrorCode.java
@@ -27,14 +27,16 @@ public enum ErrorCode {
 
     COMMENT_INVALID("C-001", "유효하지 않은 코멘트입니다.", HttpStatus.BAD_REQUEST),
     COMMENT_NOT_FOUND("C-002", "존재하지 않는 코멘트입니다.", HttpStatus.NOT_FOUND),
+    COMMENT_CONFLICT("C-003", "모멘트에 등록된 코멘트가 이미 존재합니다.", HttpStatus.CONFLICT),
 
     MOMENT_CONTENT_EMPTY("M-001", "모멘트 내용이 비어있습니다.", HttpStatus.BAD_REQUEST),
-    MOMENT_NOT_FOUND("M-002", "존재하지 않는 모멘트입니다.", HttpStatus.NOT_FOUND);
+    MOMENT_NOT_FOUND("M-002", "존재하지 않는 모멘트입니다.", HttpStatus.NOT_FOUND),
+    ;
 
     private final String code;
     private final String message;
     private final HttpStatus status;
-    
+
     ErrorCode(String code, String message, HttpStatus status) {
         this.code = code;
         this.message = message;

--- a/server/src/test/java/moment/comment/application/DefaultMomentQueryServiceTest.java
+++ b/server/src/test/java/moment/comment/application/DefaultMomentQueryServiceTest.java
@@ -1,13 +1,5 @@
 package moment.comment.application;
 
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-
-import java.util.Optional;
 import moment.comment.domain.Comment;
 import moment.comment.infrastructure.CommentRepository;
 import moment.global.exception.ErrorCode;
@@ -21,6 +13,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayNameGeneration(ReplaceUnderscores.class)
@@ -58,5 +59,29 @@ class DefaultMomentQueryServiceTest {
         assertThatThrownBy(() -> defaultCommentQueryService.getCommentById(1L))
                 .isInstanceOf(MomentException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.COMMENT_NOT_FOUND);
+    }
+
+    @Test
+    void Momment에_등록된_Comment가_존재하면_true를_반환한다() {
+        // given
+        User momenter = new User("kiki@icloud.com", "1234", "kiki");
+        Moment moment = new Moment("오늘 하루는 힘든 하루~", true, momenter);
+
+        given(commentRepository.existsByMoment(any(Moment.class))).willReturn(true);
+
+        // when & then
+        assertThat(defaultCommentQueryService.existsByMoment(moment)).isTrue();
+    }
+
+    @Test
+    void Momment에_등록된_Comment가_존재하면_false를_반환한다() {
+        // given
+        User momenter = new User("kiki@icloud.com", "1234", "kiki");
+        Moment moment = new Moment("오늘 하루는 힘든 하루~", true, momenter);
+
+        given(commentRepository.existsByMoment(any(Moment.class))).willReturn(false);
+
+        // when & then
+        assertThat(defaultCommentQueryService.existsByMoment(moment)).isFalse();
     }
 }

--- a/server/src/test/java/moment/comment/infrastructure/CommentRepositoryTest.java
+++ b/server/src/test/java/moment/comment/infrastructure/CommentRepositoryTest.java
@@ -1,13 +1,8 @@
 package moment.comment.infrastructure;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
-import java.util.List;
 import moment.comment.domain.Comment;
 import moment.moment.domain.Moment;
 import moment.moment.infrastructure.MomentRepository;
-import moment.reply.infrastructure.EmojiRepository;
 import moment.user.domain.User;
 import moment.user.infrastructure.UserRepository;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -16,15 +11,17 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 @DataJpaTest
 @DisplayNameGeneration(ReplaceUnderscores.class)
 class CommentRepositoryTest {
 
     @Autowired
     private CommentRepository commentRepository;
-
-    @Autowired
-    private EmojiRepository emojiRepository;
 
     @Autowired
     private MomentRepository momentRepository;
@@ -56,5 +53,37 @@ class CommentRepositoryTest {
                 () -> assertThat(comments.getFirst()).isEqualTo(savedComment),
                 () -> assertThat(comments.getFirst().getMoment()).isEqualTo(savedMoment)
         );
+    }
+
+    @Test
+    void Momment의_Comment가_존재하면_true를_반환한다() {
+        // given
+        User momenter = new User("kiki@icloud.com", "1234", "kiki");
+        userRepository.save(momenter);
+
+        User commenter = new User("hippo@gmail.com", "1234", "hippo");
+        userRepository.save(commenter);
+
+        Moment moment = new Moment("오늘 하루는 힘든 하루~", true, momenter);
+        momentRepository.save(moment);
+
+        Comment comment = new Comment("첫 번째 댓글", commenter, moment);
+        commentRepository.save(comment);
+
+        // when & then
+        assertThat(commentRepository.existsByMoment(moment)).isTrue();
+    }
+
+    @Test
+    void Momment의_Comment가_존재하면_false를_반환한다() {
+        // given
+        User momenter = new User("kiki@icloud.com", "1234", "kiki");
+        userRepository.save(momenter);
+
+        Moment moment = new Moment("오늘 하루는 힘든 하루~", true, momenter);
+        momentRepository.save(moment);
+
+        // when & then
+        assertThat(commentRepository.existsByMoment(moment)).isFalse();
     }
 }


### PR DESCRIPTION
# 📋 연관 이슈

- close #190 

# 🚀 작업 내용

- 1. 모멘트에 이미 코멘트 존재하는 경우 코멘트 등록 시 예외 발생하도록 수정
- 2. 관련 테스트 작성

# 💬 리뷰 중점 사항

- 테스트 시나리오에 문제가 없는지 확인 부탁드립니다.

