### PR TITLE
[FEAT] 추가 모멘트 작성 API 구현 및 테스트 코드 작성

### DIFF
--- a/server/src/main/java/moment/global/exception/ErrorCode.java
+++ b/server/src/main/java/moment/global/exception/ErrorCode.java
@@ -43,6 +43,7 @@ public enum ErrorCode {
     MOMENT_ALREADY_EXIST("M-003", "오늘 작성한 모멘트가 이미 존재합니다.", HttpStatus.BAD_REQUEST),
     MOMENT_LENGTH_INVALID("M-004", "모멘트는 1자 이상, 100자 이하로만 작성 가능합니다.", HttpStatus.BAD_REQUEST),
     MOMENTS_LIMIT_INVALID("M-005", "유효하지 않은 페이지 사이즈입니다.", HttpStatus.BAD_REQUEST),
+    MOMENT_CREATE_POINT_NOT_ENOUGH("M-006", "포인트가 부족해 추가 모멘트를 작성할 수 없습니다.", HttpStatus.BAD_REQUEST),
 
     NOTIFICATION_NOT_FOUND("N-001", "존재하지 않는 알림입니다.", HttpStatus.NOT_FOUND),
     ;

--- a/server/src/main/java/moment/global/exception/ErrorCode.java
+++ b/server/src/main/java/moment/global/exception/ErrorCode.java
@@ -43,7 +43,6 @@ public enum ErrorCode {
     MOMENT_ALREADY_EXIST("M-003", "오늘 작성한 모멘트가 이미 존재합니다.", HttpStatus.BAD_REQUEST),
     MOMENT_LENGTH_INVALID("M-004", "모멘트는 1자 이상, 100자 이하로만 작성 가능합니다.", HttpStatus.BAD_REQUEST),
     MOMENTS_LIMIT_INVALID("M-005", "유효하지 않은 페이지 사이즈입니다.", HttpStatus.BAD_REQUEST),
-    MOMENT_CREATE_POINT_NOT_ENOUGH("M-006", "포인트가 부족해 추가 모멘트를 작성할 수 없습니다.", HttpStatus.BAD_REQUEST),
 
     NOTIFICATION_NOT_FOUND("N-001", "존재하지 않는 알림입니다.", HttpStatus.NOT_FOUND),
     ;

--- a/server/src/main/java/moment/moment/application/MomentService.java
+++ b/server/src/main/java/moment/moment/application/MomentService.java
@@ -73,7 +73,7 @@ public class MomentService {
         User momenter = userQueryService.getUserById(momenterId);
 
         if(!extraMomentCreatePolicy.canCreate(momenter)) {
-            throw new MomentException(ErrorCode.MOMENT_CREATE_POINT_NOT_ENOUGH);
+            throw new MomentException(ErrorCode.USER_NOT_ENOUGH_STAR);
         }
 
         Moment momentWithoutId = new Moment(request.content(), momenter, WriteType.BASIC);

--- a/server/src/main/java/moment/moment/application/MomentService.java
+++ b/server/src/main/java/moment/moment/application/MomentService.java
@@ -1,5 +1,6 @@
 package moment.moment.application;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import moment.comment.domain.Comment;
 import moment.comment.infrastructure.CommentRepository;
@@ -61,7 +62,24 @@ public class MomentService {
 
         Moment momentWithoutId = new Moment(request.content(), momenter, WriteType.BASIC);
         Moment savedMoment = momentRepository.save(momentWithoutId);
+
         rewardService.rewardForMoment(momenter, Reason.MOMENT_CREATION, savedMoment.getId());
+
+        return MomentCreateResponse.of(savedMoment);
+    }
+
+    @Transactional
+    public MomentCreateResponse addExtraMoment(MomentCreateRequest request, Long momenterId) {
+        User momenter = userQueryService.getUserById(momenterId);
+
+        if(!extraMomentCreatePolicy.canCreate(momenter)) {
+            throw new MomentException(ErrorCode.MOMENT_CREATE_POINT_NOT_ENOUGH);
+        }
+
+        Moment momentWithoutId = new Moment(request.content(), momenter, WriteType.BASIC);
+        Moment savedMoment = momentRepository.save(momentWithoutId);
+
+        rewardService.rewardForMoment(momenter, Reason.MOMENT_ADDITIONAL_USE, savedMoment.getId());
 
         return MomentCreateResponse.of(savedMoment);
     }

--- a/server/src/main/java/moment/moment/domain/PointDeductionPolicy.java
+++ b/server/src/main/java/moment/moment/domain/PointDeductionPolicy.java
@@ -11,10 +11,8 @@ import org.springframework.stereotype.Component;
 @Primary
 public class PointDeductionPolicy implements ExtraMomentCreatePolicy {
 
-
     @Override
     public boolean canCreate(User user) {
-        // TODO : user 포인트를 확인할 수 있는 코드가 삽입되면 해당 코드 재사용
-        return user.getAvailableStar() + Reason.MOMENT_ADDITIONAL_USE.getPointTo() >= 0;
+        return !user.canNotUseStars(Reason.MOMENT_ADDITIONAL_USE.getPointTo());
     }
 }

--- a/server/src/main/java/moment/moment/dto/response/MomentCreateResponse.java
+++ b/server/src/main/java/moment/moment/dto/response/MomentCreateResponse.java
@@ -16,10 +16,7 @@ public record MomentCreateResponse(
         LocalDateTime createdAt,
 
         @Schema(description = "모멘트 내용", example = "야근 힘들어용")
-        String content,
-
-        @Schema(description = "모멘트 매칭 여부", example = "false")
-        boolean isMatched
+        String content
 ) {
 
     public static MomentCreateResponse of(Moment moment) {
@@ -27,8 +24,7 @@ public record MomentCreateResponse(
                 moment.getId(),
                 moment.getMomenter().getId(),
                 moment.getCreatedAt(),
-                moment.getContent(),
-                moment.isMatched()
+                moment.getContent()
         );
     }
 }

--- a/server/src/main/java/moment/moment/presentation/MomentController.java
+++ b/server/src/main/java/moment/moment/presentation/MomentController.java
@@ -59,6 +59,31 @@ public class MomentController {
         return ResponseEntity.status(status).body(SuccessResponse.of(status, response));
     }
 
+    @Operation(summary = "추가 모멘트 등록", description = "사용자가 추가 모멘트를 등록합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "추가 모멘트 등록 성공"),
+            @ApiResponse(responseCode = "401", description = """
+                    - [T-005] 토큰을 찾을 수 없습니다.
+                    """,
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(responseCode = "404", description = """
+                    - [U-002] 존재하지 않는 사용자입니다.
+                    - [M-006] 포인트가 부족해 추가 모멘트를 작성할 수 없습니다.
+                    """,
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+    })
+    @PostMapping("/extra")
+    public ResponseEntity<SuccessResponse<MomentCreateResponse>> createExtraMoment(
+            @Valid @RequestBody MomentCreateRequest request,
+            @AuthenticationPrincipal Authentication authentication
+    ) {
+        MomentCreateResponse response = momentService.addExtraMoment(request, authentication.id());
+        HttpStatus status = HttpStatus.CREATED;
+
+        return ResponseEntity.status(status).body(SuccessResponse.of(status, response));
+    }
+
     @Operation(summary = "내 모멘트 조회", description = "사용자가 자신의 모멘트를 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "내 모멘트 조회 성공"),

--- a/server/src/test/java/moment/moment/application/momentServiceTest.java
+++ b/server/src/test/java/moment/moment/application/momentServiceTest.java
@@ -140,7 +140,7 @@ class momentServiceTest {
 
         // when & then
         assertThatThrownBy(() -> momentService.addExtraMoment(request, 1L))
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MOMENT_CREATE_POINT_NOT_ENOUGH);
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_ENOUGH_STAR);
     }
 
     @Test

--- a/server/src/test/java/moment/moment/application/momentServiceTest.java
+++ b/server/src/test/java/moment/moment/application/momentServiceTest.java
@@ -105,6 +105,45 @@ class momentServiceTest {
     }
 
     @Test
+    void 추가_모멘트_생성에_성공한다() {
+        // given
+        String momentContent = "재미있는 내용이네요.";
+        MomentCreateRequest request = new MomentCreateRequest(momentContent);
+        User momenter = new User("lebron@gmail.com", "1234", "르브론", ProviderType.EMAIL);
+        Moment expect = new Moment(momentContent, momenter, WriteType.BASIC);
+        ReflectionTestUtils.setField(expect, "id", 1L);
+
+        given(momentRepository.save(any(Moment.class))).willReturn(expect);
+        given(userQueryService.getUserById(any(Long.class))).willReturn(momenter);
+        given(extraMomentCreatePolicy.canCreate(any(User.class))).willReturn(true);
+        doNothing().when(rewardService).rewardForMoment(momenter, Reason.MOMENT_ADDITIONAL_USE, expect.getId());
+
+        // when
+        momentService.addExtraMoment(request, 1L);
+
+        // then
+        then(momentRepository).should(times(1)).save(any(Moment.class));
+        then(rewardService).should(times(1)).rewardForMoment(momenter, Reason.MOMENT_ADDITIONAL_USE, expect.getId());
+    }
+
+    @Test
+    void 추가_모멘트_생성에_실패한다() {
+        // given
+        String momentContent = "재미있는 내용이네요.";
+        MomentCreateRequest request = new MomentCreateRequest(momentContent);
+        User momenter = new User("lebron@gmail.com", "1234", "르브론", ProviderType.EMAIL);
+        Moment expect = new Moment(momentContent, momenter, WriteType.BASIC);
+        ReflectionTestUtils.setField(expect, "id", 1L);
+
+        given(userQueryService.getUserById(any(Long.class))).willReturn(momenter);
+        given(extraMomentCreatePolicy.canCreate(any(User.class))).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> momentService.addExtraMoment(request, 1L))
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MOMENT_CREATE_POINT_NOT_ENOUGH);
+    }
+
+    @Test
     void 내가_작성한_모멘트를_생성_시간_순으로_정렬하여_페이지를_조회한다() {
         // given
         User momenter = new User("harden@gmail.com", "1234", "하든", ProviderType.EMAIL);

--- a/server/src/test/java/moment/moment/domain/PointDeductionPolicyTest.java
+++ b/server/src/test/java/moment/moment/domain/PointDeductionPolicyTest.java
@@ -8,6 +8,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -22,8 +23,7 @@ class PointDeductionPolicyTest {
     @Test
     void 포인트가_충분할_경우_추가_모멘트를_작성할_수_있다() {
         // given
-        int writablePoint = 10;
-        when(user.getAvailableStar()).thenReturn(writablePoint);
+        when(user.canNotUseStars(any())).thenReturn(false);
 
         // when
         boolean result = pointDeductionPolicy.canCreate(user);
@@ -35,8 +35,7 @@ class PointDeductionPolicyTest {
     @Test
     void 포인트가_부족할_경우_추가_모멘트를_작성할_수_없다() {
         // given
-        int unWritablePoint = 9;
-        when(user.getAvailableStar()).thenReturn(unWritablePoint);
+        when(user.canNotUseStars(any())).thenReturn(true);
 
         // when
         boolean result = pointDeductionPolicy.canCreate(user);

--- a/server/src/test/java/moment/moment/presentation/MomentControllerTest.java
+++ b/server/src/test/java/moment/moment/presentation/MomentControllerTest.java
@@ -1,5 +1,6 @@
 package moment.moment.presentation;
 
+import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import moment.auth.application.TokenManager;
 import moment.moment.domain.Moment;
@@ -26,7 +27,6 @@ import org.springframework.test.context.ActiveProfiles;
 
 import java.util.Comparator;
 
-import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -55,7 +55,7 @@ class MomentControllerTest {
         String token = tokenManager.createToken(savedMomenter.getId(), savedMomenter.getEmail());
 
         // when
-        MomentCreateResponse response = given().log().all()
+        MomentCreateResponse response = RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .cookie("token", token)
                 .body(request)
@@ -85,7 +85,7 @@ class MomentControllerTest {
         String token = tokenManager.createToken(savedMomenter.getId(), savedMomenter.getEmail());
 
         // when
-        MomentCreateResponse response = given().log().all()
+        MomentCreateResponse response = RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .cookie("token", token)
                 .body(request)
@@ -126,7 +126,7 @@ class MomentControllerTest {
         momentRepository.save(moment4);
 
         // when
-        MyMomentPageResponse response = given().log().all()
+        MyMomentPageResponse response = RestAssured.given().log().all()
                 .param("limit", 3)
                 .cookie("token", token)
                 .when().get("/api/v1/moments/me")
@@ -175,7 +175,7 @@ class MomentControllerTest {
         momentRepository.save(moment4);
 
         // when
-        MyMomentPageResponse response = given().log().all()
+        MyMomentPageResponse response = RestAssured.given().log().all()
                 .param("limit", 10)
                 .cookie("token", token)
                 .when().get("/api/v1/moments/me")
@@ -208,7 +208,7 @@ class MomentControllerTest {
         String token = tokenManager.createToken(savedMomenter.getId(), savedMomenter.getEmail());
 
         // when
-        MomentCreationStatusResponse response = given().log().all()
+        MomentCreationStatusResponse response = RestAssured.given().log().all()
                 .cookie("token", token)
                 .when().get("api/v1/moments/writable/basic")
                 .then().log().all()
@@ -233,7 +233,7 @@ class MomentControllerTest {
         String token = tokenManager.createToken(savedMomenter.getId(), savedMomenter.getEmail());
 
         // when
-        MomentCreationStatusResponse response = given().log().all()
+        MomentCreationStatusResponse response = RestAssured.given().log().all()
                 .cookie("token", token)
                 .when().get("api/v1/moments/writable/basic")
                 .then().log().all()

--- a/server/src/test/java/moment/moment/presentation/MomentControllerTest.java
+++ b/server/src/test/java/moment/moment/presentation/MomentControllerTest.java
@@ -246,5 +246,49 @@ class MomentControllerTest {
         assertThat(response.status()).isEqualTo(MomentCreationStatus.DENIED);
     }
 
-    // TODO: 추가 모멘트 작성 가능 상태 확인 api에 대한 테스트를 user의 포인트를 조정하는 로직이 들어오면 작성할 예정
+    @Test
+    void 추가_모멘트_작성_가능_상태를_가져온다() {
+        // given
+        User momenter = new User("hippo@gmail.com", "1234", "hippo", ProviderType.EMAIL);
+        momenter.addStarAndUpdateLevel(10);
+        User savedMomenter = userRepository.save(momenter);
+
+        String token = tokenManager.createToken(savedMomenter.getId(), savedMomenter.getEmail());
+
+        // when
+        MomentCreationStatusResponse response = RestAssured.given().log().all()
+                .cookie("token", token)
+                .when().get("api/v1/moments/writable/extra")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .jsonPath()
+                .getObject("data", MomentCreationStatusResponse.class);
+
+        // then
+        assertThat(response.status()).isEqualTo(MomentCreationStatus.ALLOWED);
+    }
+
+    @Test
+    void 추가_모멘트_작성_불가능_상태를_가져온다() {
+        // given
+        User momenter = new User("hippo@gmail.com", "1234", "hippo", ProviderType.EMAIL);
+        momenter.addStarAndUpdateLevel(9);
+        User savedMomenter = userRepository.save(momenter);
+
+        String token = tokenManager.createToken(savedMomenter.getId(), savedMomenter.getEmail());
+
+        // when
+        MomentCreationStatusResponse response = RestAssured.given().log().all()
+                .cookie("token", token)
+                .when().get("api/v1/moments/writable/extra")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .jsonPath()
+                .getObject("data", MomentCreationStatusResponse.class);
+
+        // then
+        assertThat(response.status()).isEqualTo(MomentCreationStatus.DENIED);
+    }
 }


### PR DESCRIPTION
# 📋 연관 이슈

- close #466 

# 🚀 작업 내용

기본 모멘트 이외의 리워드를 사용하여 추가 모멘트를 작성(생성)하는 API를 구현하였습니다.
이때 리워드를 차감하여 추가 모멘트를 작성할 수 있는지 확인한 후, 리워드를 차감하여 추가 모멘트를 생성하였습니다.

API 스펙은 아래와 같습니다.

### Method

- POST

### URL

- `/api/v1/moments/extra`

### Request

- cookie: token
- body
    
    ```json
    {
    	"content": "이제 레벨3도 끝인건가.."
    }
    ```
    

### Response

- http status: 201
- data
```json
{
  "id": 1,
  "momenterId": 1,
  "createdAt": "2025-07-14T16:24:34Z",
  "content": "그니까 끝이다"
}
```