### PR TITLE
[FEAT] Google Analytics 기능 구현 

### DIFF
--- a/.github/workflows/prod-client-cd.yml
+++ b/.github/workflows/prod-client-cd.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Create .env file
         run: |
           echo "REACT_APP_BASE_URL=${{ secrets.REACT_APP_BASE_URL }}" > .env
-
+          echo "REACT_APP_GA_ID=${{ secrets.REACT_APP_GA_ID }}" >> .env
       - name: Build application
         run: pnpm run build
         env:

--- a/client/package.json
+++ b/client/package.json
@@ -29,6 +29,7 @@
     "lucide-react": "^0.525.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-ga4": "^2.1.0",
     "react-router": "^7.6.3"
   },
   "devDependencies": {

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
+      react-ga4:
+        specifier: ^2.1.0
+        version: 2.1.0
       react-router:
         specifier: ^7.6.3
         version: 7.6.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -3985,6 +3988,9 @@ packages:
     resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
     peerDependencies:
       react: ^19.1.0
+
+  react-ga4@2.1.0:
+    resolution: {integrity: sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ==}
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -9296,6 +9302,8 @@ snapshots:
     dependencies:
       react: 19.1.0
       scheduler: 0.26.0
+
+  react-ga4@2.1.0: {}
 
   react-is@16.13.1: {}
 

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,5 +1,8 @@
 import App from '@/app/App';
+import { initGA, sendPageview } from '@/shared/lib/ga';
+import { useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
+import { useLocation } from 'react-router';
 
 async function enableMocking() {
   if (process.env.NODE_ENV !== 'development') {
@@ -15,6 +18,15 @@ async function enableMocking() {
 
 async function startApp() {
   // await enableMocking();
+  const location = useLocation();
+
+  useEffect(() => {
+    initGA();
+  }, []);
+
+  useEffect(() => {
+    sendPageview(location.pathname + location.search);
+  }, [location]);
 
   const rootElement = document.getElementById('root');
   if (!rootElement) {

--- a/client/src/pages/home/index.tsx
+++ b/client/src/pages/home/index.tsx
@@ -1,4 +1,5 @@
 import { ROUTES } from '@/app/routes/routes';
+import { sendEvent } from '@/shared/lib/ga';
 import { Button } from '@/shared/ui/button/Button';
 import { Hero } from '@/widgets/hero';
 import { useNavigate } from 'react-router';
@@ -8,6 +9,11 @@ export default function HomePage() {
   const navigate = useNavigate();
 
   const handleClick = () => {
+    sendEvent({
+      category: 'HomePage',
+      action: 'Click TodayMomentButton',
+      label: 'TodayMomentButton',
+    });
     navigate(ROUTES.TODAY_MOMENT);
   };
 

--- a/client/src/shared/lib/ga/index.ts
+++ b/client/src/shared/lib/ga/index.ts
@@ -1,0 +1,20 @@
+import ReactGA from 'react-ga4';
+
+const GA_MEASUREMENT_ID = process.env.REACT_APP_GA_ID || '';
+
+export const initGA = () => {
+  ReactGA.initialize(GA_MEASUREMENT_ID);
+};
+
+export const sendPageview = (path: string) => {
+  ReactGA.send({ hitType: 'pageview', page: path });
+};
+
+export const sendEvent = (event: {
+  category: string;
+  action: string;
+  label?: string;
+  value?: number;
+}) => {
+  ReactGA.event(event);
+};

--- a/client/webpack.common.js
+++ b/client/webpack.common.js
@@ -44,6 +44,7 @@ const config = {
       'process.env.REACT_APP_BASE_URL': JSON.stringify(
         process.env.REACT_APP_BASE_URL || 'http://localhost:8080/api/v1',
       ),
+      'process.env.REACT_APP_GA_ID': JSON.stringify(process.env.REACT_APP_GA_ID || ''),
     }),
   ],
 };


### PR DESCRIPTION
# 📋 연관 이슈

- close #258 

# 🚀 작업 내용

## Google Analytics 4 추적 기능 구현

### 1. GA 초기화 기능
- Google Analytics 4 측정 ID로 GA 초기화

### 2. 페이지뷰 추적 기능
- 특정 페이지 방문 시 GA에 페이지뷰 데이터 전송

### 3. 커스텀 이벤트 추적 기능
- 사용자 액션(클릭, 폼 제출 등)을 GA 이벤트로 전송 (HomePage에서 MyMoment Button에 적용)
- 카테고리, 액션, 라벨, 값 설정 


## 📝 Additional Description

- react-ga4 라이브러리 사용
- Github Secret에 GA-ID 추가
- 공용 Google 계정을 생성하여 Notion에 기록해두었습니다.

