### PR TITLE
[REFACTOR] 마이페이지 비밀번호 변경 API Controller 위치 변경

### DIFF
--- a/server/src/main/java/moment/user/application/UserService.java
+++ b/server/src/main/java/moment/user/application/UserService.java
@@ -6,7 +6,6 @@ import moment.global.exception.MomentException;
 import moment.user.domain.ProviderType;
 import moment.user.domain.User;
 import moment.user.dto.request.Authentication;
-import moment.user.dto.request.ChangePasswordRequest;
 import moment.user.dto.request.EmailConflictCheckRequest;
 import moment.user.dto.request.NicknameConflictCheckRequest;
 import moment.user.dto.request.UserCreateRequest;
@@ -77,30 +76,5 @@ public class UserService {
     public EmailConflictCheckResponse checkEmailConflictInBasicSignUp(EmailConflictCheckRequest request) {
         boolean existsByEmail = userRepository.existsByEmailAndProviderType(request.email(), ProviderType.EMAIL);
         return new EmailConflictCheckResponse(existsByEmail);
-    }
-
-    @Transactional
-    public void changePassword(ChangePasswordRequest request, Long userId) {
-        User user = userQueryService.getUserById(userId);
-
-        validateChangeablePasswordUser(user);
-        comparePasswordWithRepassword(request.newPassword(), request.checkedPassword());
-
-        String encodedChangePassword = passwordEncoder.encode(request.newPassword());
-        validateNotSameAsOldPassword(user, encodedChangePassword);
-
-        user.updatePassword(encodedChangePassword);
-    }
-
-    private void validateNotSameAsOldPassword(User user, String encodedChangePassword) {
-        if (user.checkPassword(encodedChangePassword)) {
-            throw new MomentException(ErrorCode.PASSWORD_SAME_AS_OLD);
-        }
-    }
-
-    private void validateChangeablePasswordUser(User user) {
-        if (!user.checkProviderType(ProviderType.EMAIL)) {
-            throw new MomentException(ErrorCode.PASSWORD_CHANGE_UNSUPPORTED_PROVIDER);
-        }
     }
 }

--- a/server/src/main/java/moment/user/presentation/MyPageController.java
+++ b/server/src/main/java/moment/user/presentation/MyPageController.java
@@ -9,16 +9,20 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import moment.auth.application.AuthService;
 import moment.auth.presentation.AuthenticationPrincipal;
 import moment.global.dto.response.ErrorResponse;
 import moment.global.dto.response.SuccessResponse;
 import moment.user.application.MyPageService;
 import moment.user.dto.request.Authentication;
+import moment.user.dto.request.ChangePasswordRequest;
 import moment.user.dto.request.NicknameChangeRequest;
 import moment.user.dto.response.MyPageProfileResponse;
 import moment.user.dto.response.MyRewardHistoryPageResponse;
 import moment.user.dto.response.NicknameChangeResponse;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -34,6 +38,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MyPageController {
 
     private final MyPageService myPageService;
+    private final AuthService authService;
 
     @Operation(summary = "마이페이지 프로필 조회", description = "마이페이지 프로필 정보를 조회합니다.")
     @ApiResponses({
@@ -109,5 +114,53 @@ public class MyPageController {
         NicknameChangeResponse response = myPageService.changeNickname(request, authentication.id());
         HttpStatus status = HttpStatus.OK;
         return ResponseEntity.status(status).body(SuccessResponse.of(status, response));
+    }
+
+    @Operation(summary = "비밀번호 변경", description = "사용자가 마이페이지 내에서 비밀번호를 변경합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "비밀번호 변경 성공"),
+            @ApiResponse(responseCode = "400", description = """
+                    - [U-005] 유효하지 않은 비밀번호 형식입니다.
+                    - [U-012] 새 비밀번호가 기존의 비밀번호와 동일합니다.
+                    - [U-013] 일반 회원가입 사용자가 아닌 경우 비밀번호를 변경할 수 없습니다.
+                    """,
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(responseCode = "404", description = """
+                    - [U-002] 존재하지 않는 사용자입니다.
+                    """,
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+    })
+    @PostMapping("/password")
+    public ResponseEntity<SuccessResponse<Void>> changePassword(
+            @Valid @RequestBody ChangePasswordRequest request,
+            @AuthenticationPrincipal Authentication authentication
+    ) {
+        myPageService.changePassword(request, authentication.id());
+
+        authService.logout(authentication.id());
+
+        ResponseCookie accessCookie = ResponseCookie.from("accessToken", null)
+                .sameSite("none")
+                .secure(true)
+                .httpOnly(true)
+                .path("/")
+                .maxAge(0)
+                .build();
+
+        ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", null)
+                .sameSite("none")
+                .secure(true)
+                .httpOnly(true)
+                .path("/")
+                .maxAge(0)
+                .build();
+
+        HttpStatus status = HttpStatus.OK;
+
+        return ResponseEntity.status(status)
+                .header(HttpHeaders.SET_COOKIE, accessCookie.toString())
+                .header(HttpHeaders.SET_COOKIE, refreshCookie.toString())
+                .body(SuccessResponse.of(status, null));
     }
 }

--- a/server/src/main/java/moment/user/presentation/UserController.java
+++ b/server/src/main/java/moment/user/presentation/UserController.java
@@ -13,7 +13,6 @@ import moment.global.dto.response.ErrorResponse;
 import moment.global.dto.response.SuccessResponse;
 import moment.user.application.UserService;
 import moment.user.dto.request.Authentication;
-import moment.user.dto.request.ChangePasswordRequest;
 import moment.user.dto.request.EmailConflictCheckRequest;
 import moment.user.dto.request.NicknameConflictCheckRequest;
 import moment.user.dto.request.UserCreateRequest;
@@ -21,9 +20,7 @@ import moment.user.dto.response.EmailConflictCheckResponse;
 import moment.user.dto.response.MomentRandomNicknameResponse;
 import moment.user.dto.response.NicknameConflictCheckResponse;
 import moment.user.dto.response.UserProfileResponse;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -134,42 +131,5 @@ public class UserController {
         EmailConflictCheckResponse response = userService.checkEmailConflictInBasicSignUp(request);
         HttpStatus status = HttpStatus.OK;
         return ResponseEntity.status(status).body(SuccessResponse.of(status, response));
-    }
-
-    @Operation(summary = "비밀번호 변경", description = "사용자가 마이페이지 내에서 비밀번호를 변경합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "비밀번호 변경 성공"),
-            @ApiResponse(responseCode = "400", description = """
-                    - [U-005] 유효하지 않은 비밀번호 형식입니다.
-                    - [U-012] 새 비밀번호가 기존의 비밀번호와 동일합니다.
-                    - [U-013] 일반 회원가입 사용자가 아닌 경우 비밀번호를 변경할 수 없습니다.
-                    """,
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(responseCode = "404", description = """
-                    - [U-002] 존재하지 않는 사용자입니다.
-                    """,
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-    })
-    @PostMapping("/my/password")
-    public ResponseEntity<SuccessResponse<Void>> changePassword(
-            @Valid @RequestBody ChangePasswordRequest request,
-            @AuthenticationPrincipal Authentication authentication
-    ) {
-        ResponseCookie cookie = ResponseCookie.from("token", null)
-                .sameSite("none")
-                .secure(true)
-                .httpOnly(true)
-                .path("/")
-                .maxAge(0)
-                .build();
-
-        HttpStatus status = HttpStatus.OK;
-
-        userService.changePassword(request, authentication.id());
-
-        return ResponseEntity.status(status)
-                .header(HttpHeaders.SET_COOKIE, cookie.toString())
-                .body(SuccessResponse.of(status, null));
     }
 }

--- a/server/src/test/java/moment/user/application/UserServiceTest.java
+++ b/server/src/test/java/moment/user/application/UserServiceTest.java
@@ -1,19 +1,9 @@
 package moment.user.application;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.times;
-
 import moment.global.exception.ErrorCode;
 import moment.global.exception.MomentException;
 import moment.user.domain.ProviderType;
 import moment.user.domain.User;
-import moment.user.dto.request.ChangePasswordRequest;
 import moment.user.dto.request.EmailConflictCheckRequest;
 import moment.user.dto.request.NicknameConflictCheckRequest;
 import moment.user.dto.request.UserCreateRequest;
@@ -28,7 +18,15 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayNameGeneration(ReplaceUnderscores.class)
@@ -180,51 +178,5 @@ class UserServiceTest {
         assertThatThrownBy(() -> userService.createRandomNickname())
                 .isInstanceOf(MomentException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NICKNAME_GENERATION_FAILED);
-    }
-
-    @Test
-    void 일반_회원가입_유저가_아닌_경우_비밀번호_변경_시_예외가_발생합니다() {
-        // given
-        User user = new User("mimi@icloud.com", "test123!@#", "미미", ProviderType.GOOGLE);
-        ReflectionTestUtils.setField(user, "id", 1L);
-        ChangePasswordRequest request = new ChangePasswordRequest("change123!@#", "change123!@#");
-
-        given(userQueryService.getUserById(any(Long.class))).willReturn(user);
-
-        // when & then
-        assertThatThrownBy(() -> userService.changePassword(request, user.getId()))
-                .isInstanceOf(MomentException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PASSWORD_CHANGE_UNSUPPORTED_PROVIDER);
-    }
-
-    @Test
-    void 새_비밀번호와_확인_비밀번호가_일치하지_않는_경우_예외가_발생합니다() {
-        // given
-        User user = new User("mimi@icloud.com", "test123!@#", "미미", ProviderType.EMAIL);
-        ReflectionTestUtils.setField(user, "id", 1L);
-        ChangePasswordRequest request = new ChangePasswordRequest("change123!@#", "change123");
-
-        given(userQueryService.getUserById(any(Long.class))).willReturn(user);
-
-        // when & then
-        assertThatThrownBy(() -> userService.changePassword(request, user.getId()))
-                .isInstanceOf(MomentException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PASSWORD_MISMATCHED);
-    }
-
-    @Test
-    void 새_비밀번호가_기존_비밀번호와_동일한_경우_예외가_발생합니다() {
-        // given
-        User user = new User("mimi@icloud.com", "test123!@#", "미미", ProviderType.EMAIL);
-        ReflectionTestUtils.setField(user, "id", 1L);
-        ChangePasswordRequest request = new ChangePasswordRequest("test123!@#", "test123!@#");
-
-        given(passwordEncoder.encode(request.newPassword())).willReturn("test123!@#");
-        given(userQueryService.getUserById(any(Long.class))).willReturn(user);
-
-        // when & then
-        assertThatThrownBy(() -> userService.changePassword(request, user.getId()))
-                .isInstanceOf(MomentException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PASSWORD_SAME_AS_OLD);
     }
 }

--- a/server/src/test/java/moment/user/presentation/UserControllerTest.java
+++ b/server/src/test/java/moment/user/presentation/UserControllerTest.java
@@ -1,8 +1,5 @@
 package moment.user.presentation;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.ContentType;
@@ -11,7 +8,6 @@ import moment.common.DatabaseCleaner;
 import moment.global.dto.response.SuccessResponse;
 import moment.user.domain.ProviderType;
 import moment.user.domain.User;
-import moment.user.dto.request.ChangePasswordRequest;
 import moment.user.dto.request.EmailConflictCheckRequest;
 import moment.user.dto.request.NicknameConflictCheckRequest;
 import moment.user.dto.request.UserCreateRequest;
@@ -29,18 +25,17 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class UserControllerTest {
-
-    @Autowired
-    PasswordEncoder passwordEncoder;
 
     @LocalServerPort
     private int port;
@@ -176,40 +171,6 @@ class UserControllerTest {
         assertAll(
                 () -> assertThat(response.status()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(response.data()).isEqualTo(expect)
-        );
-    }
-
-
-    @Test
-    void 마이페이지_내에서_유저_비밀번호를_변경한다() {
-        // given
-        String nickname = "mimi";
-        String encodePassword = passwordEncoder.encode("test123!@#");
-        User user = userRepository.save(new User("mimi@icloud.com", encodePassword, nickname, ProviderType.EMAIL));
-        String token = tokenManager.createAccessToken(user.getId(), user.getEmail());
-
-        ChangePasswordRequest request = new ChangePasswordRequest("change123!@#", "change123!@#");
-
-        // when
-        SuccessResponse<Void> response = RestAssured.given().log().all()
-                .contentType(ContentType.JSON)
-                .body(request)
-                .cookie("accessToken", token)
-                .when().post("/api/v1/users/my/password")
-                .then().log().all()
-                .statusCode(HttpStatus.OK.value())
-                .extract().as(new TypeRef<>() {
-                });
-
-        User changePasswordUser = userRepository.findById(user.getId()).get();
-
-        // then
-        assertAll(
-                () -> assertThat(response.status()).isEqualTo(HttpStatus.OK.value()),
-                () -> assertThat(
-                        passwordEncoder.matches(user.getPassword(), changePasswordUser.getPassword())).isFalse(),
-                () -> assertThat(
-                        passwordEncoder.matches(request.newPassword(), changePasswordUser.getPassword())).isTrue()
         );
     }
 }


### PR DESCRIPTION
# 📋 연관 이슈

- close #508 

# 🚀 작업 내용

- 1. 마이페이지 비밀번호 변경 API Controller 위치 변경

# 💬 리뷰 중점 사항

- 마이페이지 비밀번호 변경 API 위치를 UserController에서 MyPageController에게 위임했습니다.
- 위치를 변경하면서 관련 서비스 및 테스트 코드를 수정하였습니다.
