### PR TITLE
[FEAT] 코멘트 응답형식및 불필요한 api제거

### DIFF
--- a/server/src/main/java/moment/comment/application/CommentQueryService.java
+++ b/server/src/main/java/moment/comment/application/CommentQueryService.java
@@ -2,10 +2,11 @@ package moment.comment.application;
 
 import moment.comment.domain.Comment;
 import moment.moment.domain.Moment;
+import moment.user.domain.User;
 
 public interface CommentQueryService {
 
     Comment getCommentById(Long id);
 
-    boolean existsByMoment(Moment moment);
+    boolean existsByMomentAndUser(Moment moment, User user);
 }

--- a/server/src/main/java/moment/comment/application/CommentQueryService.java
+++ b/server/src/main/java/moment/comment/application/CommentQueryService.java
@@ -8,5 +8,5 @@ public interface CommentQueryService {
 
     Comment getCommentById(Long id);
 
-    boolean existsByMomentAndUser(Moment moment, User user);
+    boolean existsByMomentAndCommenter(Moment moment, User commenter);
 }

--- a/server/src/main/java/moment/comment/application/CommentService.java
+++ b/server/src/main/java/moment/comment/application/CommentService.java
@@ -59,7 +59,7 @@ public class CommentService {
         User commenter = userQueryService.getUserById(commenterId);
         Moment moment = momentQueryService.getMomentById(request.momentId());
 
-        if (commentQueryService.existsByMoment(moment)) {
+        if (commentQueryService.existsByMomentAndUser(moment, commenter)) {
             throw new MomentException(ErrorCode.COMMENT_CONFLICT);
         }
 
@@ -163,7 +163,7 @@ public class CommentService {
             return CommentCreationStatusResponse.from(CommentCreationStatus.NOT_MATCHED);
         }
 
-        if (commentRepository.existsByMoment(matchedMoment.get())) {
+        if (commentRepository.existsByMomentAndCommenter(matchedMoment.get(), commenter)) {
             return CommentCreationStatusResponse.from(CommentCreationStatus.ALREADY_COMMENTED);
         }
 

--- a/server/src/main/java/moment/comment/application/CommentService.java
+++ b/server/src/main/java/moment/comment/application/CommentService.java
@@ -56,7 +56,7 @@ public class CommentService {
         User commenter = userQueryService.getUserById(commenterId);
         Moment moment = momentQueryService.getMomentById(request.momentId());
 
-        if (commentQueryService.existsByMomentAndUser(moment, commenter)) {
+        if (commentQueryService.existsByMomentAndCommenter(moment, commenter)) {
             throw new MomentException(ErrorCode.COMMENT_CONFLICT);
         }
 

--- a/server/src/main/java/moment/comment/application/CommentService.java
+++ b/server/src/main/java/moment/comment/application/CommentService.java
@@ -4,14 +4,11 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import moment.comment.domain.Comment;
-import moment.comment.domain.CommentCreationStatus;
 import moment.comment.dto.request.CommentCreateRequest;
 import moment.comment.dto.response.CommentCreateResponse;
-import moment.comment.dto.response.CommentCreationStatusResponse;
 import moment.comment.dto.response.MyCommentPageResponse;
 import moment.comment.dto.response.MyCommentResponse;
 import moment.comment.infrastructure.CommentRepository;
@@ -153,20 +150,5 @@ public class CommentService {
         }
 
         return nextCursor;
-    }
-
-    public CommentCreationStatusResponse canCreateComment(Long commenterId) {
-        User commenter = userQueryService.getUserById(commenterId);
-        Optional<Moment> matchedMoment = momentQueryService.findTodayMatchedMomentByCommenter(commenter);
-
-        if (matchedMoment.isEmpty()) {
-            return CommentCreationStatusResponse.from(CommentCreationStatus.NOT_MATCHED);
-        }
-
-        if (commentRepository.existsByMomentAndCommenter(matchedMoment.get(), commenter)) {
-            return CommentCreationStatusResponse.from(CommentCreationStatus.ALREADY_COMMENTED);
-        }
-
-        return CommentCreationStatusResponse.from(CommentCreationStatus.WRITABLE);
     }
 }

--- a/server/src/main/java/moment/comment/application/DefaultCommentQueryService.java
+++ b/server/src/main/java/moment/comment/application/DefaultCommentQueryService.java
@@ -24,7 +24,7 @@ public class DefaultCommentQueryService implements CommentQueryService {
     }
 
     @Override
-    public boolean existsByMomentAndUser(Moment moment, User user) {
+    public boolean existsByMomentAndCommenter(Moment moment, User user) {
         return commentRepository.existsByMomentAndCommenter(moment, user);
     }
 }

--- a/server/src/main/java/moment/comment/application/DefaultCommentQueryService.java
+++ b/server/src/main/java/moment/comment/application/DefaultCommentQueryService.java
@@ -6,6 +6,7 @@ import moment.comment.infrastructure.CommentRepository;
 import moment.global.exception.ErrorCode;
 import moment.global.exception.MomentException;
 import moment.moment.domain.Moment;
+import moment.user.domain.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,7 +24,7 @@ public class DefaultCommentQueryService implements CommentQueryService {
     }
 
     @Override
-    public boolean existsByMoment(Moment moment) {
-        return commentRepository.existsByMoment(moment);
+    public boolean existsByMomentAndUser(Moment moment, User user) {
+        return commentRepository.existsByMomentAndCommenter(moment, user);
     }
 }

--- a/server/src/main/java/moment/comment/domain/Comment.java
+++ b/server/src/main/java/moment/comment/domain/Comment.java
@@ -8,7 +8,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -39,7 +38,7 @@ public class Comment extends BaseEntity {
     @JoinColumn(nullable = false, name = "commenter_id")
     private User commenter;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(nullable = false, name = "moment_id")
     private Moment moment;
 

--- a/server/src/main/java/moment/comment/dto/response/MomentDetailResponse.java
+++ b/server/src/main/java/moment/comment/dto/response/MomentDetailResponse.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import moment.moment.domain.Moment;
 
 import java.time.LocalDateTime;
+import moment.user.domain.Level;
 
 @Schema(description = "Comment가 등록된 Moment 상세 내용")
 public record MomentDetailResponse(
@@ -13,10 +14,21 @@ public record MomentDetailResponse(
         @Schema(description = "Moment 내용", example = "테스트를 겨우 통과했어요!")
         String content,
 
+        @Schema(description = "Moment 작성자 닉네임", example = "따뜻한 감성의 시리우스")
+        String nickName,
+
+        @Schema(description = "Moment 작성자 레벨", example = "METEOR")
+        Level level,
+
         @Schema(description = "Moment 등록 시간", example = "2025-07-21T10:57:08.926954")
         LocalDateTime createdAt
 ) {
     public static MomentDetailResponse from(Moment moment) {
-        return new MomentDetailResponse(moment.getId(), moment.getContent(), moment.getCreatedAt());
+        return new MomentDetailResponse(
+                moment.getId(),
+                moment.getContent(),
+                moment.getMomenter().getNickname(),
+                moment.getMomenter().getLevel(),
+                moment.getCreatedAt());
     }
 }

--- a/server/src/main/java/moment/comment/infrastructure/CommentRepository.java
+++ b/server/src/main/java/moment/comment/infrastructure/CommentRepository.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    @EntityGraph(attributePaths = {"moment"})
+    @EntityGraph(attributePaths = {"moment.momenter"})
     @Query("""
             SELECT c FROM comments c
             WHERE c.commenter = :commenter
@@ -22,7 +22,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             """)
     List<Comment> findCommentsFirstPage(@Param("commenter") User commenter, Pageable pageable);
 
-    @EntityGraph(attributePaths = {"moment"})
+    @EntityGraph(attributePaths = {"moment.momenter"})
     @Query("""
             SELECT c FROM comments c
             WHERE c.commenter = :commenter AND (c.createdAt < :cursorTime OR (c.createdAt = :cursorTime AND c.id < :cursorId))

--- a/server/src/main/java/moment/comment/infrastructure/CommentRepository.java
+++ b/server/src/main/java/moment/comment/infrastructure/CommentRepository.java
@@ -36,5 +36,5 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @EntityGraph(attributePaths = {"moment"})
     List<Comment> findAllByMomentIn(List<Moment> moments);
 
-    boolean existsByMoment(Moment moment);
+    boolean existsByMomentAndCommenter(Moment moment, User commenter);
 }

--- a/server/src/main/java/moment/comment/presentation/CommentController.java
+++ b/server/src/main/java/moment/comment/presentation/CommentController.java
@@ -12,7 +12,6 @@ import moment.auth.presentation.AuthenticationPrincipal;
 import moment.comment.application.CommentService;
 import moment.comment.dto.request.CommentCreateRequest;
 import moment.comment.dto.response.CommentCreateResponse;
-import moment.comment.dto.response.CommentCreationStatusResponse;
 import moment.comment.dto.response.MyCommentPageResponse;
 import moment.global.dto.response.ErrorResponse;
 import moment.global.dto.response.SuccessResponse;
@@ -89,27 +88,5 @@ public class CommentController {
         MyCommentPageResponse response = commentService.getCommentsByUserIdWithCursor(nextCursor, limit, userId);
         HttpStatus status = HttpStatus.OK;
         return ResponseEntity.status(status).body(SuccessResponse.of(status, response));
-    }
-
-    @Operation(summary = "Comment 등록 전 상태 체크", description = "Comment를 등록할 수 있는 상태인지 확인합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Comment 등록 가능 여부 상태 확인 성공"),
-            @ApiResponse(responseCode = "401", description = """
-                    - [T-005] 토큰을 찾을 수 없습니다.
-                    """,
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(responseCode = "404", description = """
-                    - [U-002] 존재하지 않는 사용자입니다.
-                    """,
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
-    })
-    @GetMapping("/me/creation-status")
-    public ResponseEntity<SuccessResponse<CommentCreationStatusResponse>> readMyCreationStatus(
-            @AuthenticationPrincipal Authentication authentication) {
-        Long userId = authentication.id();
-        CommentCreationStatusResponse commentStatus = commentService.canCreateComment(userId);
-        HttpStatus status = HttpStatus.OK;
-        return ResponseEntity.status(status).body(SuccessResponse.of(status, commentStatus));
     }
 }

--- a/server/src/test/java/moment/comment/application/CommentServiceTest.java
+++ b/server/src/test/java/moment/comment/application/CommentServiceTest.java
@@ -210,7 +210,7 @@ class CommentServiceTest {
         doNothing().when(rewardService).reward(any(), any(), any());
 
         // when & then
-        assertThatCode(() -> commentService.addComment(request, newComment.getId()))
+        assertThatCode(() -> commentService.addComment(request, commenter.getId()))
                 .doesNotThrowAnyException();
     }
 }

--- a/server/src/test/java/moment/comment/application/CommentServiceTest.java
+++ b/server/src/test/java/moment/comment/application/CommentServiceTest.java
@@ -1,6 +1,7 @@
 package moment.comment.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
@@ -173,10 +174,9 @@ class CommentServiceTest {
     }
 
     @Test
-    void 코멘트가_이미_등록된_모멘트에_코멘트를_등록하는_경우_예외가_발생한다() {
+    void 동일_유저가_이미_코멘트를_등록한_모멘트에_다시_등록하는_경우_예외가_발생한다() {
         // given
         CommentCreateRequest request = new CommentCreateRequest("정말 안타깝게 됐네요!", 1L);
-
         User commenter = new User("hippo@gmail.com", "1234", "hippo", ProviderType.EMAIL);
         User momenter = new User("kiki@icloud.com", "1234", "kiki", ProviderType.EMAIL);
         Moment moment = new Moment("오늘 하루는 힘든 하루~", true, momenter);
@@ -184,11 +184,33 @@ class CommentServiceTest {
 
         given(userQueryService.getUserById(any(Long.class))).willReturn(commenter);
         given(momentQueryService.getMomentById(any(Long.class))).willReturn(moment);
-        given(commentQueryService.existsByMomentAndCommenter(any(Moment.class), any(User.class))).willReturn(true);
+        given(commentQueryService.existsByMomentAndCommenter(moment, commenter)).willReturn(true);
 
         // when & then
         assertThatThrownBy(() -> commentService.addComment(request, 1L))
                 .isInstanceOf(MomentException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.COMMENT_CONFLICT);
+    }
+
+    @Test
+    void 다른_유저가_이미_코멘트가_있는_모멘트에_새로_코멘트를_등록하는_경우_성공한다() {
+        // given
+        CommentCreateRequest request = new CommentCreateRequest("정말 안타깝게 됐네요!", 1L);
+        User commenter = new User("hippo@gmail.com", "1234", "hippo", ProviderType.EMAIL);
+        ReflectionTestUtils.setField(commenter, "id", 1L);
+        User momenter = new User("kiki@icloud.com", "1234", "kiki", ProviderType.EMAIL);
+        Moment moment = new Moment("오늘 하루는 힘든 하루~", true, momenter);
+        Comment newComment = new Comment("정말 안타깝게 됐네요!", commenter, moment);
+        ReflectionTestUtils.setField(newComment, "id", 1L);
+
+        given(userQueryService.getUserById(any(Long.class))).willReturn(commenter);
+        given(momentQueryService.getMomentById(any(Long.class))).willReturn(moment);
+        given(commentQueryService.existsByMomentAndCommenter(moment, commenter)).willReturn(false);
+        given(commentRepository.save(any(Comment.class))).willReturn(newComment);
+        doNothing().when(rewardService).reward(any(), any(), any());
+
+        // when & then
+        assertThatCode(() -> commentService.addComment(request, newComment.getId()))
+                .doesNotThrowAnyException();
     }
 }

--- a/server/src/test/java/moment/comment/application/CommentServiceTest.java
+++ b/server/src/test/java/moment/comment/application/CommentServiceTest.java
@@ -12,11 +12,8 @@ import static org.mockito.Mockito.times;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import moment.comment.domain.Comment;
-import moment.comment.domain.CommentCreationStatus;
 import moment.comment.dto.request.CommentCreateRequest;
-import moment.comment.dto.response.CommentCreationStatusResponse;
 import moment.comment.dto.response.MyCommentPageResponse;
 import moment.comment.infrastructure.CommentRepository;
 import moment.global.exception.ErrorCode;
@@ -188,66 +185,6 @@ class CommentServiceTest {
         given(userQueryService.getUserById(any(Long.class))).willReturn(commenter);
         given(momentQueryService.getMomentById(any(Long.class))).willReturn(moment);
         given(commentQueryService.existsByMomentAndUser(any(Moment.class), any(User.class))).willReturn(true);
-
-        // when & then
-        assertThatThrownBy(() -> commentService.addComment(request, 1L))
-                .isInstanceOf(MomentException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.COMMENT_CONFLICT);
-    }
-
-    @Test
-    void 아직_매칭된_모멘트가_존재하지_않을_경우의_상태를_반환한다() {
-        // given
-        Long commenterId = 1L;
-        User commenter = new User("mimi@icloud.com", "1234", "mimi", ProviderType.EMAIL);
-
-        given(userQueryService.getUserById(any(Long.class))).willReturn(commenter);
-        given(momentQueryService.findTodayMatchedMomentByCommenter(any(User.class))).willReturn(Optional.empty());
-
-        // when
-        CommentCreationStatusResponse response = commentService.canCreateComment(commenterId);
-
-        // then
-        assertAll(
-                () -> assertThat(response.commentCreationStatus()).isEqualTo(CommentCreationStatus.NOT_MATCHED),
-                () -> then(momentQueryService).should(times(1)).findTodayMatchedMomentByCommenter(commenter)
-        );
-    }
-
-    @Test
-    void 이미_매칭된_모멘트에_코멘트를_작성한_경우의_상태를_반환한다() {
-        // given
-        Long commenterId = 1L;
-        User commenter = new User("mimi@icloud.com", "1234", "mimi", ProviderType.EMAIL);
-        User momenter = new User("hippo@icloud.com", "1234", "hippo", ProviderType.EMAIL);
-        Moment moment = new Moment("집가고 싶어요..", momenter);
-
-        given(userQueryService.getUserById(any(Long.class))).willReturn(commenter);
-        given(momentQueryService.findTodayMatchedMomentByCommenter(any(User.class))).willReturn(Optional.of(moment));
-        given(commentRepository.existsByMomentAndCommenter(any(Moment.class), any(User.class))).willReturn(true);
-
-        // when
-        CommentCreationStatusResponse response = commentService.canCreateComment(commenterId);
-
-        // then
-        assertAll(
-                () -> assertThat(response.commentCreationStatus()).isEqualTo(CommentCreationStatus.ALREADY_COMMENTED),
-                () -> then(commentRepository).should(times(1)).existsByMomentAndCommenter(moment, commenter)
-        );
-    }
-
-    @Test
-    void 코멘트를_등록할_수_있는_상태를_반환한다() {
-        // given
-        CommentCreateRequest request = new CommentCreateRequest("정말 안타깝게 됐네요!", 1L);
-
-        User commenter = new User("hippo@gmail.com", "1234", "hippo", ProviderType.EMAIL);
-        User momenter = new User("kiki@icloud.com", "1234", "kiki", ProviderType.EMAIL);
-        Moment moment = new Moment("오늘 하루는 힘든 하루~", true, momenter);
-
-        given(userQueryService.getUserById(any(Long.class))).willReturn(commenter);
-        given(momentQueryService.getMomentById(any(Long.class))).willReturn(moment);
-        given(commentQueryService.existsByMomentAndUser(moment, commenter)).willReturn(true);
 
         // when & then
         assertThatThrownBy(() -> commentService.addComment(request, 1L))

--- a/server/src/test/java/moment/comment/application/CommentServiceTest.java
+++ b/server/src/test/java/moment/comment/application/CommentServiceTest.java
@@ -184,7 +184,7 @@ class CommentServiceTest {
 
         given(userQueryService.getUserById(any(Long.class))).willReturn(commenter);
         given(momentQueryService.getMomentById(any(Long.class))).willReturn(moment);
-        given(commentQueryService.existsByMomentAndUser(any(Moment.class), any(User.class))).willReturn(true);
+        given(commentQueryService.existsByMomentAndCommenter(any(Moment.class), any(User.class))).willReturn(true);
 
         // when & then
         assertThatThrownBy(() -> commentService.addComment(request, 1L))

--- a/server/src/test/java/moment/comment/application/DefaultMomentQueryServiceTest.java
+++ b/server/src/test/java/moment/comment/application/DefaultMomentQueryServiceTest.java
@@ -62,26 +62,34 @@ class DefaultMomentQueryServiceTest {
     }
 
     @Test
-    void Momment에_등록된_Comment가_존재하면_true를_반환한다() {
+    void Moment와_User로_작성한_Comment가_존재하면_true를_반환한다() {
         // given
+        User commenter = new User("hippo@gmail.com", "1234", "hippo", ProviderType.EMAIL);
         User momenter = new User("kiki@icloud.com", "1234", "kiki", ProviderType.EMAIL);
         Moment moment = new Moment("오늘 하루는 힘든 하루~", true, momenter);
 
-        given(commentRepository.existsByMoment(any(Moment.class))).willReturn(true);
+        given(commentRepository.existsByMomentAndCommenter(moment, commenter)).willReturn(true);
 
-        // when & then
-        assertThat(defaultCommentQueryService.existsByMoment(moment)).isTrue();
+        // when
+        boolean result = defaultCommentQueryService.existsByMomentAndUser(moment, commenter);
+
+        // then
+        assertThat(result).isTrue();
     }
 
     @Test
-    void Momment에_등록된_Comment가_존재하면_false를_반환한다() {
+    void Moment와_User로_작성한_Comment가_존재하지_않으면_false를_반환한다() {
         // given
+        User commenter = new User("hippo@gmail.com", "1234", "hippo", ProviderType.EMAIL);
         User momenter = new User("kiki@icloud.com", "1234", "kiki", ProviderType.EMAIL);
         Moment moment = new Moment("오늘 하루는 힘든 하루~", true, momenter);
 
-        given(commentRepository.existsByMoment(any(Moment.class))).willReturn(false);
+        given(commentRepository.existsByMomentAndCommenter(moment, commenter)).willReturn(false);
 
-        // when & then
-        assertThat(defaultCommentQueryService.existsByMoment(moment)).isFalse();
+        // when
+        boolean result = defaultCommentQueryService.existsByMomentAndUser(moment, commenter);
+
+        // then
+        assertThat(result).isFalse();
     }
 }

--- a/server/src/test/java/moment/comment/application/DefaultMomentQueryServiceTest.java
+++ b/server/src/test/java/moment/comment/application/DefaultMomentQueryServiceTest.java
@@ -62,7 +62,7 @@ class DefaultMomentQueryServiceTest {
     }
 
     @Test
-    void Moment와_User로_작성한_Comment가_존재하면_true를_반환한다() {
+    void User가_Moment에_작성한_Comment가_존재하면_true를_반환한다() {
         // given
         User commenter = new User("hippo@gmail.com", "1234", "hippo", ProviderType.EMAIL);
         User momenter = new User("kiki@icloud.com", "1234", "kiki", ProviderType.EMAIL);
@@ -78,7 +78,7 @@ class DefaultMomentQueryServiceTest {
     }
 
     @Test
-    void Moment와_User로_작성한_Comment가_존재하지_않으면_false를_반환한다() {
+    void User가_Moment에_작성한_Comment가_존재하지_않으면_false를_반환한다() {
         // given
         User commenter = new User("hippo@gmail.com", "1234", "hippo", ProviderType.EMAIL);
         User momenter = new User("kiki@icloud.com", "1234", "kiki", ProviderType.EMAIL);

--- a/server/src/test/java/moment/comment/application/DefaultMomentQueryServiceTest.java
+++ b/server/src/test/java/moment/comment/application/DefaultMomentQueryServiceTest.java
@@ -71,7 +71,7 @@ class DefaultMomentQueryServiceTest {
         given(commentRepository.existsByMomentAndCommenter(moment, commenter)).willReturn(true);
 
         // when
-        boolean result = defaultCommentQueryService.existsByMomentAndUser(moment, commenter);
+        boolean result = defaultCommentQueryService.existsByMomentAndCommenter(moment, commenter);
 
         // then
         assertThat(result).isTrue();
@@ -87,7 +87,7 @@ class DefaultMomentQueryServiceTest {
         given(commentRepository.existsByMomentAndCommenter(moment, commenter)).willReturn(false);
 
         // when
-        boolean result = defaultCommentQueryService.existsByMomentAndUser(moment, commenter);
+        boolean result = defaultCommentQueryService.existsByMomentAndCommenter(moment, commenter);
 
         // then
         assertThat(result).isFalse();

--- a/server/src/test/java/moment/comment/infrastructure/CommentRepositoryTest.java
+++ b/server/src/test/java/moment/comment/infrastructure/CommentRepositoryTest.java
@@ -1,5 +1,9 @@
 package moment.comment.infrastructure;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.List;
 import moment.comment.domain.Comment;
 import moment.moment.domain.Moment;
 import moment.moment.infrastructure.MomentRepository;
@@ -14,11 +18,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 @ActiveProfiles("test")
 @DataJpaTest
@@ -125,7 +124,7 @@ class CommentRepositoryTest {
     }
 
     @Test
-    void Momment의_Comment가_존재하면_true를_반환한다() {
+    void Moment와_User로_작성된_Comment가_존재하면_true를_반환한다() {
         // given
         User momenter = new User("kiki@icloud.com", "1234", "kiki", ProviderType.EMAIL);
         userRepository.save(momenter);
@@ -140,19 +139,22 @@ class CommentRepositoryTest {
         commentRepository.save(comment);
 
         // when & then
-        assertThat(commentRepository.existsByMoment(moment)).isTrue();
+        assertThat(commentRepository.existsByMomentAndCommenter(moment, commenter)).isTrue();
     }
 
     @Test
-    void Momment의_Comment가_존재하면_false를_반환한다() {
+    void Moment와_User로_작성된_Comment가_존재하지_않으면_false를_반환한다() {
         // given
         User momenter = new User("kiki@icloud.com", "1234", "kiki", ProviderType.EMAIL);
         userRepository.save(momenter);
+
+        User commenter = new User("hippo@gmail.com", "1234", "hippo", ProviderType.EMAIL);
+        userRepository.save(commenter);
 
         Moment moment = new Moment("오늘 하루는 힘든 하루~", true, momenter);
         momentRepository.save(moment);
 
         // when & then
-        assertThat(commentRepository.existsByMoment(moment)).isFalse();
+        assertThat(commentRepository.existsByMomentAndCommenter(moment, commenter)).isFalse();
     }
 }

--- a/server/src/test/java/moment/comment/infrastructure/CommentRepositoryTest.java
+++ b/server/src/test/java/moment/comment/infrastructure/CommentRepositoryTest.java
@@ -124,7 +124,7 @@ class CommentRepositoryTest {
     }
 
     @Test
-    void Moment와_User로_작성된_Comment가_존재하면_true를_반환한다() {
+    void User가_Moment에_작성한_Comment가_존재하면_true를_반환한다() {
         // given
         User momenter = new User("kiki@icloud.com", "1234", "kiki", ProviderType.EMAIL);
         userRepository.save(momenter);
@@ -143,7 +143,7 @@ class CommentRepositoryTest {
     }
 
     @Test
-    void Moment와_User로_작성된_Comment가_존재하지_않으면_false를_반환한다() {
+    void User가_Moment에_작성한_Comment가_존재하지_않으면_false를_반환한다() {
         // given
         User momenter = new User("kiki@icloud.com", "1234", "kiki", ProviderType.EMAIL);
         userRepository.save(momenter);

--- a/server/src/test/java/moment/comment/presentation/CommentControllerTest.java
+++ b/server/src/test/java/moment/comment/presentation/CommentControllerTest.java
@@ -9,16 +9,13 @@ import io.restassured.http.ContentType;
 import java.util.List;
 import moment.auth.infrastructure.JwtTokenManager;
 import moment.comment.domain.Comment;
-import moment.comment.domain.CommentCreationStatus;
 import moment.comment.dto.request.CommentCreateRequest;
 import moment.comment.dto.response.CommentCreateResponse;
-import moment.comment.dto.response.CommentCreationStatusResponse;
 import moment.comment.dto.response.MyCommentPageResponse;
 import moment.comment.dto.response.MyCommentResponse;
 import moment.comment.infrastructure.CommentRepository;
 import moment.global.exception.ErrorCode;
 import moment.global.exception.MomentException;
-import moment.matching.domain.Matching;
 import moment.matching.infrastructure.MatchingRepository;
 import moment.moment.domain.Moment;
 import moment.moment.infrastructure.MomentRepository;
@@ -155,101 +152,5 @@ class CommentControllerTest {
                 () -> assertThat(firstResponse.emojis().getFirst().id()).isEqualTo(savedEmoji2.getId()),
                 () -> assertThat(firstResponse.emojis().getFirst().emojiType()).isEqualTo(savedEmoji2.getEmojiType())
         );
-    }
-
-    @Test
-    void 매칭된_모멘트가_없는_경우_상태를_반환한다() {
-        // given
-        User momenter = new User("mimi@icloud.com", "mimi1234!", "mimi", ProviderType.EMAIL);
-        userRepository.saveAndFlush(momenter);
-
-        User commenter = new User("hippo@icloud.com", "hippo1234!", "hippo", ProviderType.EMAIL);
-        userRepository.saveAndFlush(commenter);
-
-        Moment moment = new Moment("오늘은 화요일", momenter);
-        momentRepository.saveAndFlush(moment);
-
-        String token = jwtTokenManager.createToken(commenter.getId(), commenter.getEmail());
-
-        // when
-        CommentCreationStatusResponse response = RestAssured.given().log().all()
-                .contentType(ContentType.JSON)
-                .cookie("token", token)
-                .when().get("/api/v1/comments/me/creation-status")
-                .then().log().all()
-                .statusCode(HttpStatus.OK.value())
-                .extract()
-                .jsonPath()
-                .getObject("data", CommentCreationStatusResponse.class);
-
-        // then
-        assertThat(response.commentCreationStatus()).isEqualTo(CommentCreationStatus.NOT_MATCHED);
-    }
-
-    @Test
-    void 이미_코멘트를_작성한_경우_상태를_반환한다() {
-        // given
-        User momenter = new User("mimi@icloud.com", "mimi1234!", "mimi", ProviderType.EMAIL);
-        userRepository.saveAndFlush(momenter);
-
-        User commenter = new User("hippo@icloud.com", "hippo1234!", "hippo", ProviderType.EMAIL);
-        userRepository.saveAndFlush(commenter);
-
-        Moment moment = new Moment("오늘은 화요일", momenter);
-        momentRepository.saveAndFlush(moment);
-
-        Matching matching = new Matching(moment, commenter);
-        matchingRepository.saveAndFlush(matching);
-
-        Comment comment = new Comment("맞아요 화요일이에요", commenter, moment);
-        commentRepository.saveAndFlush(comment);
-
-        String token = jwtTokenManager.createToken(commenter.getId(), commenter.getEmail());
-
-        // when
-        CommentCreationStatusResponse response = RestAssured.given().log().all()
-                .contentType(ContentType.JSON)
-                .cookie("token", token)
-                .when().get("/api/v1/comments/me/creation-status")
-                .then().log().all()
-                .statusCode(HttpStatus.OK.value())
-                .extract()
-                .jsonPath()
-                .getObject("data", CommentCreationStatusResponse.class);
-
-        // then
-        assertThat(response.commentCreationStatus()).isEqualTo(CommentCreationStatus.ALREADY_COMMENTED);
-    }
-
-    @Test
-    void 코멘트를_작성할_수_있는_상태를_반환한다() {
-        // given
-        User momenter = new User("mimi@icloud.com", "mimi1234!", "mimi", ProviderType.EMAIL);
-        userRepository.saveAndFlush(momenter);
-
-        User commenter = new User("hippo@icloud.com", "hippo1234!", "hippo", ProviderType.EMAIL);
-        userRepository.saveAndFlush(commenter);
-
-        Moment moment = new Moment("오늘은 화요일", momenter);
-        momentRepository.saveAndFlush(moment);
-
-        Matching matching = new Matching(moment, commenter);
-        matchingRepository.saveAndFlush(matching);
-
-        String token = jwtTokenManager.createToken(commenter.getId(), commenter.getEmail());
-
-        // when
-        CommentCreationStatusResponse response = RestAssured.given().log().all()
-                .contentType(ContentType.JSON)
-                .cookie("token", token)
-                .when().get("/api/v1/comments/me/creation-status")
-                .then().log().all()
-                .statusCode(HttpStatus.OK.value())
-                .extract()
-                .jsonPath()
-                .getObject("data", CommentCreationStatusResponse.class);
-
-        // then
-        assertThat(response.commentCreationStatus()).isEqualTo(CommentCreationStatus.WRITABLE);
     }
 }


### PR DESCRIPTION
# 📋 연관 이슈

- close #454 

# 🚀 작업 내용

- 1. 코멘트 상태 조회 api 제거
- 2. 나의 코멘트 조회 응답 모멘트 작성자 정보 추가

## 📝 Additional Description

```json
{
  "status": 200,
  "data": {
    "items": [
      {
        "id": 1,
        "content": "정말 멋진 하루군요!",
        "createdAt": "2025-07-21T10:57:08.926954",
        "moment": {
          "id": 1,
          "nickName" : "따뜻한 겨울의 시리우스",
          "level" : "METEOR",
          "content": "테스트를 겨우 통과했어요!",
          "createdAt": "2025-07-21T10:57:08.926954"
        },
        "emojis": [
          {
            "id": 1,
            "emojiType": "HEART",
            "userId": 2
          }
        ]
      }
    ],
    "nextCursor": "2025-07-21T10:57:08.926954_1",
    "hasNextPage": false,
    "pageSize": 10
  }
}
```
```JSON
"nickName" : "따뜻한 겨울의 시리우스",
"level" : "METEOR",
```
추가

- /api/v1/comments/me/creation-status api 엔드포인트 제거


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Moment details now include the author’s nickname and level.

- **Behavior Changes**
  - Moments support multiple comments; each user can post at most one comment per moment (conflict enforced per user).

- **API Changes**
  - Removed endpoint for checking comment creation status (GET /api/v1/comments/me/creation-status); clients should handle conflict responses on duplicate attempts.

- **Tests**
  - Removed creation-status tests and updated tests to validate existence by moment+commenter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->