### PR TITLE
[FEAT] 닉네임 중복 체크 API 구현

### DIFF
--- a/server/src/main/java/moment/user/application/UserService.java
+++ b/server/src/main/java/moment/user/application/UserService.java
@@ -5,7 +5,9 @@ import moment.global.exception.ErrorCode;
 import moment.global.exception.MomentException;
 import moment.user.domain.User;
 import moment.user.dto.request.Authentication;
+import moment.user.dto.request.NicknameConflictCheckRequest;
 import moment.user.dto.request.UserCreateRequest;
+import moment.user.dto.response.NicknameConflictCheckResponse;
 import moment.user.dto.response.UserProfileResponse;
 import moment.user.infrastructure.UserRepository;
 import org.springframework.stereotype.Service;
@@ -48,5 +50,10 @@ public class UserService {
     public UserProfileResponse getUserProfile(Authentication authentication) {
         User user = userQueryService.getUserById(authentication.id());
         return UserProfileResponse.from(user);
+    }
+
+    public NicknameConflictCheckResponse checkNicknameConflict(NicknameConflictCheckRequest request) {
+        boolean existsByNickname = userRepository.existsByNickname(request.nickname());
+        return new NicknameConflictCheckResponse(existsByNickname);
     }
 }

--- a/server/src/main/java/moment/user/domain/User.java
+++ b/server/src/main/java/moment/user/domain/User.java
@@ -14,6 +14,9 @@ import moment.global.domain.BaseEntity;
 import moment.global.exception.ErrorCode;
 import moment.global.exception.MomentException;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 @Entity(name = "users")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -21,7 +24,8 @@ import moment.global.exception.MomentException;
 @ToString
 public class User extends BaseEntity {
 
-    private static final String EMAIL_REGEX = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
+    private static final Pattern EMAIL_REGEX = Pattern.compile("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$");
+    private static final Pattern NICKNAME_REGEX = Pattern.compile("^[a-zA-Z0-9가-힣]{2,6}$");
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -54,7 +58,9 @@ public class User extends BaseEntity {
         if (email == null || email.isBlank()) {
             throw new IllegalArgumentException("email이 null이거나 빈 값이어서는 안 됩니다.");
         }
-        if (!email.matches(EMAIL_REGEX)) {
+
+        Matcher matcher = EMAIL_REGEX.matcher(email);
+        if (!matcher.matches()) {
             throw new MomentException(ErrorCode.EMAIL_INVALID);
         }
     }
@@ -68,6 +74,11 @@ public class User extends BaseEntity {
     private void validateNickname(String nickname) {
         if (nickname == null || nickname.isBlank()) {
             throw new IllegalArgumentException("nickname이 null이거나 빈 값이어서는 안 됩니다.");
+        }
+
+        Matcher matcher = NICKNAME_REGEX.matcher(nickname);
+        if (!matcher.matches()) {
+            throw new MomentException(ErrorCode.NICKNAME_INVALID);
         }
     }
 

--- a/server/src/main/java/moment/user/domain/User.java
+++ b/server/src/main/java/moment/user/domain/User.java
@@ -11,8 +11,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import moment.global.domain.BaseEntity;
-import moment.global.exception.ErrorCode;
-import moment.global.exception.MomentException;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -61,7 +59,7 @@ public class User extends BaseEntity {
 
         Matcher matcher = EMAIL_REGEX.matcher(email);
         if (!matcher.matches()) {
-            throw new MomentException(ErrorCode.EMAIL_INVALID);
+            throw new IllegalArgumentException("유효하지 않은 이메일 형식입니다.");
         }
     }
 
@@ -78,7 +76,7 @@ public class User extends BaseEntity {
 
         Matcher matcher = NICKNAME_REGEX.matcher(nickname);
         if (!matcher.matches()) {
-            throw new MomentException(ErrorCode.NICKNAME_INVALID);
+            throw new IllegalArgumentException("유효하지 않은 닉네임 형식입니다.");
         }
     }
 

--- a/server/src/main/java/moment/user/dto/request/NicknameConflictCheckRequest.java
+++ b/server/src/main/java/moment/user/dto/request/NicknameConflictCheckRequest.java
@@ -1,0 +1,14 @@
+package moment.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+@Schema(description = "닉네임 중복 확인 요청")
+public record NicknameConflictCheckRequest(
+        @Schema(description = "중복 확인 닉네임", example = "mimi")
+        @Pattern(regexp = "^[a-zA-Z0-9가-힣]{2,6}$", message = "NICKNAME_INVALID")
+        @NotBlank(message = "NICKNAME_INVALID")
+        String nickname
+) {
+}

--- a/server/src/main/java/moment/user/dto/response/NicknameConflictCheckResponse.java
+++ b/server/src/main/java/moment/user/dto/response/NicknameConflictCheckResponse.java
@@ -1,0 +1,10 @@
+package moment.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "닉네임 중복 확인 응답")
+public record NicknameConflictCheckResponse(
+        @Schema(description = "중복 확인 결과", example = "false")
+        boolean isExists
+) {
+}

--- a/server/src/main/java/moment/user/presentation/UserController.java
+++ b/server/src/main/java/moment/user/presentation/UserController.java
@@ -6,13 +6,16 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import moment.auth.presentation.AuthenticationPrincipal;
 import moment.global.dto.response.ErrorResponse;
 import moment.global.dto.response.SuccessResponse;
 import moment.user.application.UserService;
 import moment.user.dto.request.Authentication;
+import moment.user.dto.request.NicknameConflictCheckRequest;
 import moment.user.dto.request.UserCreateRequest;
+import moment.user.dto.response.NicknameConflictCheckResponse;
 import moment.user.dto.response.UserProfileResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -73,6 +76,24 @@ public class UserController {
     ) {
         UserProfileResponse response = userService.getUserProfile(authentication);
         HttpStatus status = HttpStatus.OK;
-        return ResponseEntity.status(status).body(SuccessResponse.of(status,response));
+        return ResponseEntity.status(status).body(SuccessResponse.of(status, response));
+    }
+
+    @Operation(summary = "닉네임 중복 여부 조회", description = "닉네임 중복 여부를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "닉네임 중복 여부 조회 성공"),
+            @ApiResponse(responseCode = "400", description = """
+                    - [U-006] 유효하지 않은 닉네임 형식입니다.
+                    """,
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @PostMapping("/nickname/check")
+    public ResponseEntity<SuccessResponse<NicknameConflictCheckResponse>> readNicknameConflict(
+            @Valid @RequestBody NicknameConflictCheckRequest request
+    ) {
+        NicknameConflictCheckResponse response = userService.checkNicknameConflict(request);
+        HttpStatus status = HttpStatus.OK;
+        return ResponseEntity.status(status).body(SuccessResponse.of(status, response));
     }
 }

--- a/server/src/main/java/moment/user/presentation/UserController.java
+++ b/server/src/main/java/moment/user/presentation/UserController.java
@@ -88,7 +88,7 @@ public class UserController {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             )
     })
-    @PostMapping("/nickname/check")
+    @PostMapping("/signup/nickname/check")
     public ResponseEntity<SuccessResponse<NicknameConflictCheckResponse>> readNicknameConflict(
             @Valid @RequestBody NicknameConflictCheckRequest request
     ) {

--- a/server/src/test/java/moment/comment/domain/CommentTest.java
+++ b/server/src/test/java/moment/comment/domain/CommentTest.java
@@ -1,8 +1,5 @@
 package moment.comment.domain;
 
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import moment.global.exception.ErrorCode;
 import moment.global.exception.MomentException;
 import moment.moment.domain.Moment;
@@ -13,6 +10,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 class CommentTest {
@@ -86,13 +86,13 @@ class CommentTest {
     @Test
     void Comment와_Moment_작성자가_아니라면_예외가_발생한다() {
         // given
-        User momenter = new User("momenter@email.com", "1234", "momenter");
+        User momenter = new User("momenter@email.com", "1234", "momter");
         ReflectionTestUtils.setField(momenter, "id", 1L);
 
-        User commenter = new User("commenter@email.com", "1234", "commenter");
+        User commenter = new User("commenter@email.com", "1234", "comter");
         ReflectionTestUtils.setField(commenter, "id", 2L);
 
-        User unAuthorized = new User("no@email.com", "1", "unAuthorized");
+        User unAuthorized = new User("no@email.com", "1", "nouser");
         ReflectionTestUtils.setField(unAuthorized, "id", 3L);
 
         Moment moment = new Moment("오늘 야근 정말 힘들었네요", momenter);

--- a/server/src/test/java/moment/reply/application/EmojiServiceTest.java
+++ b/server/src/test/java/moment/reply/application/EmojiServiceTest.java
@@ -1,13 +1,6 @@
 package moment.reply.application;
 
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-
 import moment.comment.application.CommentQueryService;
 import moment.comment.domain.Comment;
 import moment.global.exception.ErrorCode;
@@ -26,6 +19,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -79,7 +79,7 @@ class EmojiServiceTest {
         Authentication authentication = new Authentication(1L);
         EmojiCreateRequest request = new EmojiCreateRequest("HEART", 1L);
 
-        User unAuthorized = new User("noUser@gmail.com", "1234", "unAuthorized");
+        User unAuthorized = new User("noUser@gmail.com", "1234", "noUser");
         Comment comment = mock(Comment.class);
         Moment moment = mock(Moment.class);
         given(comment.getMoment()).willReturn(moment);

--- a/server/src/test/java/moment/reply/infrastructure/EmojiRepositoryTest.java
+++ b/server/src/test/java/moment/reply/infrastructure/EmojiRepositoryTest.java
@@ -1,9 +1,5 @@
 package moment.reply.infrastructure;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-
-import java.util.List;
 import moment.comment.domain.Comment;
 import moment.comment.infrastructure.CommentRepository;
 import moment.moment.domain.Moment;
@@ -16,6 +12,11 @@ import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DataJpaTest
 @DisplayNameGeneration(ReplaceUnderscores.class)
@@ -37,7 +38,7 @@ class EmojiRepositoryTest {
     void 코멘트에_달린_모든_이모지를_조회한다() {
         // given
         User momenter = userRepository.save(new User("ekorea623@gmail.com", "1q2w3e4r", "drago"));
-        User commenter = userRepository.save(new User("user@gmail.com", "1234", "commenter"));
+        User commenter = userRepository.save(new User("user@gmail.com", "1234", "user"));
         Moment moment = momentRepository.save(new Moment("오런완!", true, momenter));
         Comment comment = commentRepository.save(new Comment("수고 많으셨습니다.", commenter, moment));
 

--- a/server/src/test/java/moment/user/application/UserServiceTest.java
+++ b/server/src/test/java/moment/user/application/UserServiceTest.java
@@ -1,15 +1,11 @@
 package moment.user.application;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.times;
-
 import moment.global.exception.ErrorCode;
 import moment.global.exception.MomentException;
 import moment.user.domain.User;
+import moment.user.dto.request.NicknameConflictCheckRequest;
 import moment.user.dto.request.UserCreateRequest;
+import moment.user.dto.response.NicknameConflictCheckResponse;
 import moment.user.infrastructure.UserRepository;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -19,17 +15,22 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
 @ExtendWith(MockitoExtension.class)
 @DisplayNameGeneration(ReplaceUnderscores.class)
 class UserServiceTest {
 
+    private final UserCreateRequest request = new UserCreateRequest("mimi@icloud.com", "mimi1234", "mimi1234", "미미");
     @InjectMocks
     private UserService userService;
-
     @Mock
     private UserRepository userRepository;
-
-    private final UserCreateRequest request = new UserCreateRequest("mimi@icloud.com", "mimi1234", "mimi1234", "미미");
 
     @Test
     void 유저_생성에_성공한다() {
@@ -75,5 +76,33 @@ class UserServiceTest {
         assertThatThrownBy(() -> userService.addUser(request))
                 .isInstanceOf(MomentException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PASSWORD_MISMATCHED);
+    }
+
+    @Test
+    void 이미_존재하는_닉네임일_경우_true를_반환한다() {
+        // given
+        NicknameConflictCheckRequest request = new NicknameConflictCheckRequest("mimi");
+
+        given(userRepository.existsByNickname(any(String.class))).willReturn(true);
+
+        // when
+        NicknameConflictCheckResponse response = userService.checkNicknameConflict(request);
+
+        // & then
+        assertThat(response.isExists()).isTrue();
+    }
+
+    @Test
+    void 이미_존재하는_닉네임이_아닐_경우_false를_반환한다() {
+        // given
+        NicknameConflictCheckRequest request = new NicknameConflictCheckRequest("mimi");
+
+        given(userRepository.existsByNickname(any(String.class))).willReturn(false);
+
+        // when
+        NicknameConflictCheckResponse response = userService.checkNicknameConflict(request);
+
+        // & then
+        assertThat(response.isExists()).isFalse();
     }
 }

--- a/server/src/test/java/moment/user/domain/UserTest.java
+++ b/server/src/test/java/moment/user/domain/UserTest.java
@@ -48,8 +48,17 @@ class UserTest {
     }
 
     @ParameterizedTest
-    @CsvSource(value = {"null", "''", "' '"}, nullValues = "null")
+    @CsvSource(value = {"m", "!mimi", "mimimim"})
     void 닉네임_형식이_유효하지_않은_경우_예외가_발생한다(String nickname) {
+        // when & then
+        assertThatThrownBy(() -> new User("mimi@icloud.com", "password", nickname))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("유효하지 않은 닉네임 형식입니다.");
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {"null", "''", "' '"}, nullValues = "null")
+    void 닉네임_형식이_빈_값인_경우_예외가_발생한다(String nickname) {
         // when & then
         assertThatThrownBy(() -> new User("mimi@icloud.com", "password", nickname))
                 .isInstanceOf(IllegalArgumentException.class)

--- a/server/src/test/java/moment/user/domain/UserTest.java
+++ b/server/src/test/java/moment/user/domain/UserTest.java
@@ -1,16 +1,14 @@
 package moment.user.domain;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import moment.global.exception.ErrorCode;
-import moment.global.exception.MomentException;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 class UserTest {
@@ -36,8 +34,8 @@ class UserTest {
     void 이메일_형식이_유효하지_않은_경우_예외가_발생한다(String email) {
         // when & then
         assertThatThrownBy(() -> new User(email, "password", "mimi"))
-                .isInstanceOf(MomentException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.EMAIL_INVALID);
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("유효하지 않은 이메일 형식입니다.");
     }
 
     @ParameterizedTest

--- a/server/src/test/java/moment/user/presentation/UserControllerTest.java
+++ b/server/src/test/java/moment/user/presentation/UserControllerTest.java
@@ -1,18 +1,16 @@
 package moment.user.presentation;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.ContentType;
 import moment.auth.application.TokenManager;
 import moment.global.dto.response.SuccessResponse;
 import moment.user.domain.User;
+import moment.user.dto.request.NicknameConflictCheckRequest;
 import moment.user.dto.request.UserCreateRequest;
+import moment.user.dto.response.NicknameConflictCheckResponse;
 import moment.user.dto.response.UserProfileResponse;
 import moment.user.infrastructure.UserRepository;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -20,6 +18,9 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
@@ -71,6 +72,33 @@ class UserControllerTest {
                 });
 
         // then
+        assertAll(
+                () -> assertThat(response.status()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.data()).isEqualTo(expect)
+        );
+    }
+
+    @Test
+    void 닉네임_중복_여부_조회를_성공한다() {
+        // given
+        String nickname = "mimi";
+        NicknameConflictCheckRequest request = new NicknameConflictCheckRequest(nickname);
+
+        userRepository.save(new User("mimi@icloud.com", "password", nickname));
+
+        // when
+        SuccessResponse<NicknameConflictCheckResponse> response = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when().post("/api/v1/users/nickname/check")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract().as(new TypeRef<>() {
+                });
+
+        // then
+        NicknameConflictCheckResponse expect = new NicknameConflictCheckResponse(true);
+
         assertAll(
                 () -> assertThat(response.status()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(response.data()).isEqualTo(expect)

--- a/server/src/test/java/moment/user/presentation/UserControllerTest.java
+++ b/server/src/test/java/moment/user/presentation/UserControllerTest.java
@@ -90,7 +90,7 @@ class UserControllerTest {
         SuccessResponse<NicknameConflictCheckResponse> response = RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .body(request)
-                .when().post("/api/v1/users/nickname/check")
+                .when().post("/api/v1/users/signup/nickname/check")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract().as(new TypeRef<>() {


### PR DESCRIPTION
# 📋 연관 이슈

- close #255 

# 🚀 작업 내용

- 닉네임 중복 체크 API 구현

# 💬 리뷰 중점 사항

- 닉네임 중복 체크 API 기능 확인 부탁드립니다.
- 닉네임 중복 체크 swagger 예외 관련 문서화 제대로 되어 있는지 확인 부탁드립니다.

