### PR TITLE
[FIX] 개발 서버 schema.sql 내부에 alter table 쿼리 제거

### DIFF
--- a/server/src/main/resources/schema.sql
+++ b/server/src/main/resources/schema.sql
@@ -65,13 +65,6 @@ CREATE TABLE IF NOT EXISTS emojis
         UNIQUE (user_id, comment_id, type)
 );
 
-ALTER TABLE users ADD COLUMN provider_type VARCHAR(20) NOT NULL;
-
-ALTER TABLE users DROP INDEX email;
-
-ALTER TABLE users ADD UNIQUE (email, provider_type);
-
--- 포인트 히스토리 테이블 추가
 CREATE TABLE IF NOT EXISTS point_history
 (
     id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,


### PR DESCRIPTION
# 📋 연관 이슈

- close #323 

# 🚀 작업 내용

- 1. alter table 중복 실행 시 duplicate column 에러 발생하여 개발 서버에 적용되는 schema.sql에서 alter table 쿼리 제거
