### PR TITLE
[FEAT] Login Redirect 로직 구현 

### DIFF
--- a/client/src/app/routes/ProtectedRoute.tsx
+++ b/client/src/app/routes/ProtectedRoute.tsx
@@ -12,6 +12,7 @@ export const ProtectedRoute: React.FC = () => {
   }
 
   if (isError || !profile) {
+    alert('로그인 후 이용해주세요.');
     return <Navigate to={ROUTES.LOGIN} state={{ from: location }} replace />;
   }
 

--- a/client/src/app/routes/ProtectedRoute.tsx
+++ b/client/src/app/routes/ProtectedRoute.tsx
@@ -1,0 +1,19 @@
+import { useProfileQuery } from '@/features/auth/hooks/useProfileQuery';
+import React from 'react';
+import { Navigate, Outlet, useLocation } from 'react-router';
+import { ROUTES } from './routes';
+
+export const ProtectedRoute: React.FC = () => {
+  const { data: profile, isLoading, isError } = useProfileQuery();
+  const location = useLocation();
+
+  if (isLoading) {
+    return null;
+  }
+
+  if (isError || !profile) {
+    return <Navigate to={ROUTES.LOGIN} state={{ from: location }} replace />;
+  }
+
+  return <Outlet />;
+};

--- a/client/src/app/routes/index.tsx
+++ b/client/src/app/routes/index.tsx
@@ -1,16 +1,17 @@
 import { Layout } from '@/app/layout/ui';
+import { ProtectedRoute } from '@/app/routes/ProtectedRoute';
 import { ROUTES } from '@/app/routes/routes';
 import HomePage from '@/pages/home';
-import MyMoments from '@/pages/myMoments';
 import LoginPage from '@/pages/login';
+import MyMoments from '@/pages/myMoments';
 import SignupPage from '@/pages/signup';
 
-import TodayMomentPage from '@/pages/todayMoment';
 import PostCommentsPage from '@/pages/postComments';
+import TodayMomentPage from '@/pages/todayMoment';
 
-import { createBrowserRouter, createRoutesFromElements, Route } from 'react-router';
 import TodayCommentPage from '@/pages/todayComment/TodayCommentPage';
 import TodayCommentSuccessPage from '@/pages/todayComment/TodayCommentSuccessPage';
+import { createBrowserRouter, createRoutesFromElements, Route } from 'react-router';
 
 export const router = createBrowserRouter(
   createRoutesFromElements(
@@ -18,12 +19,13 @@ export const router = createBrowserRouter(
       <Route index element={<HomePage />} />
       <Route path={ROUTES.SIGNUP} element={<SignupPage />} />
       <Route path={ROUTES.LOGIN} element={<LoginPage />} />
-      <Route path={ROUTES.MY_MOMENTS} element={<MyMoments />} />
-      <Route path={ROUTES.TODAY_MOMENT} element={<TodayMomentPage />} />
-      <Route path={ROUTES.POST_COMMENTS} element={<PostCommentsPage />} />
-      <Route path={ROUTES.TODAY_MOMENT} element={<TodayMomentPage />} />
-      <Route path={ROUTES.TODAY_COMMENT} element={<TodayCommentPage />} />
-      <Route path={ROUTES.TODAY_COMMENT_SUCCESS} element={<TodayCommentSuccessPage />} />
+      <Route element={<ProtectedRoute />}>
+        <Route path={ROUTES.MY_MOMENTS} element={<MyMoments />} />
+        <Route path={ROUTES.TODAY_MOMENT} element={<TodayMomentPage />} />
+        <Route path={ROUTES.POST_COMMENTS} element={<PostCommentsPage />} />
+        <Route path={ROUTES.TODAY_COMMENT} element={<TodayCommentPage />} />
+        <Route path={ROUTES.TODAY_COMMENT_SUCCESS} element={<TodayCommentSuccessPage />} />
+      </Route>
     </Route>,
   ),
 );


### PR DESCRIPTION
# 📋 연관 이슈

- close #240 

# 🚀 작업 내용

인증되지 않은 사용자가 보호된 페이지에 접근할 때 자동으로 로그인 페이지로 리다이렉트하는 기능을 구현하였습니다.


## ProtectedRoute 컴포넌트 구현
- `useProfileQuery` 훅을 활용한 사용자 인증 상태 확인
- 로딩 상태 처리 및 인증 실패 시 로그인 페이지 자동 리다이렉트
- 현재 페이지 정보를 state로 전달하여 로그인 후 원래 페이지 복귀 가능

## 라우트 구조 개선
- 공개 페이지(홈, 회원가입, 로그인)와 보호된 페이지 분리
- 보호된 페이지들을 ProtectedRoute로 래핑
  - 내 모멘트 페이지
  - 오늘의 모멘트 작성 페이지  
  - 댓글 작성 페이지
  - 오늘의 댓글 페이지 및 성공 페이지
