### PR TITLE
[FEAT] heartbeat 메서드 로깅 제외

### DIFF
--- a/server/src/main/java/moment/global/logging/NoLogging.java
+++ b/server/src/main/java/moment/global/logging/NoLogging.java
@@ -1,0 +1,11 @@
+package moment.global.logging;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NoLogging {
+}

--- a/server/src/main/java/moment/global/logging/ServiceLogAspect.java
+++ b/server/src/main/java/moment/global/logging/ServiceLogAspect.java
@@ -14,11 +14,11 @@ import org.springframework.stereotype.Component;
 @Profile({"test", "dev"})
 public class ServiceLogAspect {
 
-    @Pointcut("@within(org.springframework.stereotype.Service) && !within(*..*QueryService)")
-    public void serviceWithoutQuery() {
+    @Pointcut("@within(org.springframework.stereotype.Service) && !within(*..*QueryService) && !@annotation(moment.global.logging.NoLogging)")
+    public void serviceWithoutQueryAndNoLogging() {
     }
 
-    @Around("serviceWithoutQuery()")
+    @Around("serviceWithoutQueryAndNoLogging()")
     public Object logService(ProceedingJoinPoint joinPoint) throws Throwable {
         log.info("start service: [{}]", joinPoint.getSignature().getName());
 

--- a/server/src/main/java/moment/notification/application/SseNotificationService.java
+++ b/server/src/main/java/moment/notification/application/SseNotificationService.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.extern.slf4j.Slf4j;
+import moment.global.logging.NoLogging;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -42,6 +43,7 @@ public class SseNotificationService {
     }
 
     @Scheduled(fixedRate = 45_000) // 45초마다 실행
+    @NoLogging
     public void sendHeartbeat() {
         emitters.forEach((userId, emitter) -> {
             try {


### PR DESCRIPTION
# 📋 연관 이슈

- close #514 

# 🚀 작업 내용

- 1. 서비스 클래스 내에서 사용할 수 있는 로깅 제외 어노테이션 구현했습니다. 
- 2. heartbeat 메서드를 로깅에서 제외했습니다.



