### PR TITLE
[FEAT] 회원가입 시 아이디, 닉네임 중복 체크 로직 추가 & 타임 스탬프 기준 KR로 수정

### DIFF
--- a/client/src/app/styles/theme.ts
+++ b/client/src/app/styles/theme.ts
@@ -18,6 +18,8 @@ export const theme = {
     'amber-500': '#F59E0B',
     'red-500': '#EF4444',
     'navy-900': '#0a0a0f',
+    'navy-900_20': 'color-mix(in srgb, #0a0a0f 20%, transparent)',
+    'navy-900_40': 'color-mix(in srgb, #0a0a0f 40%, transparent)',
     'indigo-950': '#0d162b',
     'gray-200': '#CBD5E1',
     'gray-400': '#93A1B7',

--- a/client/src/features/auth/api/checkEmailExist.ts
+++ b/client/src/features/auth/api/checkEmailExist.ts
@@ -1,6 +1,6 @@
 import { api } from '@/app/lib/api';
 
 export const checkEmailExist = async (email: string) => {
-  const response = await api.post('/users/signup/email/check', email);
+  const response = await api.post('/users/signup/email/check', { email });
   return response.data;
 };

--- a/client/src/features/auth/api/checkEmailExist.ts
+++ b/client/src/features/auth/api/checkEmailExist.ts
@@ -1,0 +1,6 @@
+import { api } from '@/app/lib/api';
+
+export const checkEmailExist = async (email: string) => {
+  const response = await api.post('/users/email/check', email);
+  return response.data;
+};

--- a/client/src/features/auth/api/checkEmailExist.ts
+++ b/client/src/features/auth/api/checkEmailExist.ts
@@ -1,6 +1,6 @@
 import { api } from '@/app/lib/api';
 
 export const checkEmailExist = async (email: string) => {
-  const response = await api.post('/users/email/check', email);
+  const response = await api.post('/users/signup/email/check', email);
   return response.data;
 };

--- a/client/src/features/auth/api/checkNicknameExist.ts
+++ b/client/src/features/auth/api/checkNicknameExist.ts
@@ -1,6 +1,6 @@
 import { api } from '@/app/lib/api';
 
 export const checkNicknameExist = async (nickname: string) => {
-  const response = await api.post('/users/nickname/check', nickname);
+  const response = await api.post('/users/signup/nickname/check', nickname);
   return response.data;
 };

--- a/client/src/features/auth/api/checkNicknameExist.ts
+++ b/client/src/features/auth/api/checkNicknameExist.ts
@@ -1,6 +1,6 @@
 import { api } from '@/app/lib/api';
 
 export const checkNicknameExist = async (nickname: string) => {
-  const response = await api.post('/users/signup/nickname/check', nickname);
+  const response = await api.post('/users/signup/nickname/check', { nickname });
   return response.data;
 };

--- a/client/src/features/auth/api/checkNicknameExist.ts
+++ b/client/src/features/auth/api/checkNicknameExist.ts
@@ -1,0 +1,6 @@
+import { api } from '@/app/lib/api';
+
+export const checkNicknameExist = async (nickname: string) => {
+  const response = await api.post('/users/nickname/check', nickname);
+  return response.data;
+};

--- a/client/src/features/auth/hooks/useCheckEmail.ts
+++ b/client/src/features/auth/hooks/useCheckEmail.ts
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+import { checkEmailExist } from '../api/checkEmailExist';
+
+export const useCheckEmail = () => {
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const handleCheckEmail = async (value: string) => {
+    try {
+      const result = await checkEmailExist(value);
+      setErrorMessage(result.data.isExists ? '이미 존재하는 이메일입니다.' : '');
+    } catch (error) {
+      console.log(error);
+      alert('중복 확인 실패');
+    }
+  };
+
+  return { errorMessage, handleCheckEmail };
+};

--- a/client/src/features/auth/hooks/useCheckNickname.ts
+++ b/client/src/features/auth/hooks/useCheckNickname.ts
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+import { checkNicknameExist } from '../api/checkNicknameExist';
+
+export const useCheckNickname = () => {
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const handleCheckNickname = async (value: string) => {
+    try {
+      const result = await checkNicknameExist(value);
+      setErrorMessage(result.data.isExists ? '이미 존재하는 닉네임입니다.' : '');
+    } catch (error) {
+      console.log(error);
+      alert('중복 확인 실패');
+    }
+  };
+
+  return { errorMessage, handleCheckNickname };
+};

--- a/client/src/features/auth/ui/CheckButton.tsx
+++ b/client/src/features/auth/ui/CheckButton.tsx
@@ -1,0 +1,29 @@
+import { CustomTheme } from '@/app/styles/theme';
+import { Button } from '@/shared/ui';
+
+interface CheckButton {
+  onClick: () => void;
+}
+
+export const CheckButton = ({ onClick: handleClick }: CheckButton) => {
+  return <Button externalVariant={buttonVariant} title={'중복 확인'} onClick={handleClick} />;
+};
+
+const CheckButtonStyle = {
+  button: (theme: CustomTheme) => `
+    text-wrap: nowrap;
+    font-size: 14px;
+    font-weight: 600;
+    color: ${theme.colors['gray-400']};
+    background-color: ${theme.colors['navy-900_20']};
+    border-radius: 5px;
+    padding:14px 10px;
+    border: 1px solid ${theme.colors['gray-700']};
+    cursor: pointer;
+    &:hover {
+      background-color: ${theme.colors['navy-900_40']};
+    }
+  `,
+};
+
+const buttonVariant = (theme: CustomTheme) => CheckButtonStyle.button(theme);

--- a/client/src/features/auth/ui/SignupForm.tsx
+++ b/client/src/features/auth/ui/SignupForm.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/shared/ui/button/Button';
 import { SignupStep1, SignupStep2, SignupStep3, SignupStepBar } from '@/widgets/signup';
 import * as S from './SignupForm.styles';
 import { useCheckEmail } from '../hooks/useCheckEmail';
+import { useCheckNickname } from '../hooks/useCheckNickname';
 
 export const SignupForm = () => {
   const { Funnel, Step, useStep, beforeStep, nextStep } = useFunnel(STEPS);
@@ -15,6 +16,7 @@ export const SignupForm = () => {
   const { step, setStep } = useStep();
 
   const { handleCheckEmail, errorMessage: emailErrorMessage } = useCheckEmail();
+  const { handleCheckNickname, errorMessage: nicknameErrorMessage } = useCheckNickname();
 
   const handlePreviousStep = () => {
     if (beforeStep) {
@@ -28,7 +30,11 @@ export const SignupForm = () => {
     }
   };
 
-  const isDisabled = !isSignupFormValid(errors) || isDataEmpty(signupData) || !!emailErrorMessage;
+  const isDisabled =
+    !isSignupFormValid(errors) ||
+    isDataEmpty(signupData) ||
+    !!emailErrorMessage ||
+    !!nicknameErrorMessage;
 
   return (
     <S.SignupFormWrapper>
@@ -51,6 +57,8 @@ export const SignupForm = () => {
               errors={errors}
               handleChange={handleChange}
               onNext={!nextStep || isDisabled ? undefined : handleNextStep}
+              handleCheckNickname={handleCheckNickname}
+              nicknameErrorMessage={nicknameErrorMessage}
             />
           </Step>
           <Step name="step3">

--- a/client/src/features/auth/ui/SignupForm.tsx
+++ b/client/src/features/auth/ui/SignupForm.tsx
@@ -6,12 +6,15 @@ import { STEPS } from '@/shared/types/step';
 import { Button } from '@/shared/ui/button/Button';
 import { SignupStep1, SignupStep2, SignupStep3, SignupStepBar } from '@/widgets/signup';
 import * as S from './SignupForm.styles';
+import { useCheckEmail } from '../hooks/useCheckEmail';
 
 export const SignupForm = () => {
   const { Funnel, Step, useStep, beforeStep, nextStep } = useFunnel(STEPS);
 
   const { signupData, errors, handleChange, handleClick } = useSignup();
   const { step, setStep } = useStep();
+
+  const { handleCheckEmail, errorMessage: emailErrorMessage } = useCheckEmail();
 
   const handlePreviousStep = () => {
     if (beforeStep) {
@@ -25,7 +28,7 @@ export const SignupForm = () => {
     }
   };
 
-  const isDisabled = !isSignupFormValid(errors) || isDataEmpty(signupData);
+  const isDisabled = !isSignupFormValid(errors) || isDataEmpty(signupData) || !!emailErrorMessage;
 
   return (
     <S.SignupFormWrapper>
@@ -38,6 +41,8 @@ export const SignupForm = () => {
               errors={errors}
               handleChange={handleChange}
               onNext={!nextStep || isDisabled ? undefined : handleNextStep}
+              handleCheckEmail={handleCheckEmail}
+              emailErrorMessage={emailErrorMessage}
             />
           </Step>
           <Step name="step2">

--- a/client/src/features/auth/utils/validateAuth.test.ts
+++ b/client/src/features/auth/utils/validateAuth.test.ts
@@ -142,13 +142,13 @@ describe('닉네임 유효성 검사', () => {
   });
 
   it('닉네임이 유효한 경우 빈 문자열을 반환해야 한다', () => {
-    const nickname = 'testnick';
+    const nickname = 'test';
     const result = validateNickname(nickname);
     expect(result).toBe('');
   });
 
   it('다양한 유효한 닉네임을 허용해야 한다', () => {
-    const validNicknames = ['ab', 'test', 'testuser123', '한글닉네임', '가나다라마바사'];
+    const validNicknames = ['ab', 'test', 'test12', '한글닉네임', '가나다라마바'];
 
     validNicknames.forEach(nickname => {
       const result = validateNickname(nickname);
@@ -217,7 +217,7 @@ describe('회원가입 폼 전체 유효성 검사', () => {
       email: 'test@example.com',
       password: 'Valid123!',
       rePassword: 'Valid123!',
-      nickname: 'testnick',
+      nickname: 'test',
     };
 
     const result = validateSignupForm(signupData);
@@ -251,7 +251,7 @@ describe('회원가입 폼 전체 유효성 검사', () => {
       email: 'invalid@',
       password: 'weak',
       rePassword: 'weak',
-      nickname: 'testnick',
+      nickname: 'test',
     };
 
     const result = validateSignupForm(signupData);
@@ -432,7 +432,7 @@ describe('isDataEmpty', () => {
       email: '',
       password: '',
       rePassword: '',
-      nickname: 'testnick',
+      nickname: 'test',
     };
 
     const result = isDataEmpty(signupData);

--- a/client/src/features/auth/utils/validateAuth.ts
+++ b/client/src/features/auth/utils/validateAuth.ts
@@ -2,6 +2,7 @@ import { LoginError, LoginFormData } from '@/features/auth/types/login';
 import { SignupErrors, SignupFormData } from '@/features/auth/types/signup';
 
 const EMAIL_REGEX = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+const NICKNAME_REGEX = /[`~!@#$%^&*()_|+\-=?;:'",.<>\{\}\[\]\\\/ ]/gim;
 
 export const validateEmail = (email: string): string => {
   if (!email) {
@@ -35,6 +36,10 @@ export const validateNickname = (nickname: string): string => {
     return '닉네임을 입력해주세요.';
   } else if (nickname.length < 2) {
     return '닉네임은 최소 2자 이상이어야 합니다.';
+  } else if (nickname.length > 6) {
+    return '닉네임은 최대 6자 이하여야 합니다.';
+  } else if (NICKNAME_REGEX.test(nickname)) {
+    return '닉네임은 특수문자를 포함할 수 없습니다.';
   }
   return '';
 };

--- a/client/src/features/auth/utils/validateAuth.ts
+++ b/client/src/features/auth/utils/validateAuth.ts
@@ -1,7 +1,7 @@
 import { LoginError, LoginFormData } from '@/features/auth/types/login';
 import { SignupErrors, SignupFormData } from '@/features/auth/types/signup';
 
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const EMAIL_REGEX = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 
 export const validateEmail = (email: string): string => {
   if (!email) {

--- a/client/src/features/auth/utils/validateAuth.ts
+++ b/client/src/features/auth/utils/validateAuth.ts
@@ -2,6 +2,7 @@ import { LoginError, LoginFormData } from '@/features/auth/types/login';
 import { SignupErrors, SignupFormData } from '@/features/auth/types/signup';
 
 const EMAIL_REGEX = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+const PASSWORD_REGEX = /^(?=.[a-z])(?=.\d)(?=.[!@#$%^&()])[a-zA-Z\d!@#$%^&*()]{8,16}$/;
 const NICKNAME_REGEX = /[`~!@#$%^&*()_|+\-=?;:'",.<>\{\}\[\]\\\/ ]/gim;
 
 export const validateEmail = (email: string): string => {
@@ -16,8 +17,12 @@ export const validateEmail = (email: string): string => {
 export const validatePassword = (password: string): string => {
   if (!password) {
     return '비밀번호를 입력해주세요.';
-  } else if (password.length < 4) {
-    return '비밀번호는 최소 4자 이상이어야 합니다.';
+  } else if (password.length < 8) {
+    return '비밀번호는 최소 8자 이상이어야 합니다.';
+  } else if (password.length > 16) {
+    return '비밀번호는 최대 16자 이하여야 합니다.';
+  } else if (!PASSWORD_REGEX.test(password)) {
+    return '비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다.';
   }
   return '';
 };

--- a/client/src/shared/utils/formatRelativeTime.ts
+++ b/client/src/shared/utils/formatRelativeTime.ts
@@ -1,7 +1,9 @@
 export const formatRelativeTime = (dateString: string): string => {
   const now = new Date();
   const targetDate = new Date(dateString);
-  const diffInSeconds = Math.floor((now.getTime() - targetDate.getTime()) / 1000);
+  const targetKoreaTime = new Date(targetDate.getTime() + 9 * 60 * 60 * 1000);
+
+  const diffInSeconds = Math.floor((now.getTime() - targetKoreaTime.getTime()) / 1000);
 
   if (isNaN(targetDate.getTime())) {
     throw new Error('Invalid date string provided');
@@ -32,11 +34,12 @@ export const formatRelativeTime = (dateString: string): string => {
   }
 
   const diffInMonths =
-    (now.getFullYear() - targetDate.getFullYear()) * 12 + (now.getMonth() - targetDate.getMonth());
+    (now.getFullYear() - targetKoreaTime.getFullYear()) * 12 +
+    (now.getMonth() - targetKoreaTime.getMonth());
   if (diffInMonths < 12) {
     return `${diffInMonths}개월 전`;
   }
 
-  const diffInYears = now.getFullYear() - targetDate.getFullYear();
+  const diffInYears = now.getFullYear() - targetKoreaTime.getFullYear();
   return `${diffInYears}년 전`;
 };

--- a/client/src/widgets/signup/SignupStep.styles.ts
+++ b/client/src/widgets/signup/SignupStep.styles.ts
@@ -29,3 +29,9 @@ export const ErrorMessage = styled.span`
   display: block;
   line-height: 1.5;
 `;
+
+export const CheckExistContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;

--- a/client/src/widgets/signup/SignupStep1.tsx
+++ b/client/src/widgets/signup/SignupStep1.tsx
@@ -2,29 +2,42 @@ import { SignupErrors, SignupFormData } from '@/features/auth/types/signup';
 import { Input } from '@/shared/ui/input/Input';
 import { useEnterKeyHandler } from '@/shared/hooks/useEnterKeyHandler';
 import * as S from './SignupStep.styles';
+import { CheckButton } from '@/features/auth/ui/CheckButton';
 
 interface SignupStep1Props {
   signupData: SignupFormData;
   errors: SignupErrors;
   handleChange: (field: keyof SignupFormData) => (e: React.ChangeEvent<HTMLInputElement>) => void;
   onNext?: () => void;
+  handleCheckEmail: (value: string) => void;
+  emailErrorMessage: string;
 }
 
-export const SignupStep1 = ({ signupData, errors, handleChange, onNext }: SignupStep1Props) => {
+export const SignupStep1 = ({
+  signupData,
+  errors,
+  handleChange,
+  onNext,
+  handleCheckEmail,
+  emailErrorMessage,
+}: SignupStep1Props) => {
   useEnterKeyHandler(onNext);
 
   return (
     <S.StepContainer>
       <S.InputGroup>
         <S.Label htmlFor="username">이메일</S.Label>
-        <Input
-          id="email"
-          type="email"
-          placeholder="이메일을 입력해주세요"
-          value={signupData.email}
-          onChange={handleChange('email')}
-        />
-        <S.ErrorMessage>{errors.email || ''}</S.ErrorMessage>
+        <S.CheckExistContainer>
+          <Input
+            id="email"
+            type="email"
+            placeholder="이메일을 입력해주세요"
+            value={signupData.email}
+            onChange={handleChange('email')}
+          />
+          <CheckButton onClick={() => handleCheckEmail(signupData.email)} />
+        </S.CheckExistContainer>
+        <S.ErrorMessage>{emailErrorMessage || errors.email}</S.ErrorMessage>
       </S.InputGroup>
 
       <S.InputGroup>

--- a/client/src/widgets/signup/SignupStep2.tsx
+++ b/client/src/widgets/signup/SignupStep2.tsx
@@ -2,29 +2,42 @@ import { SignupErrors, SignupFormData } from '@/features/auth/types/signup';
 import { Input } from '@/shared/ui/input/Input';
 import { useEnterKeyHandler } from '@/shared/hooks/useEnterKeyHandler';
 import * as S from './SignupStep.styles';
+import { CheckButton } from '@/features/auth/ui/CheckButton';
 
 interface SignupStep2Props {
   signupData: SignupFormData;
   errors: SignupErrors;
   handleChange: (field: keyof SignupFormData) => (e: React.ChangeEvent<HTMLInputElement>) => void;
   onNext?: () => void;
+  handleCheckNickname: (value: string) => void;
+  nicknameErrorMessage: string;
 }
 
-export const SignupStep2 = ({ signupData, errors, handleChange, onNext }: SignupStep2Props) => {
+export const SignupStep2 = ({
+  signupData,
+  errors,
+  handleChange,
+  onNext,
+  handleCheckNickname,
+  nicknameErrorMessage,
+}: SignupStep2Props) => {
   useEnterKeyHandler(onNext);
 
   return (
     <S.StepContainer>
       <S.InputGroup>
         <S.Label htmlFor="nickname">닉네임</S.Label>
-        <Input
-          id="nickname"
-          type="text"
-          placeholder="닉네임을 입력해주세요"
-          value={signupData.nickname}
-          onChange={handleChange('nickname')}
-        />
-        <S.ErrorMessage>{errors.nickname || ''}</S.ErrorMessage>
+        <S.CheckExistContainer>
+          <Input
+            id="nickname"
+            type="text"
+            placeholder="닉네임을 입력해주세요"
+            value={signupData.nickname}
+            onChange={handleChange('nickname')}
+          />
+          <CheckButton onClick={() => handleCheckNickname(signupData.nickname)} />
+        </S.CheckExistContainer>
+        <S.ErrorMessage>{nicknameErrorMessage || errors.nickname}</S.ErrorMessage>
       </S.InputGroup>
     </S.StepContainer>
   );


### PR DESCRIPTION
# 📋 연관 이슈

- close #246 

# 🚀 작업 내용

- 회원가입 시 아이디, 닉네임 중복 체크 기능 추가
- 닉네임 유효성 검증 추가
- 타임 스탬프 기준 수정 (UTC -> KR)

# 💬 리뷰 중점 사항
- 중복 체크 로직들은 `SignupForm`에서 불러와 각 Step 컴포넌트에 props로 전달했는데요, 이에따라 props 전달 depth가 2단계가 되어서 이부분 괜찮으신지, 혹시 괜찮은 개선안이 있으신지 의견 주시면 좋겠습니다! 개인적으로는 회원가입에만 쓰이는 로직이라 큰 문제는 없을 것 같다고 생각하긴 합니다.

## 📝 Additional Description
- 중복 체크 로직들은 `SignupForm`에서 불러와 각 Step 컴포넌트에 props로 전달한 이유:
   - 회원가입 폼(`SignupForm`)에서 이전, 다음 버튼 섹션과 본문 섹션은 분리되어 있어서 각 Step에서가 아닌 부모로 끌어올라와서 props로 전달했습니다.

## 📸 Test Screenshot

<img width="572" height="678" alt="image" src="https://github.com/user-attachments/assets/8f81930a-410f-44d2-b27e-296776d427e0" />
