### PR TITLE
[FEAT] emojis API POST, DELETE 연결 확인

### DIFF
--- a/client/src/features/comment/api/getComments.tsx
+++ b/client/src/features/comment/api/getComments.tsx
@@ -1,7 +1,7 @@
 import { api } from '@/app/lib/api';
-import { postCommentsResponse } from '../types/comments';
+import { CommentsResponse } from '../types/comments';
 
-export const getComments = async (): Promise<postCommentsResponse> => {
-  const response = await api.get<postCommentsResponse>('/comments/me');
+export const getComments = async (): Promise<CommentsResponse> => {
+  const response = await api.get<CommentsResponse>('/comments/me');
   return response.data;
 };

--- a/client/src/features/comment/api/sendComments.tsx
+++ b/client/src/features/comment/api/sendComments.tsx
@@ -1,9 +1,9 @@
 import { api } from '@/app/lib/api';
-import { sendCommentsData, sendCommentsResponse } from '../types/comments';
+import { SendCommentsData, SendCommentsResponse } from '../types/comments';
 
 export const sendComments = async (
-  commentsData: sendCommentsData,
-): Promise<sendCommentsResponse> => {
+  commentsData: SendCommentsData,
+): Promise<SendCommentsResponse> => {
   const response = await api.post('/comments', commentsData);
   return response.data;
 };

--- a/client/src/features/comment/types/comments.ts
+++ b/client/src/features/comment/types/comments.ts
@@ -1,4 +1,4 @@
-export interface postCommentsResponse {
+export interface CommentsResponse {
   status: number;
   data: [
     {
@@ -19,12 +19,12 @@ export interface postCommentsResponse {
   ];
 }
 
-export interface sendCommentsData {
+export interface SendCommentsData {
   content: string;
   momentId: number;
 }
 
-export interface sendCommentsResponse {
+export interface SendCommentsResponse {
   status: number;
   data: {
     commentId: number;
@@ -33,7 +33,7 @@ export interface sendCommentsResponse {
   };
 }
 
-export interface sendCommentsError {
+export interface SendCommentsError {
   code: string;
   message: string;
   status: number;

--- a/client/src/features/comment/types/comments.ts
+++ b/client/src/features/comment/types/comments.ts
@@ -2,6 +2,7 @@ export interface CommentsResponse {
   status: number;
   data: [
     {
+      id: number;
       content: string;
       createdAt: string;
       moment: {

--- a/client/src/features/emoji/hooks/useDeleteEmoji.ts
+++ b/client/src/features/emoji/hooks/useDeleteEmoji.ts
@@ -1,0 +1,17 @@
+import { useDeleteEmojiMutation } from './useDeleteEmojiMutation';
+
+export const useDeleteEmoji = () => {
+  const { mutateAsync: deleteEmoji } = useDeleteEmojiMutation();
+
+  const handleDeleteEmoji = async (emojiId: number) => {
+    try {
+      await deleteEmoji(emojiId);
+    } catch {
+      alert('이모지 삭제에 실패했습니다.');
+    }
+  };
+
+  return {
+    handleDeleteEmoji,
+  };
+};

--- a/client/src/features/emoji/type/emoji.ts
+++ b/client/src/features/emoji/type/emoji.ts
@@ -1,8 +1,5 @@
-// TODO: 스티커 타입 추가되면 더 추가하기
-export type EmojiType = 'HEART';
-
 export interface EmojiRequest {
-  emojiType: EmojiType;
+  emojiType: string;
   commentId: number;
 }
 

--- a/client/src/features/emoji/ui/Emoji.tsx
+++ b/client/src/features/emoji/ui/Emoji.tsx
@@ -1,0 +1,22 @@
+import styled from '@emotion/styled';
+
+interface Emoji {
+  children: React.ReactNode;
+  onClick: () => void;
+}
+
+export const Emoji = ({ children, onClick }: Emoji) => {
+  return <EmojiStyle onClick={onClick}>{children}</EmojiStyle>;
+};
+
+export const EmojiStyle = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  border-radius: 50%;
+  width: 30px;
+  height: 30px;
+  background-color: ${({ theme }) => theme.colors['gray-600_20']};
+  border: 1px solid ${({ theme }) => theme.colors['gray-600']};
+`;

--- a/client/src/features/emoji/ui/EmojiButton.tsx
+++ b/client/src/features/emoji/ui/EmojiButton.tsx
@@ -4,14 +4,13 @@ import { useEmojiMutation } from '../hooks/useEmojiMutation';
 import { EmojiType } from '../type/emoji';
 
 interface EmojiButtonProps {
-  commentId?: number;
+  commentId: number;
   emojiType?: EmojiType;
 }
 
-// 현재는 commentId와 emojiType을 옵셔널로 주지만 나중엔 필수로 바꿔야함
-export const EmojiButton = ({ commentId = 1, emojiType = 'HEART' }: EmojiButtonProps) => {
+// 현재는 emojiType을 옵셔널로 주지만 나중엔 필수로 바꿔야함
+export const EmojiButton = ({ commentId, emojiType = 'HEART' }: EmojiButtonProps) => {
   const { mutateAsync: sendEmoji } = useEmojiMutation();
-
   const handleClick = async () => {
     try {
       await sendEmoji({

--- a/client/src/features/emoji/ui/EmojiButton.tsx
+++ b/client/src/features/emoji/ui/EmojiButton.tsx
@@ -1,11 +1,10 @@
 import { CustomTheme } from '@/app/styles/theme';
 import { Button } from '@/shared/ui';
 import { useEmojiMutation } from '../hooks/useEmojiMutation';
-import { EmojiType } from '../type/emoji';
 
 interface EmojiButtonProps {
   commentId: number;
-  emojiType?: EmojiType;
+  emojiType?: string;
 }
 
 // 현재는 emojiType을 옵셔널로 주지만 나중엔 필수로 바꿔야함

--- a/client/src/features/moment/api/matchMoments.ts
+++ b/client/src/features/moment/api/matchMoments.ts
@@ -1,7 +1,7 @@
 import { api } from '@/app/lib/api';
-import { matchMomentsResponse } from '../types/moments';
+import { MatchMomentsResponse } from '../types/moments';
 
-export const matchMoments = async (): Promise<matchMomentsResponse> => {
-  const response = await api.get<matchMomentsResponse>('/moments/matching');
+export const matchMoments = async (): Promise<MatchMomentsResponse> => {
+  const response = await api.get<MatchMomentsResponse>('/moments/matching');
   return response.data;
 };

--- a/client/src/features/moment/types/moments.ts
+++ b/client/src/features/moment/types/moments.ts
@@ -22,7 +22,7 @@ export interface Comment {
   id: number;
   content: string;
   createdAt: string;
-  emoji: Emoji[];
+  emojis: Emoji[];
 }
 
 export interface Emoji {

--- a/client/src/features/moment/types/moments.ts
+++ b/client/src/features/moment/types/moments.ts
@@ -3,7 +3,7 @@ export interface MomentsResponse {
   data: MyMoments[];
 }
 
-export interface matchMomentsResponse {
+export interface MatchMomentsResponse {
   status: number;
   data: {
     id: number;

--- a/client/src/features/moment/types/moments.ts
+++ b/client/src/features/moment/types/moments.ts
@@ -19,6 +19,7 @@ export interface MyMoments {
 }
 
 export interface Comment {
+  id: number;
   content: string;
   createdAt: string;
   emoji: Emoji[];

--- a/client/src/features/moment/ui/MyMomentsList.styles.ts
+++ b/client/src/features/moment/ui/MyMomentsList.styles.ts
@@ -32,3 +32,9 @@ export const MomentsContainer = styled.section`
   align-items: center;
   gap: 16px;
 `;
+
+export const EmojiContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+`;

--- a/client/src/features/moment/ui/MyMomentsList.tsx
+++ b/client/src/features/moment/ui/MyMomentsList.tsx
@@ -38,7 +38,7 @@ export const MyMomentsList = () => {
             />
           </Card.Content>
           <Card.Action position="space-between">
-            {myMoment.comment?.content && <EmojiButton />}
+            {myMoment.comment?.content && <EmojiButton commentId={myMoment.comment.id} />}
           </Card.Action>
         </Card>
       ))}

--- a/client/src/features/moment/ui/MyMomentsList.tsx
+++ b/client/src/features/moment/ui/MyMomentsList.tsx
@@ -7,6 +7,7 @@ import { Send, Timer } from 'lucide-react';
 import { useMomentsQuery } from '../hook/useMomentsQuery';
 import { MyMoments } from '../types/moments';
 import * as S from './MyMomentsList.styles';
+import { emojiMapping } from '@/features/emoji/utils/emojiMapping';
 
 export const MyMomentsList = () => {
   const { data } = useMomentsQuery();
@@ -38,7 +39,11 @@ export const MyMomentsList = () => {
             />
           </Card.Content>
           <Card.Action position="space-between">
+            {/* TODO: 이모지 딜리트 구현 */}
             {myMoment.comment?.content && <EmojiButton commentId={myMoment.comment.id} />}
+            {myMoment.comment && (
+              <div>{myMoment.comment.emojis.map(emoji => emojiMapping(emoji.emojiType))}</div>
+            )}
           </Card.Action>
         </Card>
       ))}

--- a/client/src/features/moment/ui/MyMomentsList.tsx
+++ b/client/src/features/moment/ui/MyMomentsList.tsx
@@ -8,10 +8,13 @@ import { useMomentsQuery } from '../hook/useMomentsQuery';
 import { MyMoments } from '../types/moments';
 import * as S from './MyMomentsList.styles';
 import { emojiMapping } from '@/features/emoji/utils/emojiMapping';
+import { useDeleteEmoji } from '@/features/emoji/hooks/useDeleteEmoji';
+import { Emoji } from '@/features/emoji/ui/Emoji';
 
 export const MyMomentsList = () => {
   const { data } = useMomentsQuery();
   const myMoments = data?.data;
+  const { handleDeleteEmoji } = useDeleteEmoji();
 
   return (
     <S.MomentsContainer>
@@ -42,7 +45,13 @@ export const MyMomentsList = () => {
             {/* TODO: 이모지 딜리트 구현 */}
             {myMoment.comment?.content && <EmojiButton commentId={myMoment.comment.id} />}
             {myMoment.comment && (
-              <div>{myMoment.comment.emojis.map(emoji => emojiMapping(emoji.emojiType))}</div>
+              <S.EmojiContainer>
+                {myMoment.comment.emojis.map(emoji => (
+                  <Emoji key={emoji.id} onClick={() => handleDeleteEmoji(emoji.id)}>
+                    {emojiMapping(emoji.emojiType)}
+                  </Emoji>
+                ))}
+              </S.EmojiContainer>
             )}
           </Card.Action>
         </Card>

--- a/client/src/pages/postComments/index.tsx
+++ b/client/src/pages/postComments/index.tsx
@@ -11,6 +11,7 @@ export default function PostCommentsPage() {
   const { data: commentsResponse, isLoading, error } = useCommentsQuery();
   const { data: emojiResponse } = useEmojisQuery(4); // TODO: 현재 commentsResponse에 commentId 값이 없어서 임시로 설정.
   const emojiData = emojiResponse?.data;
+  console.log('emojiData', emojiData);
 
   if (isLoading) return <div>로딩 중...</div>;
   if (error) return <div>에러가 발생했습니다.</div>;


### PR DESCRIPTION
# 📋 연관 이슈

- close #205 

# 🚀 작업 내용

- 나의 모멘트 페이지에서 스티커 보내기를 클릭시 "HEART" 이모지가 전송(POST)되도록 했습니다.
- 스티커를 클릭시 해당 스티커는 제거(DELETE)되도록 했습니다.

## 📸 Test Screenshot
<img width="749" height="335" alt="image" src="https://github.com/user-attachments/assets/73839c92-28c2-4661-a948-44e23039a8b6" />


## 📝 Additional Description
- API 연결에 주로 신경 썼습니다.
  - 급한대로 UI는 신경쓰지않았습니다.
  - 이모지는 상태로 관리되지 않아서 액션에 따른 이모지 데이터 존재 여부가 즉각적으로 반영되지 않습니다.
