### PR TITLE
[FEAT] 마이페이지 나의 보상 기록 조회 offset 기반 페이징 처리 구현

### DIFF
--- a/server/src/main/java/moment/reward/application/RewardService.java
+++ b/server/src/main/java/moment/reward/application/RewardService.java
@@ -2,6 +2,7 @@ package moment.reward.application;
 
 import moment.reward.domain.Reason;
 import moment.user.domain.User;
+import moment.user.dto.response.MyRewardHistoryPageResponse;
 
 public interface RewardService {
 
@@ -12,4 +13,6 @@ public interface RewardService {
     void rewardForEcho(User user, Reason reason, Long contentId);
 
     void useReward(User user, Reason reason, Long contentId);
+
+    MyRewardHistoryPageResponse getRewardHistoryByUser(User user, Integer pageNum, Integer pageSize);
 }

--- a/server/src/main/java/moment/reward/application/StarRewardService.java
+++ b/server/src/main/java/moment/reward/application/StarRewardService.java
@@ -7,6 +7,11 @@ import moment.reward.domain.Reason;
 import moment.reward.domain.RewardHistory;
 import moment.reward.infrastructure.RewardRepository;
 import moment.user.domain.User;
+import moment.user.dto.response.MyRewardHistoryPageResponse;
+import moment.user.dto.response.MyRewardHistoryResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -77,5 +82,17 @@ public class StarRewardService implements RewardService {
 
         RewardHistory rewardHistory = new RewardHistory(user, star, reason, contentId);
         rewardRepository.save(rewardHistory);
+    }
+
+    @Override
+    public MyRewardHistoryPageResponse getRewardHistoryByUser(User user, Integer pageNum, Integer pageSize) {
+
+        Pageable pageable = PageRequest.of(pageNum, pageSize);
+
+        Page<RewardHistory> rewardHistoryPage = rewardRepository.findByUserOrderByCreatedAtDesc(user, pageable);
+
+        Page<MyRewardHistoryResponse> page = rewardHistoryPage.map(MyRewardHistoryResponse::from);
+
+        return MyRewardHistoryPageResponse.from(page);
     }
 }

--- a/server/src/main/java/moment/reward/infrastructure/RewardRepository.java
+++ b/server/src/main/java/moment/reward/infrastructure/RewardRepository.java
@@ -3,6 +3,8 @@ package moment.reward.infrastructure;
 import moment.reward.domain.Reason;
 import moment.reward.domain.RewardHistory;
 import moment.user.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -24,4 +26,7 @@ public interface RewardRepository extends JpaRepository<RewardHistory, Long> {
                                           @Param("reason") Reason reason,
                                           @Param("startOfToday") LocalDateTime startOfToday,
                                           @Param("endOfToday") LocalDateTime endOfToday);
+
+
+    Page<RewardHistory> findByUserOrderByCreatedAtDesc(User user, Pageable pageable);
 }

--- a/server/src/main/java/moment/user/application/MyPageService.java
+++ b/server/src/main/java/moment/user/application/MyPageService.java
@@ -1,8 +1,10 @@
 package moment.user.application;
 
 import lombok.RequiredArgsConstructor;
+import moment.reward.application.RewardService;
 import moment.user.domain.User;
 import moment.user.dto.response.MyPageProfileResponse;
+import moment.user.dto.response.MyRewardHistoryPageResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,8 +15,17 @@ public class MyPageService {
 
     private final UserQueryService userQueryService;
 
+    private final RewardService rewardService;
+
     public MyPageProfileResponse getProfile(Long userId) {
         User user = userQueryService.getUserById(userId);
         return MyPageProfileResponse.from(user);
+    }
+
+    public MyRewardHistoryPageResponse getMyRewardHistory(Integer pageNum, Integer pageSize, Long userId) {
+
+        User user = userQueryService.getUserById(userId);
+
+        return rewardService.getRewardHistoryByUser(user, pageNum, pageSize);
     }
 }

--- a/server/src/main/java/moment/user/dto/response/MyRewardHistoryPageResponse.java
+++ b/server/src/main/java/moment/user/dto/response/MyRewardHistoryPageResponse.java
@@ -1,0 +1,30 @@
+package moment.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Schema(description = "마이페이지 나의 보상 기록 페이지 조회 응답")
+public record MyRewardHistoryPageResponse(
+        @Schema(description = "마이페이지 나의 보상 내역 목록")
+        List<MyRewardHistoryResponse> items,
+
+        @Schema(description = "현재 페이지 넘버", example = "1")
+        int currentPageNum,
+
+        @Schema(description = "페이지 사이즈", example = "10")
+        int pageSize,
+
+        @Schema(description = "총 페이지 개수", example = "112")
+        int totalPages
+
+) {
+    public static MyRewardHistoryPageResponse from(Page<MyRewardHistoryResponse> page) {
+        List<MyRewardHistoryResponse> items = page.getContent();
+        int currentPageNum = page.getNumber();
+        int pageSize = page.getSize();
+        int totalPages = page.getTotalPages();
+        return new MyRewardHistoryPageResponse(items, currentPageNum, pageSize, totalPages);
+    }
+}

--- a/server/src/main/java/moment/user/dto/response/MyRewardHistoryResponse.java
+++ b/server/src/main/java/moment/user/dto/response/MyRewardHistoryResponse.java
@@ -1,0 +1,31 @@
+package moment.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import moment.reward.domain.Reason;
+import moment.reward.domain.RewardHistory;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "마이페이지 나의 보상 기록 상세 응답")
+public record MyRewardHistoryResponse(
+        @Schema(description = "나의 보상 기록 id", example = "1")
+        Long id,
+
+        @Schema(description = "별조각 변화량", example = "5")
+        Integer changeStar,
+
+        @Schema(description = "보상 사유", example = "MOMENT_CREATION")
+        Reason reason,
+
+        @Schema(description = "보상 시간", example = "2025-07-21T10:57:08.926954")
+        LocalDateTime createdAt
+) {
+    public static MyRewardHistoryResponse from(RewardHistory rewardHistory) {
+        return new MyRewardHistoryResponse(
+                rewardHistory.getId(),
+                rewardHistory.getAmount(),
+                rewardHistory.getReason(),
+                rewardHistory.getCreatedAt()
+        );
+    }
+}

--- a/server/src/main/java/moment/user/presentation/MyPageController.java
+++ b/server/src/main/java/moment/user/presentation/MyPageController.java
@@ -14,10 +14,12 @@ import moment.global.dto.response.SuccessResponse;
 import moment.user.application.MyPageService;
 import moment.user.dto.request.Authentication;
 import moment.user.dto.response.MyPageProfileResponse;
+import moment.user.dto.response.MyRewardHistoryPageResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "MyPage API", description = "마이페이지 API 명세")
@@ -46,6 +48,30 @@ public class MyPageController {
             @AuthenticationPrincipal Authentication authentication
     ) {
         MyPageProfileResponse response = myPageService.getProfile(authentication.id());
+        HttpStatus status = HttpStatus.OK;
+        return ResponseEntity.status(status).body(SuccessResponse.of(status, response));
+    }
+
+    @Operation(summary = "마이페이지 나의 보상 기록 페이징 조회", description = "마이페이지에서 나의 보상 기록을 페이지 별로 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "마이페이지 나의 보상 기록 조회 성공"),
+            @ApiResponse(responseCode = "401", description = """
+                    - [T-005] 토큰을 찾을 수 없습니다.
+                    """,
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(responseCode = "404", description = """
+                    - [U-002] 존재하지 않는 사용자입니다.
+                    """,
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+    })
+    @GetMapping("/reward/history")
+    public ResponseEntity<SuccessResponse<MyRewardHistoryPageResponse>> readMyRewardHistoryPage(
+            @RequestParam(defaultValue = "0") Integer pageNum,
+            @RequestParam(defaultValue = "10") Integer pageSize,
+            @AuthenticationPrincipal Authentication authentication
+    ) {
+        MyRewardHistoryPageResponse response = myPageService.getMyRewardHistory(pageNum, pageSize, authentication.id());
         HttpStatus status = HttpStatus.OK;
         return ResponseEntity.status(status).body(SuccessResponse.of(status, response));
     }

--- a/server/src/test/java/moment/reward/application/StarRewardServiceTest.java
+++ b/server/src/test/java/moment/reward/application/StarRewardServiceTest.java
@@ -11,6 +11,7 @@ import moment.reward.domain.RewardHistory;
 import moment.reward.infrastructure.RewardRepository;
 import moment.user.domain.ProviderType;
 import moment.user.domain.User;
+import moment.user.dto.response.MyRewardHistoryPageResponse;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
@@ -18,12 +19,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -164,5 +172,39 @@ class StarRewardServiceTest {
         assertThatThrownBy(() -> starRewardService.useReward(user, reason, user.getId()))
                 .isInstanceOf(MomentException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_ENOUGH_STAR);
+    }
+
+    @Test
+    void 유저의_보상_기록을_조회한다() {
+        // given
+        User user = new User("test@gmail.com", "qwer1234!", "신비로운 행성의 지구", ProviderType.EMAIL);
+        ReflectionTestUtils.setField(user, "id", 1L);
+        List<RewardHistory> content = createTestRewardHistory(user, 10);
+        Pageable pageable = PageRequest.of(0, 10);
+
+        Page<RewardHistory> page = new PageImpl<>(content, pageable, content.size());
+
+        given(rewardRepository.findByUserOrderByCreatedAtDesc(any(User.class), any(Pageable.class)))
+                .willReturn(page);
+
+
+        MyRewardHistoryPageResponse response = starRewardService.getRewardHistoryByUser(user, 0, 10);
+
+        // when & then
+        assertAll(
+                () -> assertThat(response.totalPages()).isEqualTo(1),
+                () -> assertThat(response.pageSize()).isEqualTo(10),
+                () -> assertThat(response.items().size()).isEqualTo(10),
+                () -> assertThat(response.currentPageNum()).isEqualTo(0)
+        );
+    }
+
+    private List<RewardHistory> createTestRewardHistory(User user, int amount) {
+        List<RewardHistory> list = new ArrayList<>();
+        for (int i = 0; i < amount; i++) {
+            RewardHistory rewardHistory = new RewardHistory(user, Reason.MOMENT_CREATION.getPointTo(), Reason.MOMENT_CREATION, (long) i);
+            list.add(rewardHistory);
+        }
+        return list;
     }
 }

--- a/server/src/test/java/moment/user/application/MyPageServiceTest.java
+++ b/server/src/test/java/moment/user/application/MyPageServiceTest.java
@@ -2,10 +2,15 @@ package moment.user.application;
 
 import moment.global.exception.ErrorCode;
 import moment.global.exception.MomentException;
+import moment.reward.application.RewardService;
+import moment.reward.domain.Reason;
+import moment.reward.domain.RewardHistory;
 import moment.user.domain.Level;
 import moment.user.domain.ProviderType;
 import moment.user.domain.User;
 import moment.user.dto.response.MyPageProfileResponse;
+import moment.user.dto.response.MyRewardHistoryPageResponse;
+import moment.user.dto.response.MyRewardHistoryResponse;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -13,6 +18,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -29,6 +42,9 @@ class MyPageServiceTest {
 
     @Mock
     private UserQueryService userQueryService;
+
+    @Mock
+    private RewardService rewardService;
 
     @Test
     void 유저_프로필_정보를_조회한다() {
@@ -62,5 +78,39 @@ class MyPageServiceTest {
         assertThatThrownBy(() -> myPageService.getProfile(1L))
                 .isInstanceOf(MomentException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    void 유저의_보상_기록을_조회한다() {
+        // given
+        User user = new User("test@gmail.com", "qwer1234!", "신비로운 행성의 지구", ProviderType.EMAIL);
+        ReflectionTestUtils.setField(user, "id", 1L);
+        List<MyRewardHistoryResponse> content = createTestRewardHistory(user, 10);
+        Pageable pageable = PageRequest.of(0, 10);
+
+        Page<MyRewardHistoryResponse> page = new PageImpl<>(content, pageable, content.size());
+
+        given(userQueryService.getUserById(any(Long.class))).willReturn(user);
+        given(rewardService.getRewardHistoryByUser(any(User.class), any(Integer.class), any(Integer.class)))
+                .willReturn(MyRewardHistoryPageResponse.from(page));
+
+        MyRewardHistoryPageResponse response = myPageService.getMyRewardHistory(0, 10, user.getId());
+
+        // when & then
+        assertAll(
+                () -> assertThat(response.totalPages()).isEqualTo(1),
+                () -> assertThat(response.pageSize()).isEqualTo(10),
+                () -> assertThat(response.items().size()).isEqualTo(10),
+                () -> assertThat(response.currentPageNum()).isEqualTo(0)
+        );
+    }
+
+    private List<MyRewardHistoryResponse> createTestRewardHistory(User user, int amount) {
+        List<RewardHistory> list = new ArrayList<>();
+        for (int i = 0; i < amount; i++) {
+            RewardHistory rewardHistory = new RewardHistory(user, Reason.MOMENT_CREATION.getPointTo(), Reason.MOMENT_CREATION, (long) i);
+            list.add(rewardHistory);
+        }
+        return list.stream().map(MyRewardHistoryResponse::from).toList();
     }
 }

--- a/server/src/test/java/moment/user/presentation/MyPageControllerTest.java
+++ b/server/src/test/java/moment/user/presentation/MyPageControllerTest.java
@@ -4,10 +4,14 @@ import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
 import moment.auth.application.TokenManager;
 import moment.global.dto.response.SuccessResponse;
+import moment.reward.domain.Reason;
+import moment.reward.domain.RewardHistory;
+import moment.reward.infrastructure.RewardRepository;
 import moment.user.domain.Level;
 import moment.user.domain.ProviderType;
 import moment.user.domain.User;
 import moment.user.dto.response.MyPageProfileResponse;
+import moment.user.dto.response.MyRewardHistoryPageResponse;
 import moment.user.infrastructure.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,6 +30,9 @@ class MyPageControllerTest {
 
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private RewardRepository rewardRepository;
 
     @Autowired
     private TokenManager tokenManager;
@@ -58,5 +65,44 @@ class MyPageControllerTest {
                 () -> assertThat(profile.expStar()).isEqualTo(0),
                 () -> assertThat(profile.nextStepExp()).isEqualTo(5)
         );
+    }
+
+    @Test
+    void 유저_보상_기록을_페이징_처리하여_조회한다() {
+        // given
+        User user = new User("test@gmail.com", "qwer1234!", "신비로운 행성의 지구", ProviderType.EMAIL);
+        userRepository.save(user);
+
+        createTestRewardHistory(user);
+
+        String token = tokenManager.createToken(user.getId(), user.getEmail());
+
+        // when
+        SuccessResponse<MyRewardHistoryPageResponse> response = RestAssured.given().log().all()
+                .cookie("token", token)
+                .param("pageNum", 1)
+                .param("pageSize", 10)
+                .when().get("/api/v1/my/reward/history")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract().as(new TypeRef<>() {
+                });
+
+        MyRewardHistoryPageResponse pageData = response.data();
+
+        // then
+        assertAll(
+                () -> assertThat(response.status()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(pageData.totalPages()).isEqualTo(2),
+                () -> assertThat(pageData.pageSize()).isEqualTo(10),
+                () -> assertThat(pageData.items().size()).isEqualTo(10),
+                () -> assertThat(pageData.currentPageNum()).isEqualTo(1)
+        );
+    }
+
+    private void createTestRewardHistory(User user) {
+        for (int i = 0; i < 20; i++) {
+            rewardRepository.save(new RewardHistory(user, Reason.MOMENT_CREATION.getPointTo(), Reason.MOMENT_CREATION, (long) i));
+        }
     }
 }


### PR DESCRIPTION
# 📋 연관 이슈

- close #472 

# 🚀 작업 내용

- 1. 마이페이지 나의 보상 기록 조회 offset 기반 페이징 처리 구현

  - offset 기반으로 페이징 처리하여 마이페이지에서 나의 보장 기록을 조회할 수 있도록 하였습니다.

- uri
```
api/vi/my/reward/history
```

- 요청 파라미터
- pageNum -> 페이지 번호
- pageSize -> 페이지 사이즈

- 응답 json
```
{
  "status": 200,
  "data": {
	  "items": [
	  	{
	  	  "id": 1,
		    "changeStar": 5,
		    "reason": "COMMENT_CREATION",
			  "createdAt" : "2025-07-21T10:57:08.926954"
		  },
		  {
	  	  "id": 2,
		    "changeStar": -5,
		    "reason": "COMMENT_CREATION",
			  "createdAt" : "2025-07-21T10:57:08.926954"
		  }
    ],
		"currentPageNum": 1,
    "pageSize": 10,
    "totalPages": 2
  }
}
``` 

# 💬 리뷰 중점 사항

- StarRewardService 에 구현한 getRewardHistoryByUser() 내에서 페이징 조회를 한 후 이를 MyPageService getMyRewardHistory() 내에서 호출 마이페이지 나의 보상 기록 조회 api를 구현하였습니다.
- service간 참조 흐름상 어색한 것이 없는지 확인 부탁드립니다!

