### PR TITLE
[FEAT] 마이페이지 비밀번호 변경 api 추가

### DIFF
--- a/server/src/main/java/moment/global/exception/ErrorCode.java
+++ b/server/src/main/java/moment/global/exception/ErrorCode.java
@@ -20,6 +20,8 @@ public enum ErrorCode {
     USER_NOT_FOUND("U-009", "존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
     USER_NICKNAME_GENERATION_FAILED("U-010", "사용 가능한 닉네임을 생성할 수 없습니다.", HttpStatus.CONFLICT),
     USER_NOT_ENOUGH_STAR("U-011", "사용 가능한 별조각을 확인해주세요.", HttpStatus.BAD_REQUEST),
+    PASSWORD_SAME_AS_OLD("U-012", "새 비밀번호가 기존의 비밀번호와 동일합니다.", HttpStatus.BAD_REQUEST),
+    PASSWORD_CHANGE_UNSUPPORTED_PROVIDER("U-013", "일반 회원가입 사용자가 아닌 경우 비밀번호를 변경할 수 없습니다.", HttpStatus.BAD_REQUEST),
 
     TOKEN_INVALID("T-001", "유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
     TOKEN_EXPIRED("T-002", "만료된 토큰입니다.", HttpStatus.UNAUTHORIZED),

--- a/server/src/main/java/moment/user/application/UserService.java
+++ b/server/src/main/java/moment/user/application/UserService.java
@@ -84,9 +84,9 @@ public class UserService {
         User user = userQueryService.getUserById(userId);
 
         validateChangeablePasswordUser(user);
-        comparePasswordWithRepassword(request.password(), request.rePassword());
+        comparePasswordWithRepassword(request.newPassword(), request.checkedPassword());
 
-        String encodedChangePassword = passwordEncoder.encode(request.password());
+        String encodedChangePassword = passwordEncoder.encode(request.newPassword());
         validateNotSameAsOldPassword(user, encodedChangePassword);
 
         user.changePassword(encodedChangePassword);

--- a/server/src/main/java/moment/user/application/UserService.java
+++ b/server/src/main/java/moment/user/application/UserService.java
@@ -6,6 +6,7 @@ import moment.global.exception.MomentException;
 import moment.user.domain.ProviderType;
 import moment.user.domain.User;
 import moment.user.dto.request.Authentication;
+import moment.user.dto.request.ChangePasswordRequest;
 import moment.user.dto.request.EmailConflictCheckRequest;
 import moment.user.dto.request.NicknameConflictCheckRequest;
 import moment.user.dto.request.UserCreateRequest;
@@ -30,7 +31,7 @@ public class UserService {
 
     @Transactional
     public void addUser(UserCreateRequest request) {
-        comparePasswordWithRepassword(request);
+        comparePasswordWithRepassword(request.password(), request.rePassword());
         validateEmailInBasicSignUp(request);
         validateNickname(request);
 
@@ -40,8 +41,8 @@ public class UserService {
         userRepository.save(user);
     }
 
-    private void comparePasswordWithRepassword(UserCreateRequest request) {
-        if (!request.password().equals(request.rePassword())) {
+    private void comparePasswordWithRepassword(String password, String rePassword) {
+        if (!password.equals(rePassword)) {
             throw new MomentException(ErrorCode.PASSWORD_MISMATCHED);
         }
     }
@@ -76,5 +77,30 @@ public class UserService {
     public EmailConflictCheckResponse checkEmailConflictInBasicSignUp(EmailConflictCheckRequest request) {
         boolean existsByEmail = userRepository.existsByEmailAndProviderType(request.email(), ProviderType.EMAIL);
         return new EmailConflictCheckResponse(existsByEmail);
+    }
+
+    @Transactional
+    public void changePassword(ChangePasswordRequest request, Long userId) {
+        User user = userQueryService.getUserById(userId);
+
+        validateChangeablePasswordUser(user);
+        comparePasswordWithRepassword(request.password(), request.rePassword());
+
+        String encodedChangePassword = passwordEncoder.encode(request.password());
+        validateNotSameAsOldPassword(user, encodedChangePassword);
+
+        user.changePassword(encodedChangePassword);
+    }
+
+    private void validateNotSameAsOldPassword(User user, String encodedChangePassword) {
+        if (user.checkPassword(encodedChangePassword)) {
+            throw new MomentException(ErrorCode.PASSWORD_SAME_AS_OLD);
+        }
+    }
+
+    private void validateChangeablePasswordUser(User user) {
+        if (!user.checkProviderType(ProviderType.EMAIL)) {
+            throw new MomentException(ErrorCode.PASSWORD_CHANGE_UNSUPPORTED_PROVIDER);
+        }
     }
 }

--- a/server/src/main/java/moment/user/domain/User.java
+++ b/server/src/main/java/moment/user/domain/User.java
@@ -105,4 +105,11 @@ public class User extends BaseEntity {
         return (availableStar + requiredStars) < 0;
     }
 
+    public void changePassword(String password) {
+        this.password = password;
+    }
+
+    public boolean checkProviderType(ProviderType providerType) {
+        return this.providerType == providerType;
+    }
 }

--- a/server/src/main/java/moment/user/dto/request/ChangePasswordRequest.java
+++ b/server/src/main/java/moment/user/dto/request/ChangePasswordRequest.java
@@ -8,11 +8,11 @@ public record ChangePasswordRequest(
         @Schema(description = "새 비밀번호", example = "hipopo12!")
         @Pattern(regexp = "^(?=.*[a-z])(?=.*\\d)(?=.*[!@#$%^&*()])[a-zA-Z\\d!@#$%^&*()]{8,16}$", message = "PASSWORD_INVALID")
         @NotBlank(message = "PASSWORD_INVALID")
-        String password,
+        String newPassword,
 
         @Schema(description = "비밀번호 확인", example = "hipopo12!")
         @Pattern(regexp = "^(?=.*[a-z])(?=.*\\d)(?=.*[!@#$%^&*()])[a-zA-Z\\d!@#$%^&*()]{8,16}$", message = "PASSWORD_INVALID")
         @NotBlank(message = "PASSWORD_INVALID")
-        String rePassword
+        String checkedPassword
 ) {
 }

--- a/server/src/main/java/moment/user/dto/request/ChangePasswordRequest.java
+++ b/server/src/main/java/moment/user/dto/request/ChangePasswordRequest.java
@@ -1,0 +1,18 @@
+package moment.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record ChangePasswordRequest(
+        @Schema(description = "새 비밀번호", example = "hipopo12!")
+        @Pattern(regexp = "^(?=.*[a-z])(?=.*\\d)(?=.*[!@#$%^&*()])[a-zA-Z\\d!@#$%^&*()]{8,16}$", message = "PASSWORD_INVALID")
+        @NotBlank(message = "PASSWORD_INVALID")
+        String password,
+
+        @Schema(description = "비밀번호 확인", example = "hipopo12!")
+        @Pattern(regexp = "^(?=.*[a-z])(?=.*\\d)(?=.*[!@#$%^&*()])[a-zA-Z\\d!@#$%^&*()]{8,16}$", message = "PASSWORD_INVALID")
+        @NotBlank(message = "PASSWORD_INVALID")
+        String rePassword
+) {
+}

--- a/server/src/main/java/moment/user/presentation/UserController.java
+++ b/server/src/main/java/moment/user/presentation/UserController.java
@@ -13,6 +13,7 @@ import moment.global.dto.response.ErrorResponse;
 import moment.global.dto.response.SuccessResponse;
 import moment.user.application.UserService;
 import moment.user.dto.request.Authentication;
+import moment.user.dto.request.ChangePasswordRequest;
 import moment.user.dto.request.EmailConflictCheckRequest;
 import moment.user.dto.request.NicknameConflictCheckRequest;
 import moment.user.dto.request.UserCreateRequest;
@@ -20,7 +21,9 @@ import moment.user.dto.response.EmailConflictCheckResponse;
 import moment.user.dto.response.MomentRandomNicknameResponse;
 import moment.user.dto.response.NicknameConflictCheckResponse;
 import moment.user.dto.response.UserProfileResponse;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -131,5 +134,42 @@ public class UserController {
         EmailConflictCheckResponse response = userService.checkEmailConflictInBasicSignUp(request);
         HttpStatus status = HttpStatus.OK;
         return ResponseEntity.status(status).body(SuccessResponse.of(status, response));
+    }
+
+    @Operation(summary = "비밀번호 변경", description = "사용자가 마이페이지 내에서 비밀번호를 변경합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "비밀번호 변경 성공"),
+            @ApiResponse(responseCode = "400", description = """
+                    - [U-005] 유효하지 않은 비밀번호 형식입니다.
+                    - [U-012] 새 비밀번호가 기존의 비밀번호와 동일합니다.
+                    - [U-013] 일반 회원가입 사용자가 아닌 경우 비밀번호를 변경할 수 없습니다.
+                    """,
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(responseCode = "404", description = """
+                    - [U-002] 존재하지 않는 사용자입니다.
+                    """,
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+    })
+    @PostMapping("/my/password")
+    public ResponseEntity<SuccessResponse<Void>> changePassword(
+            @Valid @RequestBody ChangePasswordRequest request,
+            @AuthenticationPrincipal Authentication authentication
+    ) {
+        ResponseCookie cookie = ResponseCookie.from("token", null)
+                .sameSite("none")
+                .secure(true)
+                .httpOnly(true)
+                .path("/")
+                .maxAge(0)
+                .build();
+
+        HttpStatus status = HttpStatus.OK;
+
+        userService.changePassword(request, authentication.id());
+
+        return ResponseEntity.status(status)
+                .header(HttpHeaders.SET_COOKIE, cookie.toString())
+                .body(SuccessResponse.of(status, null));
     }
 }

--- a/server/src/test/java/moment/user/application/UserServiceTest.java
+++ b/server/src/test/java/moment/user/application/UserServiceTest.java
@@ -1,5 +1,14 @@
 package moment.user.application;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
 import moment.global.exception.ErrorCode;
 import moment.global.exception.MomentException;
 import moment.user.domain.ProviderType;
@@ -20,15 +29,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayNameGeneration(ReplaceUnderscores.class)
@@ -219,7 +219,7 @@ class UserServiceTest {
         ReflectionTestUtils.setField(user, "id", 1L);
         ChangePasswordRequest request = new ChangePasswordRequest("test123!@#", "test123!@#");
 
-        given(passwordEncoder.encode(request.password())).willReturn("test123!@#");
+        given(passwordEncoder.encode(request.newPassword())).willReturn("test123!@#");
         given(userQueryService.getUserById(any(Long.class))).willReturn(user);
 
         // when & then

--- a/server/src/test/java/moment/user/application/UserServiceTest.java
+++ b/server/src/test/java/moment/user/application/UserServiceTest.java
@@ -1,18 +1,10 @@
 package moment.user.application;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.times;
-
 import moment.global.exception.ErrorCode;
 import moment.global.exception.MomentException;
 import moment.user.domain.ProviderType;
 import moment.user.domain.User;
+import moment.user.dto.request.ChangePasswordRequest;
 import moment.user.dto.request.EmailConflictCheckRequest;
 import moment.user.dto.request.NicknameConflictCheckRequest;
 import moment.user.dto.request.UserCreateRequest;
@@ -27,6 +19,16 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayNameGeneration(ReplaceUnderscores.class)
@@ -178,5 +180,51 @@ class UserServiceTest {
         assertThatThrownBy(() -> userService.createRandomNickname())
                 .isInstanceOf(MomentException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NICKNAME_GENERATION_FAILED);
+    }
+
+    @Test
+    void 일반_회원가입_유저가_아닌_경우_비밀번호_변경_시_예외가_발생합니다() {
+        // given
+        User user = new User("mimi@icloud.com", "test123!@#", "미미", ProviderType.GOOGLE);
+        ReflectionTestUtils.setField(user, "id", 1L);
+        ChangePasswordRequest request = new ChangePasswordRequest("change123!@#", "change123!@#");
+
+        given(userQueryService.getUserById(any(Long.class))).willReturn(user);
+
+        // when & then
+        assertThatThrownBy(() -> userService.changePassword(request, user.getId()))
+                .isInstanceOf(MomentException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PASSWORD_CHANGE_UNSUPPORTED_PROVIDER);
+    }
+
+    @Test
+    void 새_비밀번호와_확인_비밀번호가_일치하지_않는_경우_예외가_발생합니다() {
+        // given
+        User user = new User("mimi@icloud.com", "test123!@#", "미미", ProviderType.EMAIL);
+        ReflectionTestUtils.setField(user, "id", 1L);
+        ChangePasswordRequest request = new ChangePasswordRequest("change123!@#", "change123");
+
+        given(userQueryService.getUserById(any(Long.class))).willReturn(user);
+
+        // when & then
+        assertThatThrownBy(() -> userService.changePassword(request, user.getId()))
+                .isInstanceOf(MomentException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PASSWORD_MISMATCHED);
+    }
+
+    @Test
+    void 새_비밀번호가_기존_비밀번호와_동일한_경우_예외가_발생합니다() {
+        // given
+        User user = new User("mimi@icloud.com", "test123!@#", "미미", ProviderType.EMAIL);
+        ReflectionTestUtils.setField(user, "id", 1L);
+        ChangePasswordRequest request = new ChangePasswordRequest("test123!@#", "test123!@#");
+
+        given(passwordEncoder.encode(request.password())).willReturn("test123!@#");
+        given(userQueryService.getUserById(any(Long.class))).willReturn(user);
+
+        // when & then
+        assertThatThrownBy(() -> userService.changePassword(request, user.getId()))
+                .isInstanceOf(MomentException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PASSWORD_SAME_AS_OLD);
     }
 }

--- a/server/src/test/java/moment/user/presentation/UserControllerTest.java
+++ b/server/src/test/java/moment/user/presentation/UserControllerTest.java
@@ -35,8 +35,10 @@ class UserControllerTest {
 
     @Autowired
     PasswordEncoder passwordEncoder;
+
     @Autowired
     private UserRepository userRepository;
+
     @Autowired
     private TokenManager tokenManager;
 
@@ -185,7 +187,7 @@ class UserControllerTest {
         assertAll(
                 () -> assertThat(response.status()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(passwordEncoder.matches(user.getPassword(), changePasswordUser.getPassword())).isFalse(),
-                () -> assertThat(passwordEncoder.matches(request.password(), changePasswordUser.getPassword())).isTrue()
+                () -> assertThat(passwordEncoder.matches(request.newPassword(), changePasswordUser.getPassword())).isTrue()
         );
     }
 }

--- a/server/src/test/java/moment/user/presentation/UserControllerTest.java
+++ b/server/src/test/java/moment/user/presentation/UserControllerTest.java
@@ -7,6 +7,7 @@ import moment.auth.application.TokenManager;
 import moment.global.dto.response.SuccessResponse;
 import moment.user.domain.ProviderType;
 import moment.user.domain.User;
+import moment.user.dto.request.ChangePasswordRequest;
 import moment.user.dto.request.EmailConflictCheckRequest;
 import moment.user.dto.request.NicknameConflictCheckRequest;
 import moment.user.dto.request.UserCreateRequest;
@@ -20,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -32,8 +34,9 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 class UserControllerTest {
 
     @Autowired
+    PasswordEncoder passwordEncoder;
+    @Autowired
     private UserRepository userRepository;
-
     @Autowired
     private TokenManager tokenManager;
 
@@ -151,6 +154,38 @@ class UserControllerTest {
         assertAll(
                 () -> assertThat(response.status()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(response.data()).isEqualTo(expect)
+        );
+    }
+
+
+    @Test
+    void 마이페이지_내에서_유저_비밀번호를_변경한다() {
+        // given
+        String nickname = "mimi";
+        String encodePassword = passwordEncoder.encode("test123!@#");
+        User user = userRepository.save(new User("mimi@icloud.com", encodePassword, nickname, ProviderType.EMAIL));
+        String token = tokenManager.createToken(user.getId(), user.getEmail());
+
+        ChangePasswordRequest request = new ChangePasswordRequest("change123!@#", "change123!@#");
+
+        // when
+        SuccessResponse<Void> response = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .cookie("token", token)
+                .when().post("/api/v1/users/my/password")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract().as(new TypeRef<>() {
+                });
+
+        User changePasswordUser = userRepository.findById(user.getId()).get();
+
+        // then
+        assertAll(
+                () -> assertThat(response.status()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(passwordEncoder.matches(user.getPassword(), changePasswordUser.getPassword())).isFalse(),
+                () -> assertThat(passwordEncoder.matches(request.password(), changePasswordUser.getPassword())).isTrue()
         );
     }
 }


### PR DESCRIPTION
# 📋 연관 이슈

- close #476 

# 🚀 작업 내용

- 1. 마이페이지 내 비밀번호 변경  api 구현

- uri
```
api/v1/users/my/password
```

- 요청 json
```
{
	“newPassword”: “qwer1234!”,
	“checkPassword” : “qwer1234!”
}
```

- 응답
  - 200 ok
  - 400
  - 404

# 💬 리뷰 중점 사항

- 비밀번호 변경 시 유효성 검증이 잘 진행되고 있는지 확인 부탁드립니다.
  - EMAIL 회원가입이 아닌 경우 예외 발생해야 합니다.
  - 새 비밀번호가 기존 비밀번호와 같은 경우 예외 발생해야 합니다.
  - 새 비밀번호와 확인 비밀번호가 다른 경우 예외 발생해야 합니다.
  - 새 비밀번호와 확인 비밀번호의 양식이 옳지 않은 경우 예외가 발생해야 합니다.

