### PR TITLE
[FEAT] 회원가입 이메일 자동완성 API 연결 및 로직 수정

### DIFF
--- a/client/src/features/auth/api/getRandomNickname.ts
+++ b/client/src/features/auth/api/getRandomNickname.ts
@@ -1,0 +1,6 @@
+import { api } from '@/app/lib/api';
+
+export const getRandomNickname = async (): Promise<string> => {
+  const response = await api.get('/users/signup/nickname');
+  return response.data.data.randomNickname;
+};

--- a/client/src/features/auth/hooks/useCheckEmail.ts
+++ b/client/src/features/auth/hooks/useCheckEmail.ts
@@ -12,7 +12,7 @@ export const useCheckEmail = () => {
       setErrorMessage(isExists ? '이미 존재하는 이메일입니다.' : '');
       setIsEmailChecked(true);
     } catch (error) {
-      console.log(error);
+      console.error(error);
       alert('중복 확인 실패');
       setIsEmailChecked(false);
     }

--- a/client/src/features/auth/hooks/useCheckNickname.ts
+++ b/client/src/features/auth/hooks/useCheckNickname.ts
@@ -11,7 +11,7 @@ export const useCheckNickname = () => {
       setErrorMessage(result.data.isExists ? '이미 존재하는 닉네임입니다.' : '');
       setIsNicknameChecked(true);
     } catch (error) {
-      console.log(error);
+      console.error(error);
       alert('중복 확인 실패');
       setIsNicknameChecked(false);
     }

--- a/client/src/features/auth/hooks/useRandomNicknameQuery.ts
+++ b/client/src/features/auth/hooks/useRandomNicknameQuery.ts
@@ -1,0 +1,9 @@
+import { getRandomNickname } from '@/features/auth/api/getRandomNickname';
+import { useQuery } from '@tanstack/react-query';
+
+export const useRandomNicknameQuery = () => {
+  return useQuery<string>({
+    queryKey: ['randomNickname'],
+    queryFn: getRandomNickname,
+  });
+};

--- a/client/src/features/auth/hooks/useSignup.ts
+++ b/client/src/features/auth/hooks/useSignup.ts
@@ -18,7 +18,7 @@ export const useSignup = () => {
     nickname: '',
   });
 
-  const { mutateAsync: signup, isPending, error, isError } = useSignupMutation();
+  const { mutateAsync: signup, isPending, isError } = useSignupMutation();
 
   const handleChange = useCallback(
     (field: keyof SignupFormData) => (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -56,10 +56,21 @@ export const useSignup = () => {
     try {
       await signup(signupData);
     } catch (error) {
-      // 추후 UI 레벨에서 에러 처리 -> 여기서 토스트, 에러 메시지 등 표시 필요
       console.error('Signup failed:', error);
     }
   }, [signup, signupData]);
+
+  const updateNickname = useCallback(
+    (nickname: string) => {
+      setSignupData(prev => ({ ...prev, nickname }));
+      const fieldError = validateSignupField('nickname', nickname, { ...signupData, nickname });
+      setErrors(prev => ({ ...prev, nickname: fieldError }));
+    },
+    [signupData],
+  );
+
+  const isFormDataEmpty = !signupData.email || !signupData.password || !signupData.rePassword;
+  const isFirstStepDisabled = isFormDataEmpty || !isSignupFormValid(errors);
 
   return {
     signupData,
@@ -69,6 +80,9 @@ export const useSignup = () => {
     isError,
     handleChange,
     handleClick,
+    updateNickname,
     isSignupFormValid: isSignupFormValid(errors),
+    isFirstStepDisabled,
+    isFormDataEmpty,
   };
 };

--- a/client/src/features/auth/ui/LoginForm.styles.ts
+++ b/client/src/features/auth/ui/LoginForm.styles.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-export const LoginFormWrapper = styled.form`
+export const LoginFormWrapper = styled.div`
   width: 80%;
   max-width: 500px;
   height: 100%;
@@ -14,13 +14,23 @@ export const LoginFormWrapper = styled.form`
   gap: 20px;
 `;
 
+export const LoginFormContainer = styled.form`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+`;
+
 export const LoginFormTitleContainer = styled.div`
   width: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 20px;
+  gap: 16px;
 `;
 
 export const LoginLogoTitleContainer = styled.div`
@@ -60,7 +70,6 @@ export const LoginFormContent = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 20px;
 `;
 
 export const InputGroup = styled.div`

--- a/client/src/features/auth/ui/LoginForm.tsx
+++ b/client/src/features/auth/ui/LoginForm.tsx
@@ -1,8 +1,8 @@
 import { useLoginForm } from '@/features/auth/hooks/useLoginForm';
 import { Input } from '@/shared/ui/input/Input';
 import { useNavigate } from 'react-router';
-import * as S from './LoginForm.styles';
 import { GoogleLoginButton } from './GoogleLoginButton';
+import * as S from './LoginForm.styles';
 
 export const LoginForm = () => {
   const navigate = useNavigate();
@@ -19,43 +19,45 @@ export const LoginForm = () => {
   };
 
   return (
-    <S.LoginFormWrapper onSubmit={handleSubmit}>
-      <S.LoginFormTitleContainer>
-        <S.LoginLogoTitleContainer>
-          <S.LogoImage src="/logo.webp" alt="Moment Logo Image" />
-          <S.LogoTitle>모멘트</S.LogoTitle>
-        </S.LoginLogoTitleContainer>
-        <S.LoginTitle>로그인</S.LoginTitle>
-        <S.LoginDescription>이메일과 비밀번호를 입력하여 로그인해주세요.</S.LoginDescription>
-      </S.LoginFormTitleContainer>
-      <S.LoginFormContent>
-        <S.InputGroup>
-          <S.Label htmlFor="email">이메일</S.Label>
-          <Input
-            id="email"
-            type="email"
-            placeholder="이메일을 입력해주세요"
-            value={formData.email}
-            onChange={handleChange('email')}
-          />
-          <S.ErrorMessage>{errors.email || ' '}</S.ErrorMessage>
-        </S.InputGroup>
-        <S.InputGroup>
-          <S.Label htmlFor="password">비밀번호</S.Label>
-          <Input
-            id="password"
-            type="password"
-            placeholder="비밀번호를 입력해주세요"
-            value={formData.password}
-            onChange={handleChange('password')}
-          />
-          <S.ErrorMessage>{errors.password || ' '}</S.ErrorMessage>
-        </S.InputGroup>
-      </S.LoginFormContent>
-      <S.LoginFooter>
+    <S.LoginFormWrapper>
+      <S.LoginFormContainer onSubmit={handleSubmit}>
+        <S.LoginFormTitleContainer>
+          <S.LoginLogoTitleContainer>
+            <S.LogoImage src="/logo.webp" alt="Moment Logo Image" />
+            <S.LogoTitle>모멘트</S.LogoTitle>
+          </S.LoginLogoTitleContainer>
+          <S.LoginTitle>로그인</S.LoginTitle>
+          <S.LoginDescription>이메일과 비밀번호를 입력하여 로그인해주세요.</S.LoginDescription>
+        </S.LoginFormTitleContainer>
+        <S.LoginFormContent>
+          <S.InputGroup>
+            <S.Label htmlFor="email">이메일</S.Label>
+            <Input
+              id="email"
+              type="email"
+              placeholder="이메일을 입력해주세요"
+              value={formData.email}
+              onChange={handleChange('email')}
+            />
+            <S.ErrorMessage>{errors.email || ' '}</S.ErrorMessage>
+          </S.InputGroup>
+          <S.InputGroup>
+            <S.Label htmlFor="password">비밀번호</S.Label>
+            <Input
+              id="password"
+              type="password"
+              placeholder="비밀번호를 입력해주세요"
+              value={formData.password}
+              onChange={handleChange('password')}
+            />
+            <S.ErrorMessage>{errors.password || ' '}</S.ErrorMessage>
+          </S.InputGroup>
+        </S.LoginFormContent>
         <S.LoginButton type="submit" disabled={isDisabled}>
           로그인
         </S.LoginButton>
+      </S.LoginFormContainer>
+      <S.LoginFooter>
         <GoogleLoginButton onClick={handleGoogleLogin} />
         <S.LoginFooterContent>
           <S.LoginForgotPassword>비밀번호를 잊으셨나요?</S.LoginForgotPassword>

--- a/client/src/features/auth/ui/SignupForm.tsx
+++ b/client/src/features/auth/ui/SignupForm.tsx
@@ -28,8 +28,8 @@ export const SignupForm = () => {
     }
   };
 
-  console.log('???????????????????????', signupData);
-  console.log('@@@@@@@@@@@@@@@@@@@@@', errors);
+  const isDisabled =
+    (nextStep && isFirstStepDisabled) || !isEmailChecked || emailErrorMessage !== '';
 
   return (
     <S.SignupFormWrapper>
@@ -41,7 +41,7 @@ export const SignupForm = () => {
               signupData={signupData}
               errors={errors}
               handleChange={handleChange}
-              onNext={!nextStep || isFirstStepDisabled ? undefined : handleNextStep}
+              onNext={isDisabled ? undefined : handleNextStep}
               handleCheckEmail={handleCheckEmail}
               emailErrorMessage={emailErrorMessage}
               isEmailChecked={isEmailChecked}
@@ -62,11 +62,7 @@ export const SignupForm = () => {
 
       <S.ButtonContainer>
         <Button title="이전" onClick={handlePreviousStep} disabled={!beforeStep} />
-        <Button
-          title="다음"
-          onClick={handleNextStep}
-          disabled={!nextStep || (step === 'step1' && isFirstStepDisabled)}
-        />
+        <Button title="다음" onClick={handleNextStep} disabled={isDisabled} />
       </S.ButtonContainer>
     </S.SignupFormWrapper>
   );

--- a/client/src/features/auth/ui/SignupForm.tsx
+++ b/client/src/features/auth/ui/SignupForm.tsx
@@ -1,26 +1,20 @@
 import { useSignup } from '@/features/auth/hooks/useSignup';
-import { isDataEmpty, isSignupFormValid } from '@/features/auth/utils/validateAuth';
 import { useFunnel } from '@/shared/hooks/useFunnel';
 import type { Step } from '@/shared/types/step';
 import { STEPS } from '@/shared/types/step';
 import { Button } from '@/shared/ui/button/Button';
 import { SignupStep1, SignupStep2, SignupStep3, SignupStepBar } from '@/widgets/signup';
 import { useCheckEmail } from '../hooks/useCheckEmail';
-import { useCheckNickname } from '../hooks/useCheckNickname';
 import * as S from './SignupForm.styles';
 
 export const SignupForm = () => {
   const { Funnel, Step, useStep, beforeStep, nextStep } = useFunnel(STEPS);
 
-  const { signupData, errors, handleChange, handleClick } = useSignup();
+  const { signupData, errors, handleChange, handleClick, updateNickname, isFirstStepDisabled } =
+    useSignup();
   const { step, setStep } = useStep();
 
   const { handleCheckEmail, errorMessage: emailErrorMessage, isEmailChecked } = useCheckEmail();
-  const {
-    handleCheckNickname,
-    errorMessage: nicknameErrorMessage,
-    isNicknameChecked,
-  } = useCheckNickname();
 
   const handlePreviousStep = () => {
     if (beforeStep) {
@@ -34,11 +28,8 @@ export const SignupForm = () => {
     }
   };
 
-  const isDisabled =
-    !isSignupFormValid(errors) ||
-    isDataEmpty(signupData) ||
-    !!emailErrorMessage ||
-    !!nicknameErrorMessage;
+  console.log('???????????????????????', signupData);
+  console.log('@@@@@@@@@@@@@@@@@@@@@', errors);
 
   return (
     <S.SignupFormWrapper>
@@ -50,7 +41,7 @@ export const SignupForm = () => {
               signupData={signupData}
               errors={errors}
               handleChange={handleChange}
-              onNext={!nextStep || isDisabled ? undefined : handleNextStep}
+              onNext={!nextStep || isFirstStepDisabled ? undefined : handleNextStep}
               handleCheckEmail={handleCheckEmail}
               emailErrorMessage={emailErrorMessage}
               isEmailChecked={isEmailChecked}
@@ -59,12 +50,8 @@ export const SignupForm = () => {
           <Step name="step2">
             <SignupStep2
               signupData={signupData}
-              errors={errors}
-              handleChange={handleChange}
-              onNext={!nextStep || isDisabled ? undefined : handleNextStep}
-              handleCheckNickname={handleCheckNickname}
-              nicknameErrorMessage={nicknameErrorMessage}
-              isNicknameChecked={isNicknameChecked}
+              onNext={!nextStep ? undefined : handleNextStep}
+              updateNickname={updateNickname}
             />
           </Step>
           <Step name="step3">
@@ -74,8 +61,12 @@ export const SignupForm = () => {
       </S.SignupFormContent>
 
       <S.ButtonContainer>
-        <Button title="이전" onClick={handlePreviousStep} disabled={!beforeStep || isDisabled} />
-        <Button title="다음" onClick={handleNextStep} disabled={!nextStep || isDisabled} />
+        <Button title="이전" onClick={handlePreviousStep} disabled={!beforeStep} />
+        <Button
+          title="다음"
+          onClick={handleNextStep}
+          disabled={!nextStep || (step === 'step1' && isFirstStepDisabled)}
+        />
       </S.ButtonContainer>
     </S.SignupFormWrapper>
   );

--- a/client/src/features/auth/utils/validateAuth.test.ts
+++ b/client/src/features/auth/utils/validateAuth.test.ts
@@ -1,7 +1,7 @@
 import { LoginFormData } from '@/features/auth/types/login';
 import { SignupFormData } from '@/features/auth/types/signup';
 import {
-  isDataEmpty,
+  isLoginFormEmpty,
   isLoginFormValid,
   isSignupFormValid,
   validateEmail,
@@ -141,6 +141,18 @@ describe('닉네임 유효성 검사', () => {
     expect(result).toBe('닉네임은 최소 2자 이상이어야 합니다.');
   });
 
+  it('닉네임이 15자를 초과하는 경우 에러를 반환해야 한다', () => {
+    const nickname = 'a'.repeat(16); // 16자
+    const result = validateNickname(nickname);
+    expect(result).toBe('닉네임은 최대 15자 이하여야 합니다.');
+  });
+
+  it('닉네임에 특수문자가 포함된 경우 에러를 반환해야 한다', () => {
+    const nickname = 'test!';
+    const result = validateNickname(nickname);
+    expect(result).toBe('닉네임은 특수문자를 포함할 수 없습니다.');
+  });
+
   it('닉네임이 유효한 경우 빈 문자열을 반환해야 한다', () => {
     const nickname = 'test';
     const result = validateNickname(nickname);
@@ -148,12 +160,18 @@ describe('닉네임 유효성 검사', () => {
   });
 
   it('다양한 유효한 닉네임을 허용해야 한다', () => {
-    const validNicknames = ['ab', 'test', 'test12', '한글닉네임', '가나다라마바'];
+    const validNicknames = ['ab', 'test', 'test12', '한글닉네임', '가나다라마바사아자차카타파'];
 
     validNicknames.forEach(nickname => {
       const result = validateNickname(nickname);
       expect(result).toBe('');
     });
+  });
+
+  it('15자 정확히인 닉네임은 유효해야 한다', () => {
+    const nickname = '가'.repeat(15); // 정확히 15자
+    const result = validateNickname(nickname);
+    expect(result).toBe('');
   });
 });
 
@@ -391,14 +409,14 @@ describe('isSignupFormValid', () => {
   });
 });
 
-describe('isDataEmpty', () => {
+describe('isLoginFormEmpty', () => {
   it('로그인 데이터가 모두 비어있는 경우 true를 반환해야 한다', () => {
     const loginData: LoginFormData = {
       email: '',
       password: '',
     };
 
-    const result = isDataEmpty(loginData);
+    const result = isLoginFormEmpty(loginData);
 
     expect(result).toBe(true);
   });
@@ -409,12 +427,12 @@ describe('isDataEmpty', () => {
       password: '',
     };
 
-    const result = isDataEmpty(loginData);
+    const result = isLoginFormEmpty(loginData);
 
     expect(result).toBe(false);
   });
 
-  it('회원가입 데이터가 모두 비어있는 경우 true를 반환해야 한다', () => {
+  it('회원가입 데이터가 모두 비어있는 경우를 체크해야 한다', () => {
     const signupData: SignupFormData = {
       email: '',
       password: '',
@@ -422,12 +440,12 @@ describe('isDataEmpty', () => {
       nickname: '',
     };
 
-    const result = isDataEmpty(signupData);
+    const isSignupFormEmpty = Object.values(signupData).every(value => value === '');
 
-    expect(result).toBe(true);
+    expect(isSignupFormEmpty).toBe(true);
   });
 
-  it('회원가입 데이터가 일부라도 채워져 있는 경우 false를 반환해야 한다', () => {
+  it('회원가입 데이터가 일부라도 채워져 있는 경우를 체크해야 한다', () => {
     const signupData: SignupFormData = {
       email: '',
       password: '',
@@ -435,8 +453,8 @@ describe('isDataEmpty', () => {
       nickname: 'test',
     };
 
-    const result = isDataEmpty(signupData);
+    const isSignupFormEmpty = Object.values(signupData).every(value => value === '');
 
-    expect(result).toBe(false);
+    expect(isSignupFormEmpty).toBe(false);
   });
 });

--- a/client/src/features/auth/utils/validateAuth.ts
+++ b/client/src/features/auth/utils/validateAuth.ts
@@ -2,7 +2,7 @@ import { LoginError, LoginFormData } from '@/features/auth/types/login';
 import { SignupErrors, SignupFormData } from '@/features/auth/types/signup';
 
 const EMAIL_REGEX = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
-const NICKNAME_REGEX = /[`~!@#$%^&*()_|+\-=?;:'",.<>\{\}\[\]\\\/ ]/gim;
+const NICKNAME_REGEX = /[`~!@#$%^&*()_|+\-=?;:'",.<>\{\}\[\]\\\/]/gim;
 const PASSWORD_REGEX = /^(?=.*[a-z])(?=.*\d)(?=.*[!@#$%^&*()])[a-zA-Z\d!@#$%^&*()]{8,16}$/;
 
 export const validateEmail = (email: string): string => {
@@ -37,8 +37,8 @@ export const validateNickname = (nickname: string): string => {
     return '닉네임을 입력해주세요.';
   } else if (nickname.length < 2) {
     return '닉네임은 최소 2자 이상이어야 합니다.';
-  } else if (nickname.length > 6) {
-    return '닉네임은 최대 6자 이하여야 합니다.';
+  } else if (nickname.length > 15) {
+    return '닉네임은 최대 15자 이하여야 합니다.';
   } else if (NICKNAME_REGEX.test(nickname)) {
     return '닉네임은 특수문자를 포함할 수 없습니다.';
   }
@@ -88,6 +88,6 @@ export const isSignupFormValid = (errors: SignupErrors): boolean => {
   return Object.values(errors).every(error => error === '');
 };
 
-export const isDataEmpty = (data: LoginFormData | SignupFormData): boolean => {
+export const isLoginFormEmpty = (data: LoginFormData): boolean => {
   return Object.values(data).every(value => value === '');
 };

--- a/client/src/features/comment/ui/TodayCommentWriteContent.tsx
+++ b/client/src/features/comment/ui/TodayCommentWriteContent.tsx
@@ -5,7 +5,7 @@ import * as S from '../../moment/ui/TodayContent.styles';
 import { useSendComments } from '../hooks/useSendComments';
 
 export const TodayCommentWriteContent = () => {
-  const MAX_LENGTH = 300;
+  const MAX_LENGTH = 200;
 
   const { momentsData, comment, handleChange, handleSubmit } = useSendComments();
   const currentLength = comment.length;

--- a/client/src/features/moment/ui/TodayMomentWriteContent.tsx
+++ b/client/src/features/moment/ui/TodayMomentWriteContent.tsx
@@ -14,7 +14,7 @@ export const TodayMomentWriteContent = ({
   handleSendContent,
   content,
 }: TodayMomentWriteContent) => {
-  const MAX_LENGTH = 300;
+  const MAX_LENGTH = 200;
 
   return (
     <S.TodayContentWrapper>

--- a/client/src/pages/collection/CollectionHeader.tsx
+++ b/client/src/pages/collection/CollectionHeader.tsx
@@ -5,8 +5,6 @@ import * as S from './index.styles';
 export const CollectionHeader = () => {
   const currentpath = useLocation().pathname;
 
-  console.log('currentpath', currentpath);
-
   return (
     <S.CollectionHeaderContainer>
       <S.CollectionHeaderLinkContainer

--- a/client/src/widgets/signup/SignupStep2.tsx
+++ b/client/src/widgets/signup/SignupStep2.tsx
@@ -1,29 +1,29 @@
-import { SignupErrors, SignupFormData } from '@/features/auth/types/signup';
-import { Input } from '@/shared/ui/input/Input';
+import { useRandomNicknameQuery } from '@/features/auth/hooks/useRandomNicknameQuery';
+import { SignupFormData } from '@/features/auth/types/signup';
 import { useEnterKeyHandler } from '@/shared/hooks/useEnterKeyHandler';
+import { Input } from '@/shared/ui/input/Input';
+import { useEffect } from 'react';
 import * as S from './SignupStep.styles';
-import { CheckButton } from '@/features/auth/ui/CheckButton';
 
 interface SignupStep2Props {
   signupData: SignupFormData;
-  errors: SignupErrors;
-  handleChange: (field: keyof SignupFormData) => (e: React.ChangeEvent<HTMLInputElement>) => void;
   onNext?: () => void;
-  handleCheckNickname: (value: string) => void;
-  nicknameErrorMessage: string;
-  isNicknameChecked: boolean;
+  updateNickname: (nickname: string) => void;
 }
 
-export const SignupStep2 = ({
-  signupData,
-  errors,
-  handleChange,
-  onNext,
-  handleCheckNickname,
-  nicknameErrorMessage,
-  isNicknameChecked,
-}: SignupStep2Props) => {
+export const SignupStep2 = ({ signupData, onNext, updateNickname }: SignupStep2Props) => {
   useEnterKeyHandler(onNext);
+  const { data: randomNickname, isError, error } = useRandomNicknameQuery();
+
+  useEffect(() => {
+    if (randomNickname) {
+      updateNickname(randomNickname);
+    }
+  }, [randomNickname]);
+
+  if (isError) {
+    console.error('Error fetching random nickname:', error);
+  }
 
   return (
     <S.StepContainer>
@@ -35,14 +35,11 @@ export const SignupStep2 = ({
             type="text"
             placeholder="닉네임을 입력해주세요"
             value={signupData.nickname}
-            onChange={handleChange('nickname')}
+            disabled
           />
-          <CheckButton onClick={() => handleCheckNickname(signupData.nickname)} />
         </S.CheckExistContainer>
-        {isNicknameChecked && !nicknameErrorMessage ? (
-          <S.SuccessMessage>사용 가능한 닉네임입니다.</S.SuccessMessage>
-        ) : (
-          <S.ErrorMessage>{nicknameErrorMessage || errors.nickname}</S.ErrorMessage>
+        {isError && (
+          <S.ErrorMessage>닉네임을 가져오는 데 실패했습니다. 다시 시도해주세요.</S.ErrorMessage>
         )}
       </S.InputGroup>
     </S.StepContainer>

--- a/client/src/widgets/signup/SignupStep2.tsx
+++ b/client/src/widgets/signup/SignupStep2.tsx
@@ -2,6 +2,8 @@ import { useRandomNicknameQuery } from '@/features/auth/hooks/useRandomNicknameQ
 import { SignupFormData } from '@/features/auth/types/signup';
 import { useEnterKeyHandler } from '@/shared/hooks/useEnterKeyHandler';
 import { Input } from '@/shared/ui/input/Input';
+import styled from '@emotion/styled';
+import { RotateCw } from 'lucide-react';
 import { useEffect } from 'react';
 import * as S from './SignupStep.styles';
 
@@ -13,7 +15,7 @@ interface SignupStep2Props {
 
 export const SignupStep2 = ({ signupData, onNext, updateNickname }: SignupStep2Props) => {
   useEnterKeyHandler(onNext);
-  const { data: randomNickname, isError, error } = useRandomNicknameQuery();
+  const { data: randomNickname, isError, error, refetch } = useRandomNicknameQuery();
 
   useEffect(() => {
     if (randomNickname) {
@@ -24,6 +26,10 @@ export const SignupStep2 = ({ signupData, onNext, updateNickname }: SignupStep2P
   if (isError) {
     console.error('Error fetching random nickname:', error);
   }
+
+  const handleRotateNickname = () => {
+    refetch();
+  };
 
   return (
     <S.StepContainer>
@@ -37,6 +43,9 @@ export const SignupStep2 = ({ signupData, onNext, updateNickname }: SignupStep2P
             value={signupData.nickname}
             disabled
           />
+          <RotateNicknameButton onClick={handleRotateNickname}>
+            <RotateCw size={25} color="white" />
+          </RotateNicknameButton>
         </S.CheckExistContainer>
         {isError && (
           <S.ErrorMessage>닉네임을 가져오는 데 실패했습니다. 다시 시도해주세요.</S.ErrorMessage>
@@ -45,3 +54,17 @@ export const SignupStep2 = ({ signupData, onNext, updateNickname }: SignupStep2P
     </S.StepContainer>
   );
 };
+
+export const RotateNicknameButton = styled.button`
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    scale: 1.1;
+    transition: scale 0.1s ease-in-out;
+  }
+`;


### PR DESCRIPTION
# 📋 연관 이슈

- close #363 

# 🚀 작업 내용

# 회원가입 2단계 랜덤 닉네임 자동 설정 기능 구현

## 개요
회원가입 프로세스에서 사용자가 닉네임을 직접 입력하는 대신, 서버에서 생성한 랜덤 닉네임을 자동으로 받아와 설정하는 기능을 구현했습니다.

## 주요 변경사항

### 백엔드
- **MomentRandomNicknameGenerator**: 우주/별자리 테마의 시적인 랜덤 닉네임 생성기 구현
  - 형용사 + 연결어 + 명사 조합으로 "꿈꾸는 우주의 시리우스" 형태의 닉네임 생성
  - 기존 AlphanumericNicknameGenerator 대신 @Primary로 설정하여 기본 생성기로 사용
- **NicknameGenerateService**: 중복 닉네임 검증 로직과 재시도 메커니즘(최대 5회) 구현
- **GET /users/signup/nickname** API 엔드포인트 추가

### 프론트엔드
- **useRandomNicknameQuery**: React Query를 활용한 랜덤 닉네임 조회 커스텀 훅 구현
- **getRandomNickname**: 랜덤 닉네임 API 호출 함수 구현
- **SignupStep2 컴포넌트**: 
  - 컴포넌트 마운트 시 자동으로 랜덤 닉네임 조회
  - 닉네임 입력 필드를 disabled 상태로 변경하여 자동 설정된 닉네임 표시
  - API 호출 실패 시 에러 메시지 표시
  - 닉네임 다시 받기 기능 구현

## 사용자 경험 개선
- 사용자가 닉네임을 고민할 필요 없이 자동으로 생성된 감성적인 닉네임 제공
- 닉네임 중복 검사 과정 자동화로 회원가입 프로세스 간소화
- 일관된 브랜드 톤앤매너를 반영한 닉네임으로 서비스 정체성 강화

## 📸 Test Screenshot

<img width="2876" height="1450" alt="image" src="https://github.com/user-attachments/assets/0da6deb6-b4f6-4444-8f29-ae34853c8f86" />

## 📝 Additional Description
- 전반적인 유효성 검사 강화
- 회원가입 Step1에서 유효성 검사 통과 안했는데 다음 step으로 넘어가는 문제 해결
- 로그인 페이지에서 구글 로그인 버튼 클릭 시 에러 메시지 나오는 문제 해결