### PR TITLE
[FEAT] 내 모멘트 모음 조회 API 수정

### DIFF
--- a/server/src/main/java/moment/moment/application/MomentService.java
+++ b/server/src/main/java/moment/moment/application/MomentService.java
@@ -98,23 +98,27 @@ public class MomentService {
 
         if (comments.isEmpty()) {
             List<MyMomentResponse> responses = moments.stream()
-                    .map(moment -> MyMomentResponse.of(moment, null, Collections.emptyList()))
+                    .map(moment -> MyMomentResponse.of(moment, Collections.emptyList(), Collections.emptyMap()))
                     .toList();
 
             return MyMomentPageResponse.of(responses, nextCursor, hasNextPage, responses.size());
         }
 
-        Map<Moment, Comment> commentByMoment = comments.stream()
-                .collect(Collectors.toMap(Comment::getMoment, comment -> comment));
+        Map<Moment, List<Comment>> commentsByMoment = comments.stream()
+                .collect(Collectors.groupingBy(Comment::getMoment));
 
-        Map<Comment, List<Echo>> emojisByComment = echoRepository.findAllByCommentIn(comments).stream()
+        Map<Comment, List<Echo>> echosByComment = echoRepository.findAllByCommentIn(comments).stream()
                 .collect(Collectors.groupingBy(Echo::getComment));
 
         List<MyMomentResponse> responses = moments.stream()
                 .map(moment -> {
-                    Comment comment = commentByMoment.get(moment);
-                    List<Echo> relatedEchos = emojisByComment.getOrDefault(comment, Collections.emptyList());
-                    return MyMomentResponse.of(moment, comment, relatedEchos);
+                    List<Comment> momentComments = commentsByMoment.getOrDefault(moment, List.of());
+
+                    Map<Long, List<Echo>> echomap = momentComments.stream()
+                            .collect(Collectors.toMap(Comment::getId,
+                                    comment -> echosByComment.getOrDefault(comment, List.of())));
+
+                    return MyMomentResponse.of(moment, momentComments, echomap);
                 })
                 .toList();
 

--- a/server/src/main/java/moment/moment/application/MomentService.java
+++ b/server/src/main/java/moment/moment/application/MomentService.java
@@ -114,11 +114,11 @@ public class MomentService {
                 .map(moment -> {
                     List<Comment> momentComments = commentsByMoment.getOrDefault(moment, List.of());
 
-                    Map<Long, List<Echo>> echomap = momentComments.stream()
+                    Map<Long, List<Echo>> commentEchos = momentComments.stream()
                             .collect(Collectors.toMap(Comment::getId,
                                     comment -> echosByComment.getOrDefault(comment, List.of())));
 
-                    return MyMomentResponse.of(moment, momentComments, echomap);
+                    return MyMomentResponse.of(moment, momentComments, commentEchos);
                 })
                 .toList();
 

--- a/server/src/main/java/moment/moment/dto/response/MyMomentCommentResponse.java
+++ b/server/src/main/java/moment/moment/dto/response/MyMomentCommentResponse.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import moment.comment.domain.Comment;
 import moment.reply.domain.Echo;
+import moment.user.domain.Level;
 
 @Schema(description = "모멘트에 달린 코멘트 응답")
 public record MyMomentCommentResponse(
@@ -14,21 +15,29 @@ public record MyMomentCommentResponse(
         @Schema(description = "코멘트 내용", example = "안됐네요.")
         String content,
 
+        @Schema(description = "코멘터 닉네임", example = "미미")
+        String nickname,
+
+        @Schema(description = "코멘터 레벨", example = "ASTEROID_WHITE")
+        Level level,
+
         @Schema(description = "코멘트 작성 시간", example = "2025-07-14T16:30:34Z")
         LocalDateTime createdAt,
 
-        List<MyMomentEchoResponse> emojis
+        List<MyMomentEchoResponse> echos
 ) {
 
     public static MyMomentCommentResponse of(Comment comment, List<Echo> echoes) {
-        List<MyMomentEchoResponse> emojiDetailRespons = echoes.stream()
+        List<MyMomentEchoResponse> echoDetailResponse = echoes.stream()
                 .map(MyMomentEchoResponse::from)
                 .toList();
         
         return new MyMomentCommentResponse(
                 comment.getId(),
                 comment.getContent(),
+                comment.getCommenter().getNickname(),
+                comment.getCommenter().getLevel(),
                 comment.getCreatedAt(),
-                emojiDetailRespons);
+                echoDetailResponse);
     }
 }

--- a/server/src/main/java/moment/moment/dto/response/MyMomentResponse.java
+++ b/server/src/main/java/moment/moment/dto/response/MyMomentResponse.java
@@ -2,7 +2,9 @@ package moment.moment.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import moment.comment.domain.Comment;
 import moment.moment.domain.Moment;
 import moment.reply.domain.Echo;
@@ -21,19 +23,22 @@ public record MyMomentResponse(
         @Schema(description = "내 모멘트 작성 시간,", example = "2025-07-14T16:24:34Z")
         LocalDateTime createdAt,
 
-        MyMomentCommentResponse comment
+        List<MyMomentCommentResponse> comments
 ) {
 
-    public static MyMomentResponse of(Moment moment, Comment comment, List<Echo> echoes) {
-        if (comment != null) {
-            MyMomentCommentResponse myMomentCommentResponse = MyMomentCommentResponse.of(comment, echoes);
-            
+    public static MyMomentResponse of(Moment moment, List<Comment> comments, Map<Long, List<Echo>> echoMap) {
+        if (!comments.isEmpty()) {
+            List<MyMomentCommentResponse> myMomentCommentResponses = comments.stream()
+                    .map(comment -> MyMomentCommentResponse.of(
+                            comment, echoMap.getOrDefault(comment.getId(), List.of())))
+                    .toList();
+
             return new MyMomentResponse(
                     moment.getId(),
                     moment.getMomenterId(),
                     moment.getContent(),
                     moment.getCreatedAt(),
-                    myMomentCommentResponse);
+                    myMomentCommentResponses);
         }
 
         return new MyMomentResponse(
@@ -41,6 +46,6 @@ public record MyMomentResponse(
                 moment.getMomenterId(),
                 moment.getContent(),
                 moment.getCreatedAt(),
-                null);
+                Collections.emptyList());
     }
 }

--- a/server/src/test/java/moment/moment/application/momentServiceTest.java
+++ b/server/src/test/java/moment/moment/application/momentServiceTest.java
@@ -126,10 +126,10 @@ class momentServiceTest {
         given(echoRepository.findAllByCommentIn(any(List.class)))
                 .willReturn(List.of(echo));
 
-        //when
+        // when
         MyMomentPageResponse response = momentService.getMyMoments(null, 1, 1L);
 
-        //then
+        // then
         assertAll(
                 () -> then(commentRepository).should(times(1)).findAllByMomentIn(any(List.class)),
                 () -> then(echoRepository).should(times(1)).findAllByCommentIn(any(List.class)),


### PR DESCRIPTION
# 📋 연관 이슈

- close #468

# 🚀 작업 내용

내 모멘트 모음을 조회할 때 응답 필드를 수정하였습니다.

moment와 comment의 관계가 1:1에서 1:m으로 변경되면서 moment에 달린 comment를 여러건 조회하도록 변경하였습니다.
comment별로 commenter의 닉네임과 레벨을 추가로 반환하였습니다.
emoji -> echo 도메인명의 변경을 진행했습니다.
