### PR TITLE
[FIX] 추가 코멘트 작성 API 호출 시 작성 타입 수정

### DIFF
--- a/server/src/main/java/moment/moment/application/MomentService.java
+++ b/server/src/main/java/moment/moment/application/MomentService.java
@@ -78,7 +78,7 @@ public class MomentService {
             throw new MomentException(ErrorCode.USER_NOT_ENOUGH_STAR);
         }
 
-        Moment momentWithoutId = new Moment(request.content(), momenter, WriteType.BASIC);
+        Moment momentWithoutId = new Moment(request.content(), momenter, WriteType.EXTRA);
         Moment savedMoment = momentRepository.save(momentWithoutId);
 
         rewardService.rewardForMoment(momenter, Reason.MOMENT_ADDITIONAL_USE, savedMoment.getId());

--- a/server/src/main/java/moment/moment/presentation/MomentController.java
+++ b/server/src/main/java/moment/moment/presentation/MomentController.java
@@ -156,7 +156,7 @@ public class MomentController {
         return ResponseEntity.status(status).body(SuccessResponse.of(status, response));
     }
 
-    @Operation(summary = "코멘트를 달 수 있는 조회", description = "사용자가 코멘트를 달 수 있는 모멘트를 조회합니다.")
+    @Operation(summary = "코멘트를 달 수 있는 모멘트 조회", description = "사용자가 코멘트를 달 수 있는 모멘트를 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "코멘트를 달 수 있는 모멘트 조회 성공"),
             @ApiResponse(responseCode = "401", description = """

--- a/server/src/test/java/moment/moment/application/momentServiceTest.java
+++ b/server/src/test/java/moment/moment/application/momentServiceTest.java
@@ -88,12 +88,12 @@ class momentServiceTest {
         doNothing().when(rewardService).rewardForMoment(momenter, Reason.MOMENT_CREATION, expect.getId());
 
         ArgumentCaptor<Moment> captor = ArgumentCaptor.forClass(Moment.class);
-        verify(momentRepository).save(captor.capture());
 
         // when
         momentService.addBasicMoment(request, 1L);
 
         // then
+        verify(momentRepository).save(captor.capture());
         Moment savedMoment = captor.getValue();
         assertAll(
                 () -> assertThat(savedMoment.getWriteType()).isEqualTo(WriteType.BASIC),
@@ -132,12 +132,12 @@ class momentServiceTest {
         doNothing().when(rewardService).rewardForMoment(momenter, Reason.MOMENT_ADDITIONAL_USE, expect.getId());
 
         ArgumentCaptor<Moment> captor = ArgumentCaptor.forClass(Moment.class);
-        verify(momentRepository).save(captor.capture());
 
         // when
         momentService.addExtraMoment(request, 1L);
 
         // then
+        verify(momentRepository).save(captor.capture());
         Moment savedMoment = captor.getValue();
         assertAll(
                 () -> assertThat(savedMoment.getWriteType()).isEqualTo(WriteType.EXTRA),

--- a/server/src/test/java/moment/moment/application/momentServiceTest.java
+++ b/server/src/test/java/moment/moment/application/momentServiceTest.java
@@ -11,6 +11,7 @@ import moment.moment.domain.MomentCreationStatus;
 import moment.moment.domain.WriteType;
 import moment.moment.dto.request.MomentCreateRequest;
 import moment.moment.dto.response.CommentableMomentResponse;
+import moment.moment.dto.response.MomentCreateResponse;
 import moment.moment.dto.response.MomentCreationStatusResponse;
 import moment.moment.dto.response.MyMomentPageResponse;
 import moment.moment.infrastructure.MomentRepository;
@@ -25,6 +26,7 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -41,6 +43,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayNameGeneration(ReplaceUnderscores.class)
@@ -84,11 +87,19 @@ class momentServiceTest {
         given(basicMomentCreatePolicy.canCreate(any(User.class))).willReturn(true);
         doNothing().when(rewardService).rewardForMoment(momenter, Reason.MOMENT_CREATION, expect.getId());
 
+        ArgumentCaptor<Moment> captor = ArgumentCaptor.forClass(Moment.class);
+        verify(momentRepository).save(captor.capture());
+
         // when
         momentService.addBasicMoment(request, 1L);
 
         // then
-        then(momentRepository).should(times(1)).save(any(Moment.class));
+        Moment savedMoment = captor.getValue();
+        assertAll(
+                () -> assertThat(savedMoment.getWriteType()).isEqualTo(WriteType.BASIC),
+                () -> then(momentRepository).should(times(1)).save(any(Moment.class))
+        );
+
     }
 
     @Test
@@ -120,12 +131,20 @@ class momentServiceTest {
         given(extraMomentCreatePolicy.canCreate(any(User.class))).willReturn(true);
         doNothing().when(rewardService).rewardForMoment(momenter, Reason.MOMENT_ADDITIONAL_USE, expect.getId());
 
+        ArgumentCaptor<Moment> captor = ArgumentCaptor.forClass(Moment.class);
+        verify(momentRepository).save(captor.capture());
+
         // when
         momentService.addExtraMoment(request, 1L);
 
         // then
-        then(momentRepository).should(times(1)).save(any(Moment.class));
-        then(rewardService).should(times(1)).rewardForMoment(momenter, Reason.MOMENT_ADDITIONAL_USE, expect.getId());
+        Moment savedMoment = captor.getValue();
+        assertAll(
+                () -> assertThat(savedMoment.getWriteType()).isEqualTo(WriteType.EXTRA),
+                () -> then(momentRepository).should(times(1)).save(any(Moment.class)),
+                () -> then(rewardService).should(times(1)).rewardForMoment(
+                        momenter, Reason.MOMENT_ADDITIONAL_USE, expect.getId())
+        );
     }
 
     @Test


### PR DESCRIPTION
# 📋 연관 이슈

- close #486 

# 🚀 작업 내용

- 1. 추가 코멘트 작성 API 호출 시 작성 타입 수정

추가 코멘트 작성 API 호출 시 DB에 작성 타입(write_type)을 BASIC으로 저장하고 있어 EXTRA를 저장하도록 변경하였습니다.
그리고 관련된 코드를 검증할 수 있도록 테스트 코드를 보충하였습니다.


- 2. Swagger summary (간단한) 수정

swagger summary가 어색하게 작성된 부분을 수정했습니다.
