### PR TITLE
[FEAT] 이메일 중복 확인 API 구현

### DIFF
--- a/server/src/main/java/moment/user/application/UserService.java
+++ b/server/src/main/java/moment/user/application/UserService.java
@@ -5,7 +5,9 @@ import moment.global.exception.ErrorCode;
 import moment.global.exception.MomentException;
 import moment.user.domain.User;
 import moment.user.dto.request.Authentication;
+import moment.user.dto.request.EmailConflictCheckRequest;
 import moment.user.dto.request.UserCreateRequest;
+import moment.user.dto.response.EmailConflictCheckResponse;
 import moment.user.dto.response.UserProfileResponse;
 import moment.user.infrastructure.UserRepository;
 import org.springframework.stereotype.Service;
@@ -33,20 +35,26 @@ public class UserService {
         }
     }
 
-    private void validateEmail(UserCreateRequest request) {
-        if (userRepository.existsByEmail(request.email())) {
-            throw new MomentException(ErrorCode.USER_CONFLICT);
-        }
-    }
-
     private void validateNickname(UserCreateRequest request) {
         if (userRepository.existsByNickname(request.nickname())) {
             throw new MomentException(ErrorCode.USER_NICKNAME_CONFLICT);
         }
     }
 
+    private void validateEmail(UserCreateRequest request) {
+        if (userRepository.existsByEmail(request.email())) {
+            throw new MomentException(ErrorCode.USER_CONFLICT);
+        }
+    }
+
     public UserProfileResponse getUserProfile(Authentication authentication) {
         User user = userQueryService.getUserById(authentication.id());
         return UserProfileResponse.from(user);
+    }
+
+    // todo existsByEmail도 QueryService에 들어가야 되는건지?
+    public EmailConflictCheckResponse checkEmailConflict(EmailConflictCheckRequest request) {
+        boolean existsByEmail = userRepository.existsByEmail(request.email());
+        return new EmailConflictCheckResponse(existsByEmail);
     }
 }

--- a/server/src/main/java/moment/user/dto/request/EmailConflictCheckRequest.java
+++ b/server/src/main/java/moment/user/dto/request/EmailConflictCheckRequest.java
@@ -1,0 +1,14 @@
+package moment.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+@Schema(description = "이메일 중복 확인 요청")
+public record EmailConflictCheckRequest(
+        @Schema(description = "중복 확인 이메일", example = "mimi@icloud.com")
+        @Pattern(regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", message = "EMAIL_INVALID")
+        @NotBlank(message = "EMAIL_INVALID")
+        String email
+) {
+}

--- a/server/src/main/java/moment/user/dto/request/UserCreateRequest.java
+++ b/server/src/main/java/moment/user/dto/request/UserCreateRequest.java
@@ -1,20 +1,30 @@
 package moment.user.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import moment.user.domain.User;
 
 @Schema(description = "회원가입 요청")
 public record UserCreateRequest(
         @Schema(description = "사용자 이메일(아이디)", example = "mimi@icloud.com")
+        @Pattern(regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", message = "EMAIL_INVALID")
+        @NotBlank(message = "EMAIL_INVALID")
         String email,
 
         @Schema(description = "사용자 비밀번호", example = "1234")
+        @Pattern(regexp = "^(?=.*[a-z])(?=.*\\d)[a-z\\d]{8,16}$", message = "PASSWORD_INVALID")
+        @NotBlank(message = "PASSWORD_INVALID")
         String password,
 
         @Schema(description = "비밀번호 확인", example = "1234")
+        @Pattern(regexp = "^(?=.*[a-z])(?=.*\\d)[a-z\\d]{8,16}$", message = "PASSWORD_INVALID")
+        @NotBlank(message = "PASSWORD_INVALID")
         String rePassword,
 
         @Schema(description = "사용자 닉네임", example = "mimi")
+        @Pattern(regexp = "^[a-zA-Z0-9가-힣]{2,6}$", message = "NICKNAME_INVALID")
+        @NotBlank(message = "NICKNAME_INVALID")
         String nickname
 ) {
 

--- a/server/src/main/java/moment/user/dto/response/EmailConflictCheckResponse.java
+++ b/server/src/main/java/moment/user/dto/response/EmailConflictCheckResponse.java
@@ -1,0 +1,10 @@
+package moment.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "이메일 중복 확인 응답")
+public record EmailConflictCheckResponse(
+        @Schema(description = "중복 확인 결과", example = "false")
+        boolean isExists
+) {
+}

--- a/server/src/main/java/moment/user/presentation/UserController.java
+++ b/server/src/main/java/moment/user/presentation/UserController.java
@@ -6,13 +6,16 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import moment.auth.presentation.AuthenticationPrincipal;
 import moment.global.dto.response.ErrorResponse;
 import moment.global.dto.response.SuccessResponse;
 import moment.user.application.UserService;
 import moment.user.dto.request.Authentication;
+import moment.user.dto.request.EmailConflictCheckRequest;
 import moment.user.dto.request.UserCreateRequest;
+import moment.user.dto.response.EmailConflictCheckResponse;
 import moment.user.dto.response.UserProfileResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -48,7 +51,7 @@ public class UserController {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
     })
     @PostMapping("/signup")
-    public ResponseEntity<SuccessResponse<Void>> createUser(@RequestBody UserCreateRequest request) {
+    public ResponseEntity<SuccessResponse<Void>> createUser(@Valid @RequestBody UserCreateRequest request) {
         userService.addUser(request);
         HttpStatus status = HttpStatus.CREATED;
         return ResponseEntity.status(status).body(SuccessResponse.of(status, null));
@@ -73,6 +76,28 @@ public class UserController {
     ) {
         UserProfileResponse response = userService.getUserProfile(authentication);
         HttpStatus status = HttpStatus.OK;
-        return ResponseEntity.status(status).body(SuccessResponse.of(status,response));
+        return ResponseEntity.status(status).body(SuccessResponse.of(status, response));
+    }
+
+    @Operation(summary = "이메일 중복 여부 조회", description = "회원 가입 시 이메일 중복 여부를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "이메일 중복 여부 조회 성공"),
+            @ApiResponse(responseCode = "400", description = """
+                    - [U-004] 유효하지 않은 이메일 형식입니다.
+                    """,
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(responseCode = "409", description = """
+                    - [U-001] 이미 가입된 사용자입니다.
+                    """,
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+    })
+    @PostMapping("/email/check")
+    public ResponseEntity<SuccessResponse<EmailConflictCheckResponse>> readEmailConflict(
+            @Valid @RequestBody EmailConflictCheckRequest request
+    ) {
+        EmailConflictCheckResponse response = userService.checkEmailConflict(request);
+        HttpStatus status = HttpStatus.OK;
+        return ResponseEntity.status(status).body(SuccessResponse.of(status, response));
     }
 }


### PR DESCRIPTION
# 📋 연관 이슈

- close #244 

# 🚀 작업 내용

- 1.  이메일 중복 체크 API 구현
- 2. dto validation 적용

# 💬 리뷰 중점 사항

- UserService 내 이메일 중복 체크 관련 로직를 집중적으로 리뷰 부탁드립니다.
- User 도메인 내 dto에 validation 적용하였습니다. 관련 내용 리뷰 부탁드립니다.


