### PR TITLE
[FIX] 일반 회원가입에서 이메일 중복 확인 시 ProviderType 고려하도록 변경

### DIFF
--- a/server/src/main/java/moment/user/application/UserService.java
+++ b/server/src/main/java/moment/user/application/UserService.java
@@ -31,7 +31,7 @@ public class UserService {
     @Transactional
     public void addUser(UserCreateRequest request) {
         comparePasswordWithRepassword(request);
-        validateEmail(request);
+        validateEmailInBasicSignUp(request);
         validateNickname(request);
 
         String encodedPassword = passwordEncoder.encode(request.password());
@@ -52,8 +52,8 @@ public class UserService {
         }
     }
 
-    private void validateEmail(UserCreateRequest request) {
-        if (userRepository.existsByEmail(request.email())) {
+    private void validateEmailInBasicSignUp(UserCreateRequest request) {
+        if (userRepository.existsByEmailAndProviderType(request.email(), ProviderType.EMAIL)) {
             throw new MomentException(ErrorCode.USER_CONFLICT);
         }
     }
@@ -73,8 +73,8 @@ public class UserService {
         return new NicknameConflictCheckResponse(existsByNickname);
     }
 
-    public EmailConflictCheckResponse checkEmailConflict(EmailConflictCheckRequest request) {
-        boolean existsByEmail = userRepository.existsByEmail(request.email());
+    public EmailConflictCheckResponse checkEmailConflictInBasicSignUp(EmailConflictCheckRequest request) {
+        boolean existsByEmail = userRepository.existsByEmailAndProviderType(request.email(), ProviderType.EMAIL);
         return new EmailConflictCheckResponse(existsByEmail);
     }
 }

--- a/server/src/main/java/moment/user/infrastructure/UserRepository.java
+++ b/server/src/main/java/moment/user/infrastructure/UserRepository.java
@@ -11,11 +11,11 @@ import org.springframework.data.repository.query.Param;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    boolean existsByEmail(String email);
-
     boolean existsByNickname(String nickname);
 
-    Optional<User> findByEmail(String email);
+    boolean existsByEmailAndProviderType(String email, ProviderType providerType);
+
+    Optional<User> findByEmailAndProviderType(String email, ProviderType providerType);
 
     @Query("""
     SELECT u FROM users u
@@ -29,6 +29,4 @@ public interface UserRepository extends JpaRepository<User, Long> {
     List<User> findNotMatchedUsersToday(@Param("startOfDay") LocalDateTime startOfDay,
                                         @Param("endOfDay") LocalDateTime endOfDay,
                                         @Param("momenter") User momenter);
-
-    Optional<User> findByEmailAndProviderType(String email, ProviderType providerType);
 }

--- a/server/src/main/java/moment/user/presentation/UserController.java
+++ b/server/src/main/java/moment/user/presentation/UserController.java
@@ -128,7 +128,7 @@ public class UserController {
     public ResponseEntity<SuccessResponse<EmailConflictCheckResponse>> readEmailConflict(
             @Valid @RequestBody EmailConflictCheckRequest request
     ) {
-        EmailConflictCheckResponse response = userService.checkEmailConflict(request);
+        EmailConflictCheckResponse response = userService.checkEmailConflictInBasicSignUp(request);
         HttpStatus status = HttpStatus.OK;
         return ResponseEntity.status(status).body(SuccessResponse.of(status, response));
     }

--- a/server/src/test/java/moment/auth/application/AuthServiceTest.java
+++ b/server/src/test/java/moment/auth/application/AuthServiceTest.java
@@ -26,6 +26,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @DisplayNameGeneration(ReplaceUnderscores.class)
 class AuthServiceTest {
 
+    private final String email = "ekorea623@gmail.com";
+
     @InjectMocks
     private AuthService authService;
 
@@ -39,11 +41,13 @@ class AuthServiceTest {
     private PasswordEncoder passwordEncoder;
 
     @Test
-    void 로그인에_성공한다() {
+    void 일반_로그인에_성공한다() {
         // given
-        LoginRequest request = new LoginRequest("ekorea623@gmail.com", "1q2w3e4r");
-        given(userRepository.findByEmailAndProviderType(any(), any(ProviderType.class)))
-                .willReturn(Optional.of(new User("ekorea623@gmail.com", "1q2w3e4r", "drago", ProviderType.EMAIL)));
+        LoginRequest request = new LoginRequest(email, "1q2w3e4r");
+
+        given(userRepository.findByEmailAndProviderType(email, ProviderType.EMAIL))
+                .willReturn(Optional.of(new User(email, "1q2w3e4r", "drago", ProviderType.EMAIL)));
+
         given(tokenManager.createToken(any(), any())).willReturn("asdfsvssefsdf");
         given(passwordEncoder.matches(any(), any())).willReturn(true);
 
@@ -56,10 +60,10 @@ class AuthServiceTest {
     }
 
     @Test
-    void 로그인시_존재하지_않는_이메일을_입력한_경우_예외가_발생한다() {
+    void 일반_로그인시_존재하지_않는_이메일을_입력한_경우_예외가_발생한다() {
         // given
-        LoginRequest request = new LoginRequest("ekorea623@gmail.com", "1q2w3e4r");
-        given(userRepository.findByEmailAndProviderType(any(), any(ProviderType.class)))
+        LoginRequest request = new LoginRequest(email, "1q2w3e4r");
+        given(userRepository.findByEmailAndProviderType(email, ProviderType.EMAIL))
                 .willReturn(Optional.empty());
 
         // when & then
@@ -69,10 +73,10 @@ class AuthServiceTest {
     }
 
     @Test
-    void 로그인시_비밀번호를_잘못_입력한_경우_예외가_발생한다() {
+    void 일반_로그인시_비밀번호를_잘못_입력한_경우_예외가_발생한다() {
         // given
         LoginRequest request = new LoginRequest("ekorea623@gmail.com", "1q2w3e4");
-        given(userRepository.findByEmailAndProviderType(any(), any(ProviderType.class)))
+        given(userRepository.findByEmailAndProviderType(email, ProviderType.EMAIL))
                 .willReturn(Optional.of(new User("ekorea623@gmail.com", "1q2w3e4r", "drago", ProviderType.EMAIL)));
 
         // when & then

--- a/server/src/test/java/moment/auth/application/GoogleAuthServiceTest.java
+++ b/server/src/test/java/moment/auth/application/GoogleAuthServiceTest.java
@@ -1,5 +1,12 @@
 package moment.auth.application;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import java.util.Optional;
 import moment.auth.dto.google.GoogleAccessToken;
 import moment.auth.dto.google.GoogleUserInfo;
 import moment.auth.infrastructure.GoogleAuthClient;
@@ -13,14 +20,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
-
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
 class GoogleAuthServiceTest {
@@ -69,15 +68,16 @@ class GoogleAuthServiceTest {
     void 신규_유저가_구글_로그인을_하면_회원가입_처리_후_토큰을_반환한다() {
         // given
         String expectedToken = "testToken";
+        String email = "mimi@icloud.com";
         GoogleAccessToken googleAccessToken = new GoogleAccessToken("accessToken", 1800, "scope", "tokenType", "idToken");
-        GoogleUserInfo googleUserInfo = new GoogleUserInfo("sub", "name", "givenName", "picture", "mimi@icloud.com", true);
+        GoogleUserInfo googleUserInfo = new GoogleUserInfo("sub", "name", "givenName", "picture", email, true);
 
         given(googleAuthClient.getAccessToken(any(String.class))).willReturn(googleAccessToken);
         given(googleAuthClient.getUserInfo(googleAccessToken.getAccessToken())).willReturn(googleUserInfo);
-        given(userRepository.findByEmailAndProviderType(any(String.class), any(ProviderType.class))).willReturn(Optional.empty());
+        given(userRepository.findByEmailAndProviderType(email, ProviderType.GOOGLE)).willReturn(Optional.empty());
         given(passwordEncoder.encode(any(String.class))).willReturn("encodedPassword");
         given(nicknameGenerateService.createRandomNickname()).willReturn("반짝이는 우주의 퀘이사");
-        given(userRepository.save(any(User.class))).willReturn(new User("mimi@icloud.com", "encodedPassword", "mimi", ProviderType.GOOGLE));
+        given(userRepository.save(any(User.class))).willReturn(new User(email, "encodedPassword", "mimi", ProviderType.GOOGLE));
         given(tokenManager.createToken(any(), any(String.class))).willReturn(expectedToken);
 
         // when

--- a/server/src/test/java/moment/user/infrastructure/UserRepositoryTest.java
+++ b/server/src/test/java/moment/user/infrastructure/UserRepositoryTest.java
@@ -31,71 +31,35 @@ import org.springframework.test.context.ActiveProfiles;
 @DisplayNameGeneration(ReplaceUnderscores.class)
 class UserRepositoryTest {
 
+    private final String email = "mimi@icloud.com";
+
     @Autowired
     private UserRepository userRepository;
 
     @Test
-    void 이메일을_가진_유저가_있다면_참을_반환한다() {
+    void 이메일과_회원가입_방식을_기준으로_사용자_존재_여부를_확인할_수_있다() {
         // given
-        String existedEmail = "mimi@icloud.com";
-        userRepository.save(new User(existedEmail, "password", "mimi", ProviderType.EMAIL));
-
-        // when & then
-        assertThat(userRepository.existsByEmail(existedEmail)).isTrue();
-    }
-
-    @Test
-    void 이메일을_가진_유저가_없다면_거짓을_반환한다() {
-        // given
-        String notExistedEmail = "mimi@icloud.com";
-        userRepository.save(new User("hippo@gmail.com", "password", "hippo", ProviderType.EMAIL));
-
-        // when & then
-        assertThat(userRepository.existsByEmail(notExistedEmail)).isFalse();
-    }
-
-    @Test
-    void 닉네임을_가진_유저가_있다면_참을_반환한다() {
-        // given
-        String existedNickname = "mimi";
-        userRepository.save(new User("mimi@icloud.com", "password", existedNickname, ProviderType.EMAIL));
-
-        // when & then
-        assertThat(userRepository.existsByNickname(existedNickname)).isTrue();
-    }
-
-    @Test
-    void 닉네임을_가진_유저가_없다면_거짓을_반환한다() {
-        // given
-        String notExistedNickname = "hippo";
-        userRepository.save(new User("mimi@icloud.com", "password", "mimi", ProviderType.EMAIL));
-
-        // when & then
-        assertThat(userRepository.existsByNickname(notExistedNickname)).isFalse();
-    }
-
-    @Test
-    void 이메일을_가진_유저를_찾는다() {
-        // given
-        userRepository.save(new User("mimi@icloud.com", "password", "mimi", ProviderType.EMAIL));
+        ProviderType providerType = ProviderType.EMAIL;
+        userRepository.save(new User(email, "password", "mimi", providerType));
 
         // when
-        Optional<User> user = userRepository.findByEmail("mimi@icloud.com");
+        boolean result = userRepository.existsByEmailAndProviderType(email, providerType);
 
         // then
-        assertThat(user).isPresent();
+        assertThat(result).isTrue();
     }
 
     @Test
-    void 가입되지_않은_이메일은_찾을_수_없다() {
+    void 같은_이메일이더라도_다른_회원가입_방식인_경우_존재_여부를_확인할_수_없다() {
         // given
-        userRepository.save(new User("mimi@icloud.com", "password", "mimi", ProviderType.EMAIL));
+        User googleUser = new User(email, "password", "mimi", ProviderType.GOOGLE);
+        userRepository.save(googleUser);
 
         // when
-        Optional<User> user = userRepository.findByEmail("noUser@gmail.com");
+        boolean result = userRepository.existsByEmailAndProviderType(email, ProviderType.EMAIL);
 
         // then
-        assertThat(user).isEmpty();
+        assertThat(result).isFalse();
     }
 
     @Test
@@ -123,10 +87,30 @@ class UserRepositoryTest {
         userRepository.save(googleUser);
 
         // when
-        Optional<User> user = userRepository.findByEmailAndProviderType(email, ProviderType.EMAIL);
+        Optional<User> emailSignUpUser = userRepository.findByEmailAndProviderType(email, ProviderType.EMAIL);
 
         // then
-        assertThat(user).isEmpty();
+        assertThat(emailSignUpUser).isEmpty();
+    }
+
+    @Test
+    void 닉네임을_가진_유저가_있다면_참을_반환한다() {
+        // given
+        String existedNickname = "mimi";
+        userRepository.save(new User("mimi@icloud.com", "password", existedNickname, ProviderType.EMAIL));
+
+        // when & then
+        assertThat(userRepository.existsByNickname(existedNickname)).isTrue();
+    }
+
+    @Test
+    void 닉네임을_가진_유저가_없다면_거짓을_반환한다() {
+        // given
+        String notExistedNickname = "hippo";
+        userRepository.save(new User("mimi@icloud.com", "password", "mimi", ProviderType.EMAIL));
+
+        // when & then
+        assertThat(userRepository.existsByNickname(notExistedNickname)).isFalse();
     }
 
     @TestConfiguration

--- a/server/src/test/java/moment/user/presentation/UserControllerTest.java
+++ b/server/src/test/java/moment/user/presentation/UserControllerTest.java
@@ -1,5 +1,8 @@
 package moment.user.presentation;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.ContentType;
@@ -23,9 +26,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
@@ -38,7 +38,7 @@ class UserControllerTest {
     private TokenManager tokenManager;
 
     @Test
-    void 유저_생성에_성공한다() {
+    void 일반_회원가입시_유저_생성에_성공한다() {
         // given
         UserCreateRequest request = new UserCreateRequest("mimi@icloud.com", "mimi1234!", "mimi1234!", "mimi");
 
@@ -54,7 +54,7 @@ class UserControllerTest {
         // then
         assertAll(
                 () -> assertThat(response.status()).isEqualTo(HttpStatus.CREATED.value()),
-                () -> assertThat(userRepository.existsByEmail("mimi@icloud.com")).isTrue()
+                () -> assertThat(userRepository.existsByEmailAndProviderType("mimi@icloud.com", ProviderType.EMAIL)).isTrue()
         );
     }
 


### PR DESCRIPTION
# 📋 연관 이슈

- close #351 

# 🚀 작업 내용

- 1. 일반 회원가입에서 이메일 중복 확인 시 ProviderType 고려하도록 변경
- 2. 테스트 코드에서 UserRepository 모킹 시 정확히 특정 이메일과 ProviderType을 모킹하도록 변경
- 3. 불필요 테스트 코드 삭제, 테스트 코드 네이밍 수정