### PR TITLE
[BUILD] 배포 이미지 선정 방식 변경

### DIFF
--- a/.github/workflows/dev-server-cd.yml
+++ b/.github/workflows/dev-server-cd.yml
@@ -27,8 +27,18 @@ jobs:
             sudo docker rm -f moment-app-server
           fi
 
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: build-artifact
+
+      - name: Extract deploy tag
+        run: |
+          export DEPLOY_TAG=$(cat image_tag.txt)
+          echo "Deploying version: $DEPLOY_TAG"
+
       - name: Pull latest image
-        run: sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/moment:latest
+        run: sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/moment:$DEPLOY_TAG
 
       - name: Deploy with Docker Compose
         run: |

--- a/.github/workflows/dev-server-ci.yml
+++ b/.github/workflows/dev-server-ci.yml
@@ -101,4 +101,11 @@ jobs:
           cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/moment:buildcache
           cache-to: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/moment:buildcache,mode=max
 
+      - name: Save image tag to file
+        run: echo ${{ github.sha }} > ./image-tag.txt
 
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-artifact
+          path: server/image-tag.txt

--- a/server/src/main/java/moment/MomentApplication.java
+++ b/server/src/main/java/moment/MomentApplication.java
@@ -10,6 +10,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @SpringBootApplication
 public class MomentApplication {
     public static void main(String[] args) {
+        // hi
         SpringApplication.run(MomentApplication.class, args);
     }
 }


### PR DESCRIPTION
# 📋 연관 이슈

- close #418

# 🚀 작업 내용

- 1. 배포 이미지를 latest 태그가 아닌 artifact에 저장한 커밋 태그로 불러오도록 변경
