### PR TITLE
[FEAT] Emoji 데이터 상태 관리 적용

### DIFF
--- a/client/src/features/emoji/hooks/useDeleteEmojiMutation.ts
+++ b/client/src/features/emoji/hooks/useDeleteEmojiMutation.ts
@@ -6,7 +6,7 @@ export const useDeleteEmojiMutation = () => {
   return useMutation({
     mutationFn: deleteEmoji,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['emojis'] });
+      queryClient.invalidateQueries({ queryKey: ['moments'] });
     },
   });
 };

--- a/client/src/features/emoji/hooks/useEmojiMutation.ts
+++ b/client/src/features/emoji/hooks/useEmojiMutation.ts
@@ -1,8 +1,13 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { sendEmoji } from '../api/sendEmoji';
 
 export const useEmojiMutation = () => {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: sendEmoji,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['moments'] });
+    },
   });
 };

--- a/client/src/features/emoji/ui/EmojiButton.tsx
+++ b/client/src/features/emoji/ui/EmojiButton.tsx
@@ -1,29 +1,18 @@
 import { CustomTheme } from '@/app/styles/theme';
 import { Button } from '@/shared/ui';
 import { useEmojiMutation } from '../hooks/useEmojiMutation';
-import { Emoji } from '../type/emoji';
 
 interface EmojiButtonProps {
   commentId: number;
   emojiType?: string;
-  onAddEmojiData: (newEmoji: Emoji) => void;
 }
 
 // 현재는 emojiType을 옵셔널로 주지만 나중엔 필수로 바꿔야함
-export const EmojiButton = ({
-  commentId,
-  emojiType = 'HEART',
-  onAddEmojiData: handleEmojiAdded,
-}: EmojiButtonProps) => {
+export const EmojiButton = ({ commentId, emojiType = 'HEART' }: EmojiButtonProps) => {
   const { mutateAsync: sendEmoji } = useEmojiMutation();
   const handleClick = async () => {
     try {
-      const response = await sendEmoji({
-        emojiType,
-        commentId,
-      });
-
-      handleEmojiAdded(response.data[0]);
+      await sendEmoji({ emojiType, commentId });
     } catch {
       alert('스티커 보내기 실패');
     }

--- a/client/src/features/emoji/ui/EmojiButton.tsx
+++ b/client/src/features/emoji/ui/EmojiButton.tsx
@@ -1,21 +1,29 @@
 import { CustomTheme } from '@/app/styles/theme';
 import { Button } from '@/shared/ui';
 import { useEmojiMutation } from '../hooks/useEmojiMutation';
+import { Emoji } from '../type/emoji';
 
 interface EmojiButtonProps {
   commentId: number;
   emojiType?: string;
+  onAddEmojiData: (newEmoji: Emoji) => void;
 }
 
 // 현재는 emojiType을 옵셔널로 주지만 나중엔 필수로 바꿔야함
-export const EmojiButton = ({ commentId, emojiType = 'HEART' }: EmojiButtonProps) => {
+export const EmojiButton = ({
+  commentId,
+  emojiType = 'HEART',
+  onAddEmojiData: handleEmojiAdded,
+}: EmojiButtonProps) => {
   const { mutateAsync: sendEmoji } = useEmojiMutation();
   const handleClick = async () => {
     try {
-      await sendEmoji({
+      const response = await sendEmoji({
         emojiType,
         commentId,
       });
+
+      handleEmojiAdded(response.data[0]);
     } catch {
       alert('스티커 보내기 실패');
     }

--- a/client/src/features/moment/ui/MyMomentsCard.tsx
+++ b/client/src/features/moment/ui/MyMomentsCard.tsx
@@ -12,12 +12,7 @@ import * as S from './MyMomentsList.styles';
 
 export const MyMomentsCard = ({ myMoment, index }: { myMoment: MyMoments; index: number }) => {
   const { handleDeleteEmoji } = useDeleteEmoji();
-
   const emojis = myMoment.comment?.emojis || [];
-
-  const handleDeleteEmojiData = (emojiId: number) => {
-    handleDeleteEmoji(emojiId);
-  };
 
   return (
     <Card width="large" key={index}>
@@ -44,7 +39,7 @@ export const MyMomentsCard = ({ myMoment, index }: { myMoment: MyMoments; index:
         {myMoment.comment && (
           <S.EmojiContainer>
             {emojis.map(emoji => (
-              <Emoji key={emoji.id} onClick={() => handleDeleteEmojiData(emoji.id)}>
+              <Emoji key={emoji.id} onClick={() => handleDeleteEmoji(emoji.id)}>
                 {emojiMapping(emoji.emojiType)}
               </Emoji>
             ))}

--- a/client/src/features/moment/ui/MyMomentsCard.tsx
+++ b/client/src/features/moment/ui/MyMomentsCard.tsx
@@ -6,31 +6,17 @@ import { formatRelativeTime } from '@/shared/utils/formatRelativeTime';
 import { Send, Timer } from 'lucide-react';
 import { emojiMapping } from '@/features/emoji/utils/emojiMapping';
 import { Emoji } from '@/features/emoji/ui/Emoji';
-import { Emoji as EmojiType, MyMoments } from '../types/moments';
-import { useEffect, useState } from 'react';
+import { MyMoments } from '../types/moments';
 import { useDeleteEmoji } from '@/features/emoji/hooks/useDeleteEmoji';
 import * as S from './MyMomentsList.styles';
 
 export const MyMomentsCard = ({ myMoment, index }: { myMoment: MyMoments; index: number }) => {
   const { handleDeleteEmoji } = useDeleteEmoji();
 
-  // TODO: 추후 커스텀 훅으로 분리 예정
-  const [emojiData, setEmojiData] = useState<EmojiType[]>([]);
-
-  useEffect(() => {
-    if (myMoment.comment?.emojis) {
-      setEmojiData(myMoment.comment?.emojis);
-    }
-  }, [myMoment.comment?.emojis]);
+  const emojis = myMoment.comment?.emojis || [];
 
   const handleDeleteEmojiData = (emojiId: number) => {
     handleDeleteEmoji(emojiId);
-    const emojis = emojiData.filter(emoji => emoji.id !== emojiId);
-    setEmojiData(emojis);
-  };
-
-  const handleAddEmojiData = (newEmoji: EmojiType) => {
-    setEmojiData(prev => [...prev, newEmoji]);
   };
 
   return (
@@ -54,13 +40,10 @@ export const MyMomentsCard = ({ myMoment, index }: { myMoment: MyMoments; index:
         <SimpleCard height="small" content={myMoment.comment?.content || <NotFoundComments />} />
       </Card.Content>
       <Card.Action position="space-between">
-        {/* TODO: 이모지 딜리트 구현 */}
-        {myMoment.comment?.content && (
-          <EmojiButton commentId={myMoment.comment.id} onAddEmojiData={handleAddEmojiData} />
-        )}
+        {myMoment.comment?.content && <EmojiButton commentId={myMoment.comment.id} />}
         {myMoment.comment && (
           <S.EmojiContainer>
-            {emojiData.map(emoji => (
+            {emojis.map(emoji => (
               <Emoji key={emoji.id} onClick={() => handleDeleteEmojiData(emoji.id)}>
                 {emojiMapping(emoji.emojiType)}
               </Emoji>

--- a/client/src/features/moment/ui/MyMomentsCard.tsx
+++ b/client/src/features/moment/ui/MyMomentsCard.tsx
@@ -1,0 +1,73 @@
+import { theme } from '@/app/styles/theme';
+import { NotFoundComments } from '@/features/comment/ui/NotFoundComments';
+import { EmojiButton } from '@/features/emoji/ui/EmojiButton';
+import { Card, SimpleCard } from '@/shared/ui';
+import { formatRelativeTime } from '@/shared/utils/formatRelativeTime';
+import { Send, Timer } from 'lucide-react';
+import { emojiMapping } from '@/features/emoji/utils/emojiMapping';
+import { Emoji } from '@/features/emoji/ui/Emoji';
+import { Emoji as EmojiType, MyMoments } from '../types/moments';
+import { useEffect, useState } from 'react';
+import { useDeleteEmoji } from '@/features/emoji/hooks/useDeleteEmoji';
+import * as S from './MyMomentsList.styles';
+
+export const MyMomentsCard = ({ myMoment, index }: { myMoment: MyMoments; index: number }) => {
+  const { handleDeleteEmoji } = useDeleteEmoji();
+
+  // TODO: 추후 커스텀 훅으로 분리 예정
+  const [emojiData, setEmojiData] = useState<EmojiType[]>([]);
+
+  useEffect(() => {
+    if (myMoment.comment?.emojis) {
+      setEmojiData(myMoment.comment?.emojis);
+    }
+  }, [myMoment.comment?.emojis]);
+
+  const handleDeleteEmojiData = (emojiId: number) => {
+    handleDeleteEmoji(emojiId);
+    const emojis = emojiData.filter(emoji => emoji.id !== emojiId);
+    setEmojiData(emojis);
+  };
+
+  const handleAddEmojiData = (newEmoji: EmojiType) => {
+    setEmojiData(prev => [...prev, newEmoji]);
+  };
+
+  return (
+    <Card width="large" key={index}>
+      {/* TODO: 추후 key값에 id 값으로 변경 필요 */}
+      <Card.TitleContainer
+        title={
+          <S.TitleWrapper>
+            {/* TODO: 추후 Icon 컴포넌트로 변경 필요 */}
+            <Timer size={16} color={theme.colors['gray-400']} />{' '}
+            <S.TimeStamp>{formatRelativeTime(myMoment.createdAt)}</S.TimeStamp>
+          </S.TitleWrapper>
+        }
+        subtitle={myMoment.content}
+      />
+      <Card.Content>
+        <S.TitleContainer>
+          <Send size={20} color={theme.colors['yellow-500']} />
+          <span>받은 공감</span>
+        </S.TitleContainer>
+        <SimpleCard height="small" content={myMoment.comment?.content || <NotFoundComments />} />
+      </Card.Content>
+      <Card.Action position="space-between">
+        {/* TODO: 이모지 딜리트 구현 */}
+        {myMoment.comment?.content && (
+          <EmojiButton commentId={myMoment.comment.id} onAddEmojiData={handleAddEmojiData} />
+        )}
+        {myMoment.comment && (
+          <S.EmojiContainer>
+            {emojiData.map(emoji => (
+              <Emoji key={emoji.id} onClick={() => handleDeleteEmojiData(emoji.id)}>
+                {emojiMapping(emoji.emojiType)}
+              </Emoji>
+            ))}
+          </S.EmojiContainer>
+        )}
+      </Card.Action>
+    </Card>
+  );
+};

--- a/client/src/features/moment/ui/MyMomentsList.tsx
+++ b/client/src/features/moment/ui/MyMomentsList.tsx
@@ -1,21 +1,13 @@
-import { theme } from '@/app/styles/theme';
-import { NotFoundComments } from '@/features/comment/ui/NotFoundComments';
-import { EmojiButton } from '@/features/emoji/ui/EmojiButton';
-import { Card, CommonSkeletonCard, SimpleCard } from '@/shared/ui';
-import { formatRelativeTime } from '@/shared/utils/formatRelativeTime';
-import { Send, Timer } from 'lucide-react';
 import { useMomentsQuery } from '../hook/useMomentsQuery';
 import { MyMoments } from '../types/moments';
 import * as S from './MyMomentsList.styles';
-import { emojiMapping } from '@/features/emoji/utils/emojiMapping';
-import { useDeleteEmoji } from '@/features/emoji/hooks/useDeleteEmoji';
-import { Emoji } from '@/features/emoji/ui/Emoji';
+import { MyMomentsCard } from './MyMomentsCard';
 import { NotFoundMyMoments } from './NotFoundMyMoments';
+import { CommonSkeletonCard } from '@/shared/ui';
 
 export const MyMomentsList = () => {
   const { data, isLoading } = useMomentsQuery();
   const myMoments = data?.data;
-  const { handleDeleteEmoji } = useDeleteEmoji();
 
   const hasMoments = myMoments?.length && myMoments.length > 0;
 
@@ -30,51 +22,14 @@ export const MyMomentsList = () => {
   }
 
   return (
-    <>
+    <S.MomentsContainer>
       {hasMoments ? (
-        <S.MomentsContainer>
-          {myMoments?.map((myMoment: MyMoments, index: number) => (
-            <Card width="large" key={index}>
-              {/* TODO: 추후 key값에 id 값으로 변경 필요 */}
-              <Card.TitleContainer
-                title={
-                  <S.TitleWrapper>
-                    {/* TODO: 추후 Icon 컴포넌트로 변경 필요 */}
-                    <Timer size={16} color={theme.colors['gray-400']} />{' '}
-                    <S.TimeStamp>{formatRelativeTime(myMoment.createdAt)}</S.TimeStamp>
-                  </S.TitleWrapper>
-                }
-                subtitle={myMoment.content}
-              />
-              <Card.Content>
-                <S.TitleContainer>
-                  <Send size={20} color={theme.colors['yellow-500']} />
-                  <span>받은 공감</span>
-                </S.TitleContainer>
-                <SimpleCard
-                  height="small"
-                  content={myMoment.comment?.content || <NotFoundComments />}
-                />
-              </Card.Content>
-              <Card.Action position="space-between">
-                {/* TODO: 이모지 딜리트 구현 */}
-                {myMoment.comment?.content && <EmojiButton commentId={myMoment.comment.id} />}
-                {myMoment.comment && (
-                  <S.EmojiContainer>
-                    {myMoment.comment.emojis.map(emoji => (
-                      <Emoji key={emoji.id} onClick={() => handleDeleteEmoji(emoji.id)}>
-                        {emojiMapping(emoji.emojiType)}
-                      </Emoji>
-                    ))}
-                  </S.EmojiContainer>
-                )}
-              </Card.Action>
-            </Card>
-          ))}
-        </S.MomentsContainer>
+        myMoments?.map((myMoment: MyMoments, index: number) => (
+          <MyMomentsCard myMoment={myMoment} index={index} />
+        ))
       ) : (
         <NotFoundMyMoments />
       )}
-    </>
+    </S.MomentsContainer>
   );
 };

--- a/client/src/pages/postComments/index.tsx
+++ b/client/src/pages/postComments/index.tsx
@@ -10,8 +10,12 @@ import { NotFoundMyComments } from './NotFoundMyComments';
 
 export default function PostCommentsPage() {
   const { data: commentsResponse, isLoading, error } = useCommentsQuery();
-  const { data: emojiResponse } = useEmojisQuery(4); // TODO: 현재 commentsResponse에 commentId 값이 없어서 임시로 설정.
-  const emojiData = emojiResponse?.data;
+
+  const getEmojiData = (commentId: number) => {
+    const { data: emojiResponse } = useEmojisQuery(commentId);
+    const emojiData = emojiResponse?.data;
+    return emojiData?.map(emoji => emojiMapping(emoji.emojiType)).join(' ');
+  };
 
   if (isLoading) {
     return (
@@ -71,14 +75,7 @@ export default function PostCommentsPage() {
                     <Gift size={20} color={theme.colors['yellow-500']} />
                     <span>받은 스티커</span>
                   </S.TitleContainer>
-                  {emojiData && emojiData.length > 0 ? (
-                    <S.Emoji>
-                      {emojiData.map(emoji => emojiMapping(emoji.emojiType)).join(' ')}
-                    </S.Emoji>
-                  ) : (
-                    // TODO: 스티커 없을 시 디자인 논의 필요
-                    <div>스티커가 없습니다.</div>
-                  )}
+                  <S.Emoji>{getEmojiData(post.id)}</S.Emoji>
                 </S.ContentContainer>
               </Card.Content>
             </Card>


### PR DESCRIPTION
# 📋 연관 이슈

- close #219 

# 🚀 작업 내용

- API 연결된 Emoji 데이터에 상태 관리를 적용했습니다. 이에 따라 이제 이모지 데이터가 추가, 삭제될 때 리렌더링되어 즉각적으로 화면에 반영이 됩니다.
- 나의 코멘트 페이지에서 Emoji GET API를 올바르게 연결시켰습니다. 

# 💬 리뷰 중점 사항

- Tanstack Query를 처음 쓰다보니 잘 작성한건지 모르겠네요. 이와 관련해서 잘 구현했는지 검토해주시면 감사하겠습니다.
- 추가 설명에 나온대로, 컴포넌트를 분리해서 각각의 이모지를 관리했는데 이 구조가 괜찮은지 봐주시면 감사하겠습니다!

## 📸 Test Screenshot

https://github.com/user-attachments/assets/9b7eb0e1-a10b-4ba4-8d2c-3f0b446f3ac7


## 📝 Additional Description
- 각 모멘트별로 emojis 상태를 관리하고자 했습니다. 따라서 `MyMomentsList`에서 해당 부분을 `MyMomentsCard`로 분리해 각 모멘트 데이터를 props로 넘겨 작업을 진행했습니다.
- 추가적으로 `postComments`에서 Emoji get API를 정상적으로 연결시켰는데, 일단 구현에 신경쓰느라 React 훅 사용 규칙을 위반한건 확인하지 못했네요. 다음 단계에서 수정하거나 내일 바로 수정해보겠습니다. 
  - 위반 규칙: 훅은 컴포넌트 최상위에서만 호출 가능 
  - 해당 부분은 구두로 얘기한대로 새로 이슈 파서 작업할 예정입니다. 
