### PR TITLE
[FEAT] 마이페이지 닉네임 변경 API 구현

### DIFF
--- a/server/src/main/java/moment/reward/application/RewardService.java
+++ b/server/src/main/java/moment/reward/application/RewardService.java
@@ -1,10 +1,13 @@
 package moment.reward.application;
 
 import moment.reward.domain.Reason;
+import moment.reward.domain.RewardHistory;
 import moment.user.domain.User;
 import moment.user.dto.response.MyRewardHistoryPageResponse;
 
 public interface RewardService {
+
+    RewardHistory save(RewardHistory rewardHistory);
 
     void rewardForMoment(User user, Reason reason, Long contentId);
 

--- a/server/src/main/java/moment/reward/application/StarRewardService.java
+++ b/server/src/main/java/moment/reward/application/StarRewardService.java
@@ -27,6 +27,12 @@ public class StarRewardService implements RewardService {
 
     @Override
     @Transactional
+    public RewardHistory save(RewardHistory rewardHistory) {
+        return rewardRepository.save(rewardHistory);
+    }
+
+    @Override
+    @Transactional
     public void rewardForMoment(User momenter, Reason reason, Long momentId) {
         LocalDate today = LocalDate.now();
 

--- a/server/src/main/java/moment/user/domain/User.java
+++ b/server/src/main/java/moment/user/domain/User.java
@@ -101,8 +101,12 @@ public class User extends BaseEntity {
         this.level = Level.getLevel(this.expStar);
     }
 
-    public boolean canNotUseStars(Integer requiredStars) {
+    public boolean canNotUseStars(int requiredStars) {
         return (availableStar + requiredStars) < 0;
     }
 
+    public void changeNickname(String newNickname, int requiredStar) {
+        this.availableStar += requiredStar;
+        this.nickname = newNickname;
+    }
 }

--- a/server/src/main/java/moment/user/dto/request/NicknameChangeRequest.java
+++ b/server/src/main/java/moment/user/dto/request/NicknameChangeRequest.java
@@ -1,0 +1,14 @@
+package moment.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+@Schema(description = "마이페이지 닉네임 변경 요청")
+public record NicknameChangeRequest(
+        @Schema(description = "새로운 닉네임", example = "신비로운 하늘의 지구")
+        @Pattern(regexp = "^.{1,15}$", message = "NICKNAME_INVALID")
+        @NotBlank(message = "NICKNAME_INVALID")
+        String newNickname
+) {
+}

--- a/server/src/main/java/moment/user/dto/response/MyPageProfileResponse.java
+++ b/server/src/main/java/moment/user/dto/response/MyPageProfileResponse.java
@@ -2,6 +2,7 @@ package moment.user.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import moment.user.domain.Level;
+import moment.user.domain.ProviderType;
 import moment.user.domain.User;
 
 @Schema(description = "마이페이지 프로필 정보 응답")
@@ -22,7 +23,10 @@ public record MyPageProfileResponse(
         Integer expStar,
 
         @Schema(description = "다음 레벨 요구 경험치", example = "200")
-        Integer nextStepExp
+        Integer nextStepExp,
+
+        @Schema(description = "사용자 가입 유형", example = "EMAIL")
+        ProviderType loginType
 ) {
     public static MyPageProfileResponse from(User user) {
         return new MyPageProfileResponse(
@@ -31,7 +35,8 @@ public record MyPageProfileResponse(
                 user.getLevel(),
                 user.getAvailableStar(),
                 user.getExpStar(),
-                user.getLevel().getNextLevelRequiredStars()
+                user.getLevel().getNextLevelRequiredStars(),
+                user.getProviderType()
         );
     }
 }

--- a/server/src/main/java/moment/user/dto/response/NicknameChangeResponse.java
+++ b/server/src/main/java/moment/user/dto/response/NicknameChangeResponse.java
@@ -1,0 +1,14 @@
+package moment.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import moment.user.domain.User;
+
+@Schema(description = "마이페이지 닉네임 변경 응답")
+public record NicknameChangeResponse(
+        @Schema(description = "변경된 닉네임", example = "신비로운 하늘의 지구")
+        String changedNickname
+) {
+    public static NicknameChangeResponse from(User user) {
+        return new NicknameChangeResponse(user.getNickname());
+    }
+}

--- a/server/src/main/java/moment/user/dto/response/UserProfileResponse.java
+++ b/server/src/main/java/moment/user/dto/response/UserProfileResponse.java
@@ -17,11 +17,15 @@ public record UserProfileResponse(
 
         @Schema(description = "다음 레벨 요구 경험치", example = "200")
         Integer nextStepExp
-
 ) {
 
     public static UserProfileResponse from(User user) {
         Level level = user.getLevel();
-        return new UserProfileResponse(user.getNickname(), user.getAvailableStar(), level, level.getNextLevelRequiredStars());
+        return new UserProfileResponse(
+                user.getNickname(),
+                user.getAvailableStar(),
+                level,
+                level.getNextLevelRequiredStars()
+        );
     }
 }

--- a/server/src/main/java/moment/user/presentation/MyPageController.java
+++ b/server/src/main/java/moment/user/presentation/MyPageController.java
@@ -7,17 +7,22 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import moment.auth.presentation.AuthenticationPrincipal;
 import moment.global.dto.response.ErrorResponse;
 import moment.global.dto.response.SuccessResponse;
 import moment.user.application.MyPageService;
 import moment.user.dto.request.Authentication;
+import moment.user.dto.request.NicknameChangeRequest;
 import moment.user.dto.response.MyPageProfileResponse;
+import moment.user.dto.response.NicknameChangeResponse;
 import moment.user.dto.response.MyRewardHistoryPageResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,7 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "MyPage API", description = "마이페이지 API 명세")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/my")
+@RequestMapping("/api/v1/me")
 public class MyPageController {
 
     private final MyPageService myPageService;
@@ -72,6 +77,36 @@ public class MyPageController {
             @AuthenticationPrincipal Authentication authentication
     ) {
         MyRewardHistoryPageResponse response = myPageService.getMyRewardHistory(pageNum, pageSize, authentication.id());
+        HttpStatus status = HttpStatus.OK;
+        return ResponseEntity.status(status).body(SuccessResponse.of(status, response));
+    }
+
+
+    @Operation(summary = "마이페이지 닉네임 변경", description = "리워드를 사용하여 닉네임을 변경합니다")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "닉네임 변경 성공"),
+            @ApiResponse(responseCode = "400", description = """
+                    - [U-006] 유효하지 않은 닉네임 형식입니다.
+                    """,
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(responseCode = "404", description = """
+                    - [U-002] 존재하지 않는 사용자입니다.
+                    - [U-011] 사용 가능한 별조각을 확인해주세요.
+                    """,
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = """
+                    - [U-003] 이미 존재하는 닉네임입니다.
+                    """,
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @PostMapping("/nickname")
+    public ResponseEntity<SuccessResponse<NicknameChangeResponse>> changeNickname(
+            @Valid @RequestBody NicknameChangeRequest request,
+            @AuthenticationPrincipal Authentication authentication
+    ) {
+        NicknameChangeResponse response = myPageService.changeNickname(request, authentication.id());
         HttpStatus status = HttpStatus.OK;
         return ResponseEntity.status(status).body(SuccessResponse.of(status, response));
     }

--- a/server/src/test/java/moment/moment/domain/PointDeductionPolicyTest.java
+++ b/server/src/test/java/moment/moment/domain/PointDeductionPolicyTest.java
@@ -1,6 +1,8 @@
 package moment.moment.domain;
 
 import moment.user.domain.User;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -12,6 +14,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class PointDeductionPolicyTest {
 
     @InjectMocks
@@ -23,7 +26,7 @@ class PointDeductionPolicyTest {
     @Test
     void 포인트가_충분할_경우_추가_모멘트를_작성할_수_있다() {
         // given
-        when(user.canNotUseStars(any())).thenReturn(false);
+        when(user.canNotUseStars(any(Integer.class))).thenReturn(false);
 
         // when
         boolean result = pointDeductionPolicy.canCreate(user);
@@ -35,7 +38,7 @@ class PointDeductionPolicyTest {
     @Test
     void 포인트가_부족할_경우_추가_모멘트를_작성할_수_없다() {
         // given
-        when(user.canNotUseStars(any())).thenReturn(true);
+        when(user.canNotUseStars(any(Integer.class))).thenReturn(true);
 
         // when
         boolean result = pointDeductionPolicy.canCreate(user);

--- a/server/src/test/java/moment/user/presentation/MyPageControllerTest.java
+++ b/server/src/test/java/moment/user/presentation/MyPageControllerTest.java
@@ -86,7 +86,7 @@ class MyPageControllerTest {
                 .cookie("token", token)
                 .param("pageNum", 1)
                 .param("pageSize", 10)
-                .when().get("/api/v1/my/reward/history")
+                .when().get("/api/v1/me/reward/history")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract().as(new TypeRef<>() {

--- a/server/src/test/java/moment/user/presentation/UserControllerTest.java
+++ b/server/src/test/java/moment/user/presentation/UserControllerTest.java
@@ -15,6 +15,8 @@ import moment.user.dto.response.MomentRandomNicknameResponse;
 import moment.user.dto.response.NicknameConflictCheckResponse;
 import moment.user.dto.response.UserProfileResponse;
 import moment.user.infrastructure.UserRepository;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -29,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class UserControllerTest {
 
     @Autowired


### PR DESCRIPTION
# 📋 연관 이슈

- close #479 

# 🚀 작업 내용

- 1. 마이페이지에서 별조각을 소모하여 닉네임을 변경하는 API 를 구현하였습니다.

- uri
```
api/v1/me/nickname
```

- 요청 json
```
{
  "newNickname" : "신비로운 하늘의 지구"
}
```

- 응답 json

```
{
  "changedNickname" : "신비로운 하늘의 지구"
}
```

- 응답 코드
  - 200 ok
    - 닉네임 변경 성공
  - 400
    - 유효하지 않은 닉네임 형식인 경우
    - 사용 가능한 별조각이 부족한 경우
  - 404
    - 존재하지 않는 사용자
  - 409
    - 닉네임 중복 시 

# 💬 리뷰 중점 사항

- 닉네임 변경 서비스 로직에서 user로 책임 전가를 할 만한 로직이 있는지 확인부탁드립니다!
- 닉네임 변경 로직 이외에 마이페이지 프로필 정보에서 가입 유형을 받아보기 위한 응답 필드를 추가하였으니 해당 부분은 참고바랍니다.
  - 비밀번호 변경 시 필요한 로직이지만 따로 pr파기에 너무 작은 작업이여서 한번에 처리함...
