### PR TITLE
[FEAT] MyPage 프로필 조회 api 기능 구현

### DIFF
--- a/server/src/main/java/moment/user/application/MyPageService.java
+++ b/server/src/main/java/moment/user/application/MyPageService.java
@@ -1,0 +1,20 @@
+package moment.user.application;
+
+import lombok.RequiredArgsConstructor;
+import moment.user.domain.User;
+import moment.user.dto.response.MyPageProfileResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MyPageService {
+
+    private final UserQueryService userQueryService;
+
+    public MyPageProfileResponse getProfile(Long userId) {
+        User user = userQueryService.getUserById(userId);
+        return MyPageProfileResponse.from(user);
+    }
+}

--- a/server/src/main/java/moment/user/domain/Level.java
+++ b/server/src/main/java/moment/user/domain/Level.java
@@ -40,4 +40,8 @@ public enum Level {
     public boolean isMatch(Integer point) {
         return point >= minPoints && point <= maxPoints;
     }
+
+    public int getNextLevelRequiredStars() {
+        return maxPoints + 1;
+    }
 }

--- a/server/src/main/java/moment/user/dto/response/MyPageProfileResponse.java
+++ b/server/src/main/java/moment/user/dto/response/MyPageProfileResponse.java
@@ -1,0 +1,37 @@
+package moment.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import moment.user.domain.Level;
+import moment.user.domain.User;
+
+@Schema(description = "마이페이지 프로필 정보 응답")
+public record MyPageProfileResponse(
+        @Schema(description = "사용자 닉네임", example = "신비로운 해성의 이카루스")
+        String nickname,
+
+        @Schema(description = "사용자 이메일", example = "test123@gmail.com")
+        String email,
+
+        @Schema(description = "사용자 레벨", example = "METEOR")
+        Level level,
+
+        @Schema(description = "사용자가 사용 가능한 별조각", example = "180")
+        Integer availableStar,
+
+        @Schema(description = "사용자 경험치", example = "150")
+        Integer expStar,
+
+        @Schema(description = "다음 레벨 요구 경험치", example = "200")
+        Integer nextStepExp
+) {
+    public static MyPageProfileResponse from(User user) {
+        return new MyPageProfileResponse(
+                user.getNickname(),
+                user.getEmail(),
+                user.getLevel(),
+                user.getAvailableStar(),
+                user.getExpStar(),
+                user.getLevel().getNextLevelRequiredStars()
+        );
+    }
+}

--- a/server/src/main/java/moment/user/dto/response/UserProfileResponse.java
+++ b/server/src/main/java/moment/user/dto/response/UserProfileResponse.java
@@ -22,6 +22,6 @@ public record UserProfileResponse(
 
     public static UserProfileResponse from(User user) {
         Level level = user.getLevel();
-        return new UserProfileResponse(user.getNickname(), user.getAvailableStar(), level, level.getMaxPoints());
+        return new UserProfileResponse(user.getNickname(), user.getAvailableStar(), level, level.getNextLevelRequiredStars());
     }
 }

--- a/server/src/main/java/moment/user/presentation/MyPageController.java
+++ b/server/src/main/java/moment/user/presentation/MyPageController.java
@@ -1,0 +1,52 @@
+package moment.user.presentation;
+
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import moment.auth.presentation.AuthenticationPrincipal;
+import moment.global.dto.response.ErrorResponse;
+import moment.global.dto.response.SuccessResponse;
+import moment.user.application.MyPageService;
+import moment.user.dto.request.Authentication;
+import moment.user.dto.response.MyPageProfileResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "MyPage API", description = "마이페이지 API 명세")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/my")
+public class MyPageController {
+
+    private final MyPageService myPageService;
+
+    @Operation(summary = "마이페이지 프로필 조회", description = "마이페이지 프로필 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "마이페이지 프로필 조회 성공"),
+            @ApiResponse(responseCode = "401", description = """
+                    - [T-005] 토큰을 찾을 수 없습니다.
+                    """,
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(responseCode = "404", description = """
+                    - [U-002] 존재하지 않는 사용자입니다.
+                    """,
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+    })
+    @GetMapping("/profile")
+    public ResponseEntity<SuccessResponse<MyPageProfileResponse>> readProfile(
+            @AuthenticationPrincipal Authentication authentication
+    ) {
+        MyPageProfileResponse response = myPageService.getProfile(authentication.id());
+        HttpStatus status = HttpStatus.OK;
+        return ResponseEntity.status(status).body(SuccessResponse.of(status, response));
+    }
+}

--- a/server/src/test/java/moment/user/application/MyPageServiceTest.java
+++ b/server/src/test/java/moment/user/application/MyPageServiceTest.java
@@ -1,0 +1,66 @@
+package moment.user.application;
+
+import moment.global.exception.ErrorCode;
+import moment.global.exception.MomentException;
+import moment.user.domain.Level;
+import moment.user.domain.ProviderType;
+import moment.user.domain.User;
+import moment.user.dto.response.MyPageProfileResponse;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class MyPageServiceTest {
+
+    @InjectMocks
+    private MyPageService myPageService;
+
+    @Mock
+    private UserQueryService userQueryService;
+
+    @Test
+    void 유저_프로필_정보를_조회한다() {
+        // given
+        User user = new User("test@gmail.com", "qwer1234!", "신비로운 행성의 지구", ProviderType.EMAIL);
+
+        given(userQueryService.getUserById(any(Long.class))).willReturn(user);
+
+        // when
+        MyPageProfileResponse profile = myPageService.getProfile(1L);
+
+        // then
+        assertAll(
+                () -> assertThat(profile.nickname()).isEqualTo(user.getNickname()),
+                () -> assertThat(profile.email()).isEqualTo(user.getEmail()),
+                () -> assertThat(profile.level()).isEqualTo(Level.ASTEROID_WHITE),
+                () -> assertThat(profile.availableStar()).isEqualTo(0),
+                () -> assertThat(profile.expStar()).isEqualTo(0),
+                () -> assertThat(profile.nextStepExp()).isEqualTo(5)
+        );
+    }
+
+    @Test
+    void 유저가_존재하지_않는_경우_프로필_조회에_실패한다() {
+        // given
+        User user = new User("test@gmail.com", "qwer1234!", "신비로운 행성의 지구", ProviderType.EMAIL);
+
+        given(userQueryService.getUserById(any(Long.class))).willThrow(new MomentException(ErrorCode.USER_NOT_FOUND));
+
+        // when & then
+        assertThatThrownBy(() -> myPageService.getProfile(1L))
+                .isInstanceOf(MomentException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+    }
+}

--- a/server/src/test/java/moment/user/presentation/MyPageControllerTest.java
+++ b/server/src/test/java/moment/user/presentation/MyPageControllerTest.java
@@ -1,0 +1,62 @@
+package moment.user.presentation;
+
+import io.restassured.RestAssured;
+import io.restassured.common.mapper.TypeRef;
+import moment.auth.application.TokenManager;
+import moment.global.dto.response.SuccessResponse;
+import moment.user.domain.Level;
+import moment.user.domain.ProviderType;
+import moment.user.domain.User;
+import moment.user.dto.response.MyPageProfileResponse;
+import moment.user.infrastructure.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+class MyPageControllerTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TokenManager tokenManager;
+
+    @Test
+    void 유저_프로필_정보를_조회한다() {
+        // given
+        User user = new User("test@gmail.com", "qwer1234!", "신비로운 행성의 지구", ProviderType.EMAIL);
+        userRepository.save(user);
+
+        String token = tokenManager.createToken(user.getId(), user.getEmail());
+
+        // when
+        SuccessResponse<MyPageProfileResponse> response = RestAssured.given().log().all()
+                .cookie("token", token)
+                .when().get("/api/v1/my/profile")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract().as(new TypeRef<>() {
+                });
+
+        // then
+        MyPageProfileResponse profile = response.data();
+        assertAll(
+                () -> assertThat(response.status()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(profile.nickname()).isEqualTo(user.getNickname()),
+                () -> assertThat(profile.email()).isEqualTo(user.getEmail()),
+                () -> assertThat(profile.level()).isEqualTo(Level.ASTEROID_WHITE),
+                () -> assertThat(profile.availableStar()).isEqualTo(0),
+                () -> assertThat(profile.expStar()).isEqualTo(0),
+                () -> assertThat(profile.nextStepExp()).isEqualTo(5)
+        );
+    }
+}

--- a/server/src/test/java/moment/user/presentation/UserControllerTest.java
+++ b/server/src/test/java/moment/user/presentation/UserControllerTest.java
@@ -64,7 +64,7 @@ class UserControllerTest {
         String nickname = "mimi";
         User user = userRepository.save(new User("mimi@icloud.com", "password", nickname, ProviderType.EMAIL));
         String token = tokenManager.createToken(user.getId(), user.getEmail());
-        UserProfileResponse expect = new UserProfileResponse(nickname, user.getAvailableStar(), user.getLevel(), user.getLevel().getMaxPoints());
+        UserProfileResponse expect = new UserProfileResponse(nickname, user.getAvailableStar(), user.getLevel(), user.getLevel().getNextLevelRequiredStars());
 
         // when
         SuccessResponse<UserProfileResponse> response = RestAssured.given().log().all()


### PR DESCRIPTION
# 📋 연관 이슈

- close #469 

# 🚀 작업 내용

- 1.마이페이지 프로필 조회 기능 API 구현

- uri 
```
api/v1/my/profile
```

- 응답 json
```
{
  "status": 200,
  "data": {
    "nickname": "mimi",
    "level": "METEOR",
    "expStar": 100,
	  "nextStepExp": 200,
	  "avabilableStar": 90,
	  "email": "test@gamil.com" 
  }
}
```

- 응답 성공 시 Status
  - 200 OK

- 응답 실패 시 Status
  - 401
  - 404



---

마이페이지에서 표시할 유저 프로필 정보를 조회하기 위한 API 입니다.

문서화 또는 반환 값에서 이상이 없는지 확인 부탁드립니다.