### PR TITLE
[FEAT] 목록 조회 기능 Cursor 기반 페이징 기능 추가

### DIFF
--- a/server/src/main/java/moment/comment/application/CommentService.java
+++ b/server/src/main/java/moment/comment/application/CommentService.java
@@ -78,7 +78,7 @@ public class CommentService {
 
         List<Comment> commentsWithinCursor = new ArrayList<>();
 
-        if (cursor == null || cursor.isEmpty()) {
+        if (cursor == null || cursor.isBlank()) {
             commentsWithinCursor = commentRepository.findCommentsFirstPage(commenter, pageable);
         }
 
@@ -120,7 +120,7 @@ public class CommentService {
     private String extractCursor(List<Comment> comments, int pageSize) {
         boolean hasNext = comments.size() > pageSize;
 
-        String nextCursor = "";
+        String nextCursor = null;
 
         List<Comment> pagingComments = new ArrayList<>(comments);
 

--- a/server/src/main/java/moment/comment/application/CommentService.java
+++ b/server/src/main/java/moment/comment/application/CommentService.java
@@ -66,9 +66,7 @@ public class CommentService {
     }
 
     public MyCommentPageResponse getCommentsByUserIdWithCursor(String cursor, int pageSize, Long commenterId) {
-        if (!userQueryService.existsById(commenterId)) {
-            throw new MomentException(ErrorCode.USER_NOT_FOUND);
-        }
+        User commenter = userQueryService.getUserById(commenterId);
 
         if (pageSize <= 0 || pageSize > 100) {
             throw new MomentException(ErrorCode.COMMENTS_LIMIT_INVALID);
@@ -79,14 +77,14 @@ public class CommentService {
         List<Comment> commentsWithinCursor = new ArrayList<>();
 
         if (cursor == null || cursor.isEmpty()) {
-            commentsWithinCursor = commentRepository.findCommentsFirstPage(commenterId, pageable);
+            commentsWithinCursor = commentRepository.findCommentsFirstPage(commenter, pageable);
         }
 
         if (cursor != null) {
             String[] cursorParts = cursor.split(CURSOR_PART_DELIMITER);
             LocalDateTime cursorDateTime = LocalDateTime.parse(cursorParts[CURSOR_TIME_INDEX]);
             Long cursorId = Long.valueOf(cursorParts[CURSOR_ID_INDEX]);
-            commentsWithinCursor = commentRepository.findCommentsNextPage(commenterId, cursorDateTime, cursorId, pageable);
+            commentsWithinCursor = commentRepository.findCommentsNextPage(commenter, cursorDateTime, cursorId, pageable);
         }
 
         String nextCursor = extractCursor(commentsWithinCursor, pageSize);

--- a/server/src/main/java/moment/comment/application/CommentService.java
+++ b/server/src/main/java/moment/comment/application/CommentService.java
@@ -11,7 +11,7 @@ import moment.comment.dto.request.CommentCreateRequest;
 import moment.comment.dto.response.CommentCreateResponse;
 import moment.comment.dto.response.CommentCreationStatusResponse;
 import moment.comment.dto.response.MyCommentPageResponse;
-import moment.comment.dto.response.MyCommentsResponse;
+import moment.comment.dto.response.MyCommentResponse;
 import moment.comment.infrastructure.CommentRepository;
 import moment.global.exception.ErrorCode;
 import moment.global.exception.MomentException;
@@ -97,8 +97,8 @@ public class CommentService {
         List<Emoji> emojis = emojiRepository.findAllByCommentIn(comments);
 
         if (emojis.isEmpty()) {
-            List<MyCommentsResponse> responses = comments.stream()
-                    .map(MyCommentsResponse::from)
+            List<MyCommentResponse> responses = comments.stream()
+                    .map(MyCommentResponse::from)
                     .toList();
             return MyCommentPageResponse.of(responses, nextCursor, hasNextPage, pageSize);
         }
@@ -106,8 +106,8 @@ public class CommentService {
         Map<Comment, List<Emoji>> commentAndEmojis = emojis.stream()
                 .collect(Collectors.groupingBy(Emoji::getComment));
 
-        List<MyCommentsResponse> responses = commentAndEmojis.entrySet().stream()
-                .map(MyCommentsResponse::from)
+        List<MyCommentResponse> responses = commentAndEmojis.entrySet().stream()
+                .map(MyCommentResponse::from)
                 .toList();
 
         return MyCommentPageResponse.of(responses, nextCursor, hasNextPage, pageSize);

--- a/server/src/main/java/moment/comment/application/CommentService.java
+++ b/server/src/main/java/moment/comment/application/CommentService.java
@@ -72,6 +72,8 @@ public class CommentService {
             throw new MomentException(ErrorCode.COMMENTS_LIMIT_INVALID);
         }
 
+        // todo : 커서 검증 필요
+
         Pageable pageable = PageRequest.of(0, pageSize + 1);
 
         List<Comment> commentsWithinCursor = new ArrayList<>();

--- a/server/src/main/java/moment/comment/dto/response/MyCommentPageResponse.java
+++ b/server/src/main/java/moment/comment/dto/response/MyCommentPageResponse.java
@@ -1,0 +1,19 @@
+package moment.comment.dto.response;
+
+import java.util.List;
+
+public record MyCommentPageResponse(
+        List<MyCommentsResponse> items,
+        String nextCursor,
+        boolean hasNextPage,
+        int pageSize
+) {
+    public static MyCommentPageResponse of(
+            List<MyCommentsResponse> responses,
+            String nextCursor,
+            boolean hasNextPage,
+            int pageSize
+    ) {
+        return new MyCommentPageResponse(responses, nextCursor, hasNextPage, pageSize);
+    }
+}

--- a/server/src/main/java/moment/comment/dto/response/MyCommentPageResponse.java
+++ b/server/src/main/java/moment/comment/dto/response/MyCommentPageResponse.java
@@ -1,11 +1,21 @@
 package moment.comment.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
+@Schema(description = "나의 Comment 페이지 조회 응답")
 public record MyCommentPageResponse(
+        @Schema(description = "조회된 나의 Comment 목록 응답")
         List<MyCommentResponse> items,
+
+        @Schema(description = "다음 페이지 시작 커서", example = "2025-07-21T10:57:08.926954_1")
         String nextCursor,
+
+        @Schema(description = "다음 페이지 존재 여부", example = "false")
         boolean hasNextPage,
+
+        @Schema(description = "페이지 사이즈 (기본 10)", example = "10")
         int pageSize
 ) {
     public static MyCommentPageResponse of(

--- a/server/src/main/java/moment/comment/dto/response/MyCommentPageResponse.java
+++ b/server/src/main/java/moment/comment/dto/response/MyCommentPageResponse.java
@@ -3,13 +3,13 @@ package moment.comment.dto.response;
 import java.util.List;
 
 public record MyCommentPageResponse(
-        List<MyCommentsResponse> items,
+        List<MyCommentResponse> items,
         String nextCursor,
         boolean hasNextPage,
         int pageSize
 ) {
     public static MyCommentPageResponse of(
-            List<MyCommentsResponse> responses,
+            List<MyCommentResponse> responses,
             String nextCursor,
             boolean hasNextPage,
             int pageSize

--- a/server/src/main/java/moment/comment/dto/response/MyCommentResponse.java
+++ b/server/src/main/java/moment/comment/dto/response/MyCommentResponse.java
@@ -1,14 +1,15 @@
 package moment.comment.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Map.Entry;
 import moment.comment.domain.Comment;
 import moment.reply.domain.Emoji;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map.Entry;
+
 @Schema(description = "나의 Comment 목록 조회 응답")
-public record MyCommentsResponse(
+public record MyCommentResponse(
         @Schema(description = "등록된 Comment id", example = "1")
         Long id,
 
@@ -24,7 +25,7 @@ public record MyCommentsResponse(
         @Schema(description = "Comment에 등록된 이모지 목록")
         List<EmojiDetailResponse> emojis
 ) {
-    public static MyCommentsResponse from(Entry<Comment, List<Emoji>> commentAndEmojis) {
+    public static MyCommentResponse from(Entry<Comment, List<Emoji>> commentAndEmojis) {
         Comment comment = commentAndEmojis.getKey();
         List<Emoji> emojis = commentAndEmojis.getValue();
 
@@ -34,7 +35,7 @@ public record MyCommentsResponse(
                 .map(EmojiDetailResponse::from)
                 .toList();
 
-        return new MyCommentsResponse(
+        return new MyCommentResponse(
                 comment.getId(),
                 comment.getContent(),
                 comment.getCreatedAt(),
@@ -43,10 +44,10 @@ public record MyCommentsResponse(
         );
     }
 
-    public static MyCommentsResponse from(Comment comment) {
+    public static MyCommentResponse from(Comment comment) {
         MomentDetailResponse momentResponse = MomentDetailResponse.from(comment.getMoment());
         List<EmojiDetailResponse> emojisResponse = null;
-        return new MyCommentsResponse(
+        return new MyCommentResponse(
                 comment.getId(),
                 comment.getContent(),
                 comment.getCreatedAt(),

--- a/server/src/main/java/moment/comment/infrastructure/CommentRepository.java
+++ b/server/src/main/java/moment/comment/infrastructure/CommentRepository.java
@@ -2,15 +2,35 @@ package moment.comment.infrastructure;
 
 import moment.comment.domain.Comment;
 import moment.moment.domain.Moment;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @EntityGraph(attributePaths = {"moment"})
-    List<Comment> findCommentsByCommenterIdOrderByCreatedAtDesc(Long commenterId);
+    @Query("""
+            SELECT c FROM comments c
+            WHERE c.commenter.id = :commenterId
+            ORDER BY c.createdAt DESC, c.id DESC
+            """)
+    List<Comment> findCommentsFirstPage(@Param("commenterId") Long commenterId, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"moment"})
+    @Query("""
+            SELECT c FROM comments c
+            WHERE c.commenter.id = :commenterId AND (c.createdAt <= :cursorTime OR (c.createdAt = :cursorTime AND c.id < :cursorId))
+            ORDER BY c.createdAt DESC, c.id DESC
+            """)
+    List<Comment> findCommentsNextPage(@Param("commenterId") Long commenterId,
+                                       @Param("cursorTime") LocalDateTime cursorDateTime,
+                                       @Param("cursorId") Long cursorId,
+                                       Pageable pageable);
 
     @EntityGraph(attributePaths = {"moment"})
     List<Comment> findAllByMomentIn(List<Moment> moments);

--- a/server/src/main/java/moment/comment/infrastructure/CommentRepository.java
+++ b/server/src/main/java/moment/comment/infrastructure/CommentRepository.java
@@ -2,6 +2,7 @@ package moment.comment.infrastructure;
 
 import moment.comment.domain.Comment;
 import moment.moment.domain.Moment;
+import moment.user.domain.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -16,18 +17,18 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @EntityGraph(attributePaths = {"moment"})
     @Query("""
             SELECT c FROM comments c
-            WHERE c.commenter.id = :commenterId
+            WHERE c.commenter = :commenter
             ORDER BY c.createdAt DESC, c.id DESC
             """)
-    List<Comment> findCommentsFirstPage(@Param("commenterId") Long commenterId, Pageable pageable);
+    List<Comment> findCommentsFirstPage(@Param("commenter") User commenter, Pageable pageable);
 
     @EntityGraph(attributePaths = {"moment"})
     @Query("""
             SELECT c FROM comments c
-            WHERE c.commenter.id = :commenterId AND (c.createdAt <= :cursorTime OR (c.createdAt = :cursorTime AND c.id < :cursorId))
+            WHERE c.commenter = :commenter AND (c.createdAt <= :cursorTime OR (c.createdAt = :cursorTime AND c.id < :cursorId))
             ORDER BY c.createdAt DESC, c.id DESC
             """)
-    List<Comment> findCommentsNextPage(@Param("commenterId") Long commenterId,
+    List<Comment> findCommentsNextPage(@Param("commenter") User commenter,
                                        @Param("cursorTime") LocalDateTime cursorDateTime,
                                        @Param("cursorId") Long cursorId,
                                        Pageable pageable);

--- a/server/src/main/java/moment/comment/presentation/CommentController.java
+++ b/server/src/main/java/moment/comment/presentation/CommentController.java
@@ -76,6 +76,7 @@ public class CommentController {
             ),
             @ApiResponse(responseCode = "404", description = """
                     - [U-002] 존재하지 않는 사용자입니다.
+                    - [C-005] 유효하지 않은 페이지 사이즈입니다.
                     """,
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })

--- a/server/src/main/java/moment/comment/presentation/CommentController.java
+++ b/server/src/main/java/moment/comment/presentation/CommentController.java
@@ -10,10 +10,10 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import moment.auth.presentation.AuthenticationPrincipal;
 import moment.comment.application.CommentService;
-import moment.comment.dto.response.CommentCreationStatusResponse;
 import moment.comment.dto.request.CommentCreateRequest;
 import moment.comment.dto.response.CommentCreateResponse;
-import moment.comment.dto.response.MyCommentsResponse;
+import moment.comment.dto.response.CommentCreationStatusResponse;
+import moment.comment.dto.response.MyCommentPageResponse;
 import moment.global.dto.response.ErrorResponse;
 import moment.global.dto.response.SuccessResponse;
 import moment.user.dto.request.Authentication;
@@ -23,9 +23,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @Tag(name = "Comment API", description = "Comment 관련 API 명세")
 @RestController
@@ -81,12 +80,14 @@ public class CommentController {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @GetMapping("/me")
-    public ResponseEntity<SuccessResponse<List<MyCommentsResponse>>> readMyComments(
+    public ResponseEntity<SuccessResponse<MyCommentPageResponse>> readMyComments(
+            @RequestParam(required = false) String nextCursor,
+            @RequestParam(defaultValue = "10") int limit,
             @AuthenticationPrincipal Authentication authentication) {
         Long userId = authentication.id();
-        List<MyCommentsResponse> myComments = commentService.getCommentsByUserId(userId);
+        MyCommentPageResponse response = commentService.getCommentsByUserIdWithCursor(nextCursor, limit, userId);
         HttpStatus status = HttpStatus.OK;
-        return ResponseEntity.status(status).body(SuccessResponse.of(status, myComments));
+        return ResponseEntity.status(status).body(SuccessResponse.of(status, response));
     }
 
     @Operation(summary = "Comment 등록 전 상태 체크", description = "Comment를 등록할 수 있는 상태인지 확인합니다.")

--- a/server/src/main/java/moment/global/exception/ErrorCode.java
+++ b/server/src/main/java/moment/global/exception/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
     COMMENT_CONFLICT("C-003", "모멘트에 등록된 코멘트가 이미 존재합니다.", HttpStatus.CONFLICT),
     COMMENT_CONTENT_INVALID("C-004", "유효하지 않은 코멘트 형식입니다.", HttpStatus.BAD_REQUEST),
     COMMENT_ID_INVALID("C-005", "유효하지 않은 코멘트 ID입니다.", HttpStatus.BAD_REQUEST),
+    COMMENTS_LIMIT_INVALID("C-005", "유효하지 않은 페이지 사이즈입니다.", HttpStatus.BAD_REQUEST),
 
     MOMENT_CONTENT_EMPTY("M-001", "모멘트 내용이 비어있습니다.", HttpStatus.BAD_REQUEST),
     MOMENT_NOT_FOUND("M-002", "존재하지 않는 모멘트입니다.", HttpStatus.NOT_FOUND),

--- a/server/src/main/java/moment/global/exception/ErrorCode.java
+++ b/server/src/main/java/moment/global/exception/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
     MOMENT_NOT_FOUND("M-002", "존재하지 않는 모멘트입니다.", HttpStatus.NOT_FOUND),
     MOMENT_ALREADY_EXIST("M-003", "오늘 작성한 모멘트가 이미 존재합니다.", HttpStatus.BAD_REQUEST),
     MOMENT_LENGTH_INVALID("M-004", "모멘트는 1자 이상, 100자 이하로만 작성 가능합니다.", HttpStatus.BAD_REQUEST),
+    MOMENTS_LIMIT_INVALID("M-005", "유효하지 않은 페이지 사이즈입니다.", HttpStatus.BAD_REQUEST),
     ;
 
     private final String code;

--- a/server/src/main/java/moment/moment/application/MomentService.java
+++ b/server/src/main/java/moment/moment/application/MomentService.java
@@ -72,7 +72,7 @@ public class MomentService {
         // todo : 커서 검증 필요
 
         if (pageSize <= 0 || pageSize > 100) {
-            throw new MomentException(ErrorCode.COMMENTS_LIMIT_INVALID);
+            throw new MomentException(ErrorCode.MOMENTS_LIMIT_INVALID);
         }
 
         PageRequest pageable = PageRequest.of(0, pageSize + 1);

--- a/server/src/main/java/moment/moment/application/MomentService.java
+++ b/server/src/main/java/moment/moment/application/MomentService.java
@@ -69,6 +69,8 @@ public class MomentService {
     public MyMomentPageResponse getMyMoments(String cursor, int pageSize, Long momenterId) {
         User momenter = userQueryService.getUserById(momenterId);
 
+        // todo : 커서 검증 필요
+
         if (pageSize <= 0 || pageSize > 100) {
             throw new MomentException(ErrorCode.COMMENTS_LIMIT_INVALID);
         }

--- a/server/src/main/java/moment/moment/dto/response/MyMomentPageResponse.java
+++ b/server/src/main/java/moment/moment/dto/response/MyMomentPageResponse.java
@@ -1,11 +1,21 @@
 package moment.moment.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
+@Schema(description = "나의 Moment 페이지 조회 응답")
 public record MyMomentPageResponse(
+        @Schema(description = "조회된 나의 Moment 목록 응답")
         List<MyMomentResponse> items,
+
+        @Schema(description = "다음 페이지 시작 커서", example = "2025-07-21T10:57:08.926954_1")
         String nextCursor,
+
+        @Schema(description = "다음 페이지 존재 여부", example = "false")
         boolean hasNextPage,
+
+        @Schema(description = "페이지 사이즈 (기본 10)", example = "10")
         int pageSize
 ) {
     public static MyMomentPageResponse of(

--- a/server/src/main/java/moment/moment/dto/response/MyMomentPageResponse.java
+++ b/server/src/main/java/moment/moment/dto/response/MyMomentPageResponse.java
@@ -1,0 +1,19 @@
+package moment.moment.dto.response;
+
+import java.util.List;
+
+public record MyMomentPageResponse(
+        List<MyMomentResponse> items,
+        String nextCursor,
+        boolean hasNextPage,
+        int pageSize
+) {
+    public static MyMomentPageResponse of(
+            List<MyMomentResponse> responses,
+            String nextCursor,
+            boolean hasNextPage,
+            int pageSize
+    ) {
+        return new MyMomentPageResponse(responses, nextCursor, hasNextPage, pageSize);
+    }
+}

--- a/server/src/main/java/moment/moment/infrastructure/MomentRepository.java
+++ b/server/src/main/java/moment/moment/infrastructure/MomentRepository.java
@@ -32,8 +32,6 @@ public interface MomentRepository extends JpaRepository<Moment, Long> {
                                        @Param("cursorId") Long cursorId,
                                        Pageable pageable);
 
-    List<Moment> findMomentByMomenterOrderByCreatedAtDesc(User Momenter);
-
     @Query("""
             SELECT ma.moment FROM matchings ma
                 WHERE ma.commenter = :commenter AND ma.createdAt BETWEEN :startOfDay AND :endOfDay

--- a/server/src/main/java/moment/moment/infrastructure/MomentRepository.java
+++ b/server/src/main/java/moment/moment/infrastructure/MomentRepository.java
@@ -1,17 +1,36 @@
 package moment.moment.infrastructure;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
 import moment.moment.domain.Moment;
 import moment.user.domain.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
 @Repository
 public interface MomentRepository extends JpaRepository<Moment, Long> {
+
+    @Query("""
+            SELECT m FROM moments m
+            WHERE m.momenter = :momenter
+            ORDER BY m.createdAt DESC, m.id DESC
+            """)
+    List<Moment> findMyMomentFirstPage(@Param("momenter") User momenter, Pageable pageable);
+
+    @Query("""
+            SELECT m FROM moments m
+            WHERE m.momenter = :momenter AND (m.createdAt <= :cursorTime OR (m.createdAt = :cursorTime AND m.id < :cursorId))
+            ORDER BY m.createdAt DESC, m.id DESC
+            """)
+    List<Moment> findMyMomentsNextPage(@Param("momenter") User momenter,
+                                       @Param("cursorTime") LocalDateTime cursorDateTime,
+                                       @Param("cursorId") Long cursorId,
+                                       Pageable pageable);
 
     List<Moment> findMomentByMomenterOrderByCreatedAtDesc(User Momenter);
 

--- a/server/src/main/java/moment/moment/presentation/MomentController.java
+++ b/server/src/main/java/moment/moment/presentation/MomentController.java
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import moment.auth.presentation.AuthenticationPrincipal;
 import moment.global.dto.response.ErrorResponse;
@@ -17,7 +16,7 @@ import moment.moment.dto.request.MomentCreateRequest;
 import moment.moment.dto.response.MatchedMomentResponse;
 import moment.moment.dto.response.MomentCreateResponse;
 import moment.moment.dto.response.MomentCreationStatusResponse;
-import moment.moment.dto.response.MyMomentResponse;
+import moment.moment.dto.response.MyMomentPageResponse;
 import moment.user.dto.request.Authentication;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -25,8 +24,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import java.util.List;
 
 @Tag(name = "Moment API", description = "모멘트 관련 API 명세")
 @RestController
@@ -74,13 +73,15 @@ public class MomentController {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
     })
     @GetMapping("/me")
-    public ResponseEntity<SuccessResponse<List<MyMomentResponse>>> readMyMoment(
+    public ResponseEntity<SuccessResponse<MyMomentPageResponse>> readMyMoment(
+            @RequestParam(required = false) String nextCursor,
+            @RequestParam(defaultValue = "10") int limit,
             @AuthenticationPrincipal Authentication authentication
     ) {
-        List<MyMomentResponse> responses = momentService.getMyMoments(authentication.id());
+        MyMomentPageResponse response = momentService.getMyMoments(nextCursor, limit, authentication.id());
         HttpStatus status = HttpStatus.OK;
 
-        return ResponseEntity.status(status).body(SuccessResponse.of(status, responses));
+        return ResponseEntity.status(status).body(SuccessResponse.of(status, response));
     }
 
     @Operation(summary = "매칭된 모멘트 조회", description = "사용자에게 매칭된 모멘트를 조회합니다.")

--- a/server/src/main/java/moment/moment/presentation/MomentController.java
+++ b/server/src/main/java/moment/moment/presentation/MomentController.java
@@ -69,6 +69,7 @@ public class MomentController {
             ),
             @ApiResponse(responseCode = "404", description = """
                     - [U-002] 존재하지 않는 사용자입니다.
+                    - [M-005] 유효하지 않은 페이지 사이즈입니다.
                     """,
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
     })

--- a/server/src/test/java/moment/comment/application/CommentServiceTest.java
+++ b/server/src/test/java/moment/comment/application/CommentServiceTest.java
@@ -16,7 +16,7 @@ import moment.comment.domain.Comment;
 import moment.comment.domain.CommentCreationStatus;
 import moment.comment.dto.request.CommentCreateRequest;
 import moment.comment.dto.response.CommentCreationStatusResponse;
-import moment.comment.dto.response.MyCommentsResponse;
+import moment.comment.dto.response.MyCommentPageResponse;
 import moment.comment.infrastructure.CommentRepository;
 import moment.global.exception.ErrorCode;
 import moment.global.exception.MomentException;
@@ -34,6 +34,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayNameGeneration(ReplaceUnderscores.class)
@@ -110,33 +114,43 @@ class CommentServiceTest {
     }
 
     @Test
-    void Commenter_ID가_일치하는_Comment_목록을_생성_시간_내림차순으로_불러온다() {
+    void Commenter_ID가_일치하는_Comment_목록을_생성_시간_내림차순으로_페이지_사이즈만큼_페이징_처리하여_불러온다() {
         // given
         User momenter1 = new User("kiki@icloud.com", "1234", "kiki");
-        User momenter2 = new User("drago@gmail.com", "1234", "drago");
+        User momenter2 = new User("drago1@gmail.com", "1234", "drago1");
         User commenter = new User("hippo@gmail.com", "1234", "hippo");
 
         Moment moment1 = new Moment("오늘 하루는 맛있는 하루~", true, momenter1);
         Moment moment2 = new Moment("오늘 하루는 행복한 하루~", true, momenter2);
+
         Comment comment1 = new Comment("moment1 comment", commenter, moment1);
+        LocalDateTime now1 = LocalDateTime.now();
+        ReflectionTestUtils.setField(comment1, "id", 1L);
+        ReflectionTestUtils.setField(comment1, "createdAt", now1);
+
         Comment comment2 = new Comment("moment2 comment", commenter, moment2);
+        LocalDateTime now2 = LocalDateTime.now();
+        ReflectionTestUtils.setField(comment2, "id", 2L);
+        ReflectionTestUtils.setField(comment2, "createdAt", now2);
 
         // given
 
         List<Comment> expectedComments = List.of(comment1, comment2);
 
-        given(commentRepository.findCommentsByCommenterIdOrderByCreatedAtDesc(any(Long.class)))
+        given(commentRepository.findCommentsFirstPage(any(Long.class), any(Pageable.class)))
                 .willReturn(expectedComments);
         given(userQueryService.existsById(any(Long.class))).willReturn(true);
         given(emojiRepository.findAllByCommentIn(any(List.class))).willReturn(Collections.emptyList());
 
         // when
-        List<MyCommentsResponse> actualComments = commentService.getCommentsByUserId(1L);
+        MyCommentPageResponse actualComments = commentService.getCommentsByUserIdWithCursor(null, 1, 1L);
 
         // then
         assertAll(
-                () -> assertThat(actualComments).hasSize(2),
-                () -> then(commentRepository).should(times(1)).findCommentsByCommenterIdOrderByCreatedAtDesc(1L)
+                () -> assertThat(actualComments.items()).hasSize(1),
+                () -> assertThat(actualComments.nextCursor()).isEqualTo(String.format("%s_%s", now1, 1)),
+                () -> assertThat(actualComments.hasNextPage()).isTrue(),
+                () -> assertThat(actualComments.pageSize()).isEqualTo(1)
         );
     }
 
@@ -146,7 +160,7 @@ class CommentServiceTest {
         given(userQueryService.existsById(any(Long.class))).willReturn(false);
 
         // when & then
-        assertThatThrownBy(() -> commentService.getCommentsByUserId(1L))
+        assertThatThrownBy(() -> commentService.getCommentsByUserIdWithCursor("", 2, 1L))
                 .isInstanceOf(MomentException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
     }
@@ -175,7 +189,7 @@ class CommentServiceTest {
     void 아직_매칭된_모멘트가_존재하지_않을_경우의_상태를_반환한다() {
         // given
         Long commenterId = 1L;
-        User commenter = new User("mimi@icloud.com",  "1234", "mimi");
+        User commenter = new User("mimi@icloud.com", "1234", "mimi");
 
         given(userQueryService.getUserById(any(Long.class))).willReturn(commenter);
         given(momentQueryService.findTodayMatchedMomentByCommenter(any(User.class))).willReturn(Optional.empty());
@@ -194,8 +208,8 @@ class CommentServiceTest {
     void 이미_매칭된_모멘트에_코멘트를_작성한_경우의_상태를_반환한다() {
         // given
         Long commenterId = 1L;
-        User commenter = new User("mimi@icloud.com",  "1234", "mimi");
-        User momenter = new User("hippo@icloud.com",  "1234", "hippo");
+        User commenter = new User("mimi@icloud.com", "1234", "mimi");
+        User momenter = new User("hippo@icloud.com", "1234", "hippo");
         Moment moment = new Moment("집가고 싶어요..", momenter);
 
         given(userQueryService.getUserById(any(Long.class))).willReturn(commenter);
@@ -216,8 +230,8 @@ class CommentServiceTest {
     void 코멘트를_등록할_수_있는_상태를_반환한다() {
         // given
         Long commenterId = 1L;
-        User commenter = new User("mimi@icloud.com",  "1234", "mimi");
-        User momenter = new User("hippo@icloud.com",  "1234", "hippo");
+        User commenter = new User("mimi@icloud.com", "1234", "mimi");
+        User momenter = new User("hippo@icloud.com", "1234", "hippo");
         Moment moment = new Moment("집가고 싶어요..", momenter);
 
         given(userQueryService.getUserById(any(Long.class))).willReturn(commenter);

--- a/server/src/test/java/moment/comment/application/CommentServiceTest.java
+++ b/server/src/test/java/moment/comment/application/CommentServiceTest.java
@@ -114,7 +114,7 @@ class CommentServiceTest {
     }
 
     @Test
-    void Commenter_ID가_일치하는_Comment_목록을_생성_시간_내림차순으로_페이지_사이즈만큼_페이징_처리하여_불러온다() {
+    void Commenter가_일치하는_Comment_목록을_생성_시간_내림차순으로_페이지_사이즈만큼_페이징_처리하여_불러온다() {
         // given
         User momenter1 = new User("kiki@icloud.com", "1234", "kiki");
         User momenter2 = new User("drago1@gmail.com", "1234", "drago1");
@@ -137,9 +137,9 @@ class CommentServiceTest {
 
         List<Comment> expectedComments = List.of(comment1, comment2);
 
-        given(commentRepository.findCommentsFirstPage(any(Long.class), any(Pageable.class)))
+        given(commentRepository.findCommentsFirstPage(any(User.class), any(Pageable.class)))
                 .willReturn(expectedComments);
-        given(userQueryService.existsById(any(Long.class))).willReturn(true);
+        given(userQueryService.getUserById(any(Long.class))).willReturn(commenter);
         given(emojiRepository.findAllByCommentIn(any(List.class))).willReturn(Collections.emptyList());
 
         // when
@@ -157,10 +157,10 @@ class CommentServiceTest {
     @Test
     void 존재하지_않는_Commenter가_Comment_목록을_조회하는_경우_예외가_발생한다() {
         // given
-        given(userQueryService.existsById(any(Long.class))).willReturn(false);
+        given(userQueryService.getUserById(any(Long.class))).willThrow(new MomentException(ErrorCode.USER_NOT_FOUND));
 
         // when & then
-        assertThatThrownBy(() -> commentService.getCommentsByUserIdWithCursor("", 2, 1L))
+        assertThatThrownBy(() -> commentService.getCommentsByUserIdWithCursor(null, 2, 1L))
                 .isInstanceOf(MomentException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
     }

--- a/server/src/test/java/moment/comment/infrastructure/CommentRepositoryTest.java
+++ b/server/src/test/java/moment/comment/infrastructure/CommentRepositoryTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
 
@@ -30,7 +31,7 @@ class CommentRepositoryTest {
     private UserRepository userRepository;
 
     @Test
-    void Comment_ID와_일치하는_Comment_목록을_생성_시간_내림차순으로_조회한다() {
+    void Comment_ID와_일치하는_Comment_목록을_페이징_처리하여_생성_시간_내림차순으로_조회한다() {
         // given
         User momenter1 = new User("kiki@icloud.com", "1234", "kiki");
         userRepository.save(momenter1);
@@ -54,8 +55,7 @@ class CommentRepositoryTest {
         Comment savedComment2 = commentRepository.save(comment2);
 
         // when
-        List<Comment> comments = commentRepository.findCommentsByCommenterIdOrderByCreatedAtDesc(savedCommenter.getId());
-
+        List<Comment> comments = commentRepository.findCommentsFirstPage(savedCommenter.getId(), PageRequest.of(0, 2));
         // then
         assertAll(
                 () -> assertThat(comments).hasSize(2),
@@ -63,6 +63,58 @@ class CommentRepositoryTest {
                 () -> assertThat(comments.getLast()).isEqualTo(savedComment1),
                 () -> assertThat(comments.getFirst().getMoment()).isEqualTo(savedMoment2),
                 () -> assertThat(comments.getLast().getMoment()).isEqualTo(savedMoment1)
+        );
+    }
+
+
+    @Test
+    void Comment_ID와_일치하는_Comment_목록을_페이징_처리하여_생성_시간_내림차순으로_원하는_커서부터_조회한다() {
+        // given
+        User momenter1 = new User("kiki@icloud.com", "1234", "kiki");
+        userRepository.save(momenter1);
+
+        User momenter2 = new User("ama@gmail.com", "1234", "ama");
+        userRepository.save(momenter2);
+
+        User commenter = new User("hippo@gmail.com", "1234", "hippo");
+        User savedCommenter = userRepository.save(commenter);
+
+        Moment moment1 = new Moment("오늘 하루는 행복한 하루~", true, momenter1);
+        Moment savedMoment1 = momentRepository.save(moment1);
+
+        Moment moment2 = new Moment("오늘 하루는 맛있는 하루~", true, momenter2);
+        Moment savedMoment2 = momentRepository.save(moment2);
+
+        Moment moment3 = new Moment("오늘 하루는 맛있는 하루~", true, momenter1);
+        Moment savedMoment3 = momentRepository.save(moment3);
+
+        Moment moment4 = new Moment("오늘 하루는 맛있는 하루~", true, momenter2);
+        Moment savedMoment4 = momentRepository.save(moment4);
+
+        Comment comment1 = new Comment("moment1 comment", commenter, savedMoment1);
+        Comment savedComment1 = commentRepository.save(comment1);
+
+        Comment comment2 = new Comment("moment2 comment", commenter, savedMoment2);
+        Comment savedComment2 = commentRepository.save(comment2);
+
+        Comment comment3 = new Comment("moment2 comment2", commenter, savedMoment3);
+        Comment savedComment3 = commentRepository.save(comment3);
+
+        Comment comment4 = new Comment("moment2 comment3", commenter, savedMoment4);
+        Comment savedComment4 = commentRepository.save(comment4);
+
+        // when
+        List<Comment> comments = commentRepository.findCommentsNextPage(savedCommenter.getId(),
+                savedComment3.getCreatedAt(),
+                savedComment3.getId(),
+                PageRequest.of(0, 3));
+
+        // then
+        assertAll(
+                () -> assertThat(comments).hasSize(3),
+                () -> assertThat(comments.getFirst()).isEqualTo(savedComment3),
+                () -> assertThat(comments.get(1)).isEqualTo(savedComment2),
+                () -> assertThat(comments.getLast()).isEqualTo(savedComment1)
         );
     }
 

--- a/server/src/test/java/moment/comment/infrastructure/CommentRepositoryTest.java
+++ b/server/src/test/java/moment/comment/infrastructure/CommentRepositoryTest.java
@@ -55,7 +55,7 @@ class CommentRepositoryTest {
         Comment savedComment2 = commentRepository.save(comment2);
 
         // when
-        List<Comment> comments = commentRepository.findCommentsFirstPage(savedCommenter.getId(), PageRequest.of(0, 2));
+        List<Comment> comments = commentRepository.findCommentsFirstPage(savedCommenter, PageRequest.of(0, 2));
         // then
         assertAll(
                 () -> assertThat(comments).hasSize(2),
@@ -104,7 +104,7 @@ class CommentRepositoryTest {
         Comment savedComment4 = commentRepository.save(comment4);
 
         // when
-        List<Comment> comments = commentRepository.findCommentsNextPage(savedCommenter.getId(),
+        List<Comment> comments = commentRepository.findCommentsNextPage(savedCommenter,
                 savedComment3.getCreatedAt(),
                 savedComment3.getId(),
                 PageRequest.of(0, 3));

--- a/server/src/test/java/moment/comment/presentation/CommentControllerTest.java
+++ b/server/src/test/java/moment/comment/presentation/CommentControllerTest.java
@@ -10,7 +10,7 @@ import moment.comment.dto.request.CommentCreateRequest;
 import moment.comment.dto.response.CommentCreateResponse;
 import moment.comment.dto.response.CommentCreationStatusResponse;
 import moment.comment.dto.response.MyCommentPageResponse;
-import moment.comment.dto.response.MyCommentsResponse;
+import moment.comment.dto.response.MyCommentResponse;
 import moment.comment.infrastructure.CommentRepository;
 import moment.global.exception.ErrorCode;
 import moment.global.exception.MomentException;
@@ -139,8 +139,8 @@ class CommentControllerTest {
                 .getObject("data", MyCommentPageResponse.class);
 
         // then
-        List<MyCommentsResponse> myComments = response.items();
-        MyCommentsResponse firstResponse = myComments.getFirst();
+        List<MyCommentResponse> myComments = response.items();
+        MyCommentResponse firstResponse = myComments.getFirst();
 
         String cursor = savedComment2.getCreatedAt().toString() + "_" + savedComment2.getId();
 

--- a/server/src/test/java/moment/moment/infrastructure/MomentRepositoryTest.java
+++ b/server/src/test/java/moment/moment/infrastructure/MomentRepositoryTest.java
@@ -1,13 +1,5 @@
 package moment.moment.infrastructure;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Optional;
 import moment.matching.domain.Matching;
 import moment.matching.infrastructure.MatchingRepository;
 import moment.moment.domain.Moment;
@@ -18,6 +10,16 @@ import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DataJpaTest
 @DisplayNameGeneration(ReplaceUnderscores.class)
@@ -33,7 +35,7 @@ class MomentRepositoryTest {
     private MatchingRepository matchingRepository;
 
     @Test
-    void 내_모멘트를_생성시간_기준_내림차순으로_정렬한다() throws InterruptedException {
+    void 내_모멘트를_생성시간_기준_내림차순으로_정렬하여_페이지를_조회한다() throws InterruptedException {
         // given
         User momenter = new User("hippo@gmail.com", "1234", "hippo");
         User savedMomenter = userRepository.save(momenter);
@@ -43,20 +45,27 @@ class MomentRepositoryTest {
         Moment moment3 = new Moment("아 짜릿해", true, savedMomenter);
         Moment moment4 = new Moment("킥킥", true, savedMomenter);
 
-        momentRepository.save(moment1);
+        Moment savedMoment1 = momentRepository.save(moment1);
         Thread.sleep(10);
-        momentRepository.save(moment2);
+        Moment savedMoment2 = momentRepository.save(moment2);
         Thread.sleep(10);
-        momentRepository.save(moment3);
+        Moment savedMoment3 = momentRepository.save(moment3);
         Thread.sleep(10);
-        momentRepository.save(moment4);
+        Moment savedMoment4 = momentRepository.save(moment4);
 
         // when
-        List<Moment> moments = momentRepository.findMomentByMomenterOrderByCreatedAtDesc(momenter);
+        List<Moment> moments = momentRepository.findMyMomentsNextPage(momenter, savedMoment3.getCreatedAt(), savedMoment3.getId(), PageRequest.of(0, 3));
 
         // then
-        assertThat(moments).hasSize(4);
-        assertThat(moments).isSortedAccordingTo(Comparator.comparing(Moment::getCreatedAt).reversed());
+        assertAll(
+                () -> assertThat(moments).hasSize(3),
+                () -> assertThat(moments).isSortedAccordingTo(Comparator.comparing(Moment::getCreatedAt).reversed()),
+                () -> assertThat(moments.getFirst()).isEqualTo(savedMoment3),
+                () -> assertThat(moments.get(1)).isEqualTo(savedMoment2),
+                () -> assertThat(moments.getLast()).isEqualTo(savedMoment1)
+        );
+
+
     }
 
     @Test


### PR DESCRIPTION
# 📋 연관 이슈

- close #312

# 🚀 작업 내용

- 1. Cursor 기반의 페이징 처리 기능 구현
- 2. 보낸 코멘트 목록 조회 페이징 처리 기능 추가
- 3. 나의 모멘트 목록 조회 페이징 처리 기능 추가

# 💬 리뷰 중점 사항

- CreatedAt + id 를 사용하여 Cursor를 생성하였습니다.
- Cursor 를 기준으로 클라이언트가 전송해준 limit 만큼 페이징 처리하여 조회 목록을 응답합니다.
- CreatedAt을 기준으로 내림차순으로 정렬하여 조회 목록을 응답합니다.
- 응답 시 응답 목록 이외에  Cursor관련 정보 (nextCursor, hasNextPage, pageSize) 함께 응답합니다.
- 코드 중복 및 페이징 처리 관련 로직은 객체로 분리하기 위한 리펙토링을 다음 작업으로 진행할 예정이 페이징 처리 로직의 흐름에 문제가 없는지 리뷰 부탁드립니다!