### PR TITLE
[FEAT] 404 에러 페이지 및 라우팅 구현

### DIFF
--- a/client/src/app/routes/index.tsx
+++ b/client/src/app/routes/index.tsx
@@ -1,16 +1,17 @@
 import { Layout } from '@/app/layout/ui';
 import { ROUTES } from '@/app/routes/routes';
 import HomePage from '@/pages/home';
-import MyMoments from '@/pages/myMoments';
 import LoginPage from '@/pages/login';
+import MyMoments from '@/pages/myMoments';
 import SignupPage from '@/pages/signup';
 
-import TodayMomentPage from '@/pages/todayMoment';
 import PostCommentsPage from '@/pages/postComments';
+import TodayMomentPage from '@/pages/todayMoment';
 
-import { createBrowserRouter, createRoutesFromElements, Route } from 'react-router';
+import NotFoundPage from '@/pages/notFound';
 import TodayCommentPage from '@/pages/todayComment/TodayCommentPage';
 import TodayCommentSuccessPage from '@/pages/todayComment/TodayCommentSuccessPage';
+import { createBrowserRouter, createRoutesFromElements, Route } from 'react-router';
 
 export const router = createBrowserRouter(
   createRoutesFromElements(
@@ -24,6 +25,7 @@ export const router = createBrowserRouter(
       <Route path={ROUTES.TODAY_MOMENT} element={<TodayMomentPage />} />
       <Route path={ROUTES.TODAY_COMMENT} element={<TodayCommentPage />} />
       <Route path={ROUTES.TODAY_COMMENT_SUCCESS} element={<TodayCommentSuccessPage />} />
+      <Route path="*" element={<NotFoundPage />} />
     </Route>,
   ),
 );

--- a/client/src/pages/home/index.tsx
+++ b/client/src/pages/home/index.tsx
@@ -1,15 +1,22 @@
-import { Hero } from '@/widgets/hero';
-import * as S from './index.styles';
+import { ROUTES } from '@/app/routes/routes';
 import { Button } from '@/shared/ui/button/Button';
+import { Hero } from '@/widgets/hero';
+import { useNavigate } from 'react-router';
+import * as S from './index.styles';
 
 export default function HomePage() {
+  const navigate = useNavigate();
   return (
     <S.HomePageWrapper>
       <S.HeroSection>
         <Hero />
       </S.HeroSection>
       <S.ContentSection>
-        <Button title="지금 시작하기" variant="secondary" />
+        <Button
+          title="모멘트 작성하기"
+          variant="secondary"
+          onClick={() => navigate(ROUTES.TODAY_MOMENT)}
+        />
       </S.ContentSection>
     </S.HomePageWrapper>
   );

--- a/client/src/pages/home/index.tsx
+++ b/client/src/pages/home/index.tsx
@@ -6,17 +6,18 @@ import * as S from './index.styles';
 
 export default function HomePage() {
   const navigate = useNavigate();
+
+  const handleClick = () => {
+    navigate(ROUTES.TODAY_MOMENT);
+  };
+
   return (
     <S.HomePageWrapper>
       <S.HeroSection>
         <Hero />
       </S.HeroSection>
       <S.ContentSection>
-        <Button
-          title="모멘트 작성하기"
-          variant="secondary"
-          onClick={() => navigate(ROUTES.TODAY_MOMENT)}
-        />
+        <Button title="모멘트 작성하기" variant="secondary" onClick={handleClick} />
       </S.ContentSection>
     </S.HomePageWrapper>
   );

--- a/client/src/pages/notFound/index.styles.ts
+++ b/client/src/pages/notFound/index.styles.ts
@@ -5,7 +5,7 @@ export const NotFoundContainer = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  min-height: 60vh;
+  min-height: 70vh;
   padding: 2rem;
 `;
 

--- a/client/src/pages/notFound/index.styles.ts
+++ b/client/src/pages/notFound/index.styles.ts
@@ -1,0 +1,41 @@
+import styled from '@emotion/styled';
+
+export const NotFoundContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  padding: 2rem;
+`;
+
+export const NotFoundContent = styled.div`
+  text-align: center;
+  max-width: 500px;
+`;
+
+export const ErrorCode = styled.h1`
+  font-size: 6rem;
+  font-weight: bold;
+  color: ${({ theme }) => theme.colors['yellow-500']};
+  margin: 0;
+  line-height: 1;
+`;
+
+export const ErrorTitle = styled.h2`
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: ${({ theme }) => theme.colors['red-500']};
+  margin: 1rem 0;
+`;
+
+export const ErrorDescription = styled.p`
+  font-size: 1rem;
+  color: ${({ theme }) => theme.colors['gray-600']};
+  line-height: 1.6;
+  margin: 1rem 0 2rem;
+`;
+
+export const ButtonContainer = styled.div`
+  margin-top: 2rem;
+`;

--- a/client/src/pages/notFound/index.tsx
+++ b/client/src/pages/notFound/index.tsx
@@ -1,0 +1,31 @@
+import { ROUTES } from '@/app/routes/routes';
+import { Button } from '@/shared/ui/button/Button';
+import { useNavigate } from 'react-router';
+import * as S from './index.styles';
+
+const NotFoundPage = () => {
+  const navigate = useNavigate();
+
+  const handleGoHome = () => {
+    navigate(ROUTES.ROOT);
+  };
+
+  return (
+    <S.NotFoundContainer>
+      <S.NotFoundContent>
+        <S.ErrorCode>404</S.ErrorCode>
+        <S.ErrorTitle>페이지를 찾을 수 없습니다</S.ErrorTitle>
+        <S.ErrorDescription>
+          죄송합니다. 요청하신 페이지를 찾을 수 없습니다.
+          <br />
+          주소를 다시 확인해주세요.
+        </S.ErrorDescription>
+        <S.ButtonContainer>
+          <Button onClick={handleGoHome} variant="primary" title="홈으로 돌아가기" />
+        </S.ButtonContainer>
+      </S.NotFoundContent>
+    </S.NotFoundContainer>
+  );
+};
+
+export default NotFoundPage;


### PR DESCRIPTION
# 📋 연관 이슈

- close #222 

# 🚀 작업 내용

#### 잘못된 라우팅 접근 시 사용자에게 친화적인 404 에러 페이지를 표시하도록 구현했습니다.

### 주요 기능

- **404 에러 페이지 컴포넌트 추가**
  - 명확한 404 에러 코드 표시
  - 사용자 친화적인 안내 메시지
  - 홈으로 돌아가기 버튼 제공

- **라우팅 개선**
  - Catch-all route (`*`) 추가로 모든 잘못된 경로 처리
  - 기존 라우팅 구조 유지하면서 에러 처리 강화

- **일관된 디자인**
  - 프로젝트 테마 색상 활용
  - 반응형 중앙 정렬 레이아웃
  - 직관적인 사용자 인터페이스

### 사용자 경험 개선

이제 사용자가 존재하지 않는 URL로 접근했을 때:
1. 빈 화면이나 브라우저 기본 에러 대신 친절한 안내 페이지 표시
2. 명확한 상황 설명과 해결 방법 제시
3. 원클릭으로 홈페이지 복귀 가능


## 📸 Test Screenshot

<img width="2880" height="1610" alt="image" src="https://github.com/user-attachments/assets/37c4f3ab-bd38-472b-a38a-f439089b6ec3" />
