### PR TITLE
[REFACTOR] 나만의 모음집 UI/UX 개선, 버그 수정

### DIFF
--- a/client/src/app/styles/theme.ts
+++ b/client/src/app/styles/theme.ts
@@ -13,6 +13,7 @@ export const theme = {
     'yellow-500': '#F1C40F',
     'yellow-300': '#F4D03F',
     'yellow-300_10': 'color-mix(in srgb, #F4D03F 10%, transparent)',
+    'yellow-300_30': 'color-mix(in srgb, #F4D03F 30%, transparent)',
     'yellow-300_50': 'color-mix(in srgb, #F4D03F 50%, transparent)',
     'yellow-300_80': 'color-mix(in srgb, #F4D03F 80%, transparent)',
     'emerald-500': '#10B981',

--- a/client/src/features/auth/ui/AuthButton.styles.ts
+++ b/client/src/features/auth/ui/AuthButton.styles.ts
@@ -23,7 +23,7 @@ export const AuthButtonContainer = styled.div`
 `;
 
 export const AuthButtonText = styled.p`
-  color: ${({ theme }) => theme.colors['yellow-300']};
+  color: ${({ theme }) => theme.colors.white};
 `;
 export const DropdownContainer = styled.div<{ $isOpen: boolean }>`
   position: absolute;

--- a/client/src/features/comment/ui/MyCommentsCard.styles.ts
+++ b/client/src/features/comment/ui/MyCommentsCard.styles.ts
@@ -22,11 +22,6 @@ export const TitleWrapper = styled.div`
   gap: 8px;
 `;
 
-export const TimeStamp = styled.span`
-  font-size: 14px;
-  color: ${({ theme }) => theme.colors['gray-400']};
-`;
-
 export const Title = styled.span`
   font-size: ${({ theme }) => theme.typography.title.fontSize.small};
   font-weight: ${({ theme }) => theme.typography.fontWeight.large};

--- a/client/src/features/comment/ui/MyCommentsCard.styles.ts
+++ b/client/src/features/comment/ui/MyCommentsCard.styles.ts
@@ -7,6 +7,12 @@ export const PostCommentsPageContainer = styled.section`
   margin: 20px;
 `;
 
+export const MyMomentContent = styled.p`
+  font-size: 1.1rem;
+  text-align: left;
+  color: ${({ theme }) => theme.colors['gray-400']};
+`;
+
 export const TitleContainer = styled.div`
   width: 100%;
   display: flex;
@@ -46,4 +52,10 @@ export const EchoContainer = styled.div`
   display: flex;
   align-items: center;
   gap: 10px;
+`;
+
+export const NoEchoContent = styled.p`
+  text-align: center;
+  font-size: 1rem;
+  color: ${({ theme }) => theme.colors['gray-400']};
 `;

--- a/client/src/features/comment/ui/MyCommentsCard.tsx
+++ b/client/src/features/comment/ui/MyCommentsCard.tsx
@@ -8,6 +8,7 @@ import { EchoTypeKey } from '@/features/echo/type/echos';
 import { useToast } from '@/shared/hooks';
 import { WriterInfo } from '@/widgets/writerInfo';
 import { Echo } from '@/features/echo/ui/Echo';
+import { WriteTime } from '@/shared/ui/writeTime';
 
 const ECHO_REWARD_POINT = 3;
 
@@ -32,7 +33,7 @@ export const MyCommentsCard = ({ myComment }: { myComment: CommentWithNotificati
         title={
           <S.TitleWrapper>
             <WriterInfo writer={myComment.moment.nickName} level={myComment.moment.level} />
-            <S.TimeStamp>{new Date(myComment.createdAt).toLocaleDateString()}</S.TimeStamp>
+            <WriteTime date={myComment.createdAt} />
           </S.TitleWrapper>
         }
         subtitle={myComment.moment.content}

--- a/client/src/features/comment/ui/MyCommentsCard.tsx
+++ b/client/src/features/comment/ui/MyCommentsCard.tsx
@@ -28,9 +28,12 @@ export const MyCommentsCard = ({ myComment }: { myComment: CommentWithNotificati
             <WriteTime date={myComment.createdAt} />
           </S.TitleWrapper>
         }
-        subtitle={myComment.moment.content}
+        subtitle={''}
       />
       <Card.Content>
+        <S.ContentContainer>
+          <S.MyMomentContent>{myComment.moment.content}</S.MyMomentContent>
+        </S.ContentContainer>
         <S.ContentContainer>
           <S.TitleContainer>
             <Send size={20} color={theme.colors['yellow-500']} />
@@ -44,9 +47,13 @@ export const MyCommentsCard = ({ myComment }: { myComment: CommentWithNotificati
             <p>받은 에코</p>
           </S.TitleContainer>
           <S.EchoContainer>
-            {(myComment.echos || []).map(echo => (
-              <Echo key={echo.id} echo={echo.echoType as EchoTypeKey} />
-            ))}
+            {myComment.echos && myComment.echos.length > 0 ? (
+              myComment.echos.map(echo => (
+                <Echo key={echo.id} echo={echo.echoType as EchoTypeKey} />
+              ))
+            ) : (
+              <S.NoEchoContent>아직 받은 에코가 없습니다.</S.NoEchoContent>
+            )}
           </S.EchoContainer>
           {!myComment.read && <Button onClick={handleCommentOpen} title="확인" />}
         </S.ContentContainer>

--- a/client/src/features/comment/ui/MyCommentsCard.tsx
+++ b/client/src/features/comment/ui/MyCommentsCard.tsx
@@ -5,25 +5,17 @@ import * as S from './MyCommentsCard.styles';
 import type { CommentWithNotifications } from '../types/commentsWithNotifications';
 import { useReadNotifications } from '@/features/notification/hooks/useReadNotifications';
 import { EchoTypeKey } from '@/features/echo/type/echos';
-import { useToast } from '@/shared/hooks';
 import { WriterInfo } from '@/widgets/writerInfo';
 import { Echo } from '@/features/echo/ui/Echo';
 import { WriteTime } from '@/shared/ui/writeTime';
 
-const ECHO_REWARD_POINT = 3;
-
 export const MyCommentsCard = ({ myComment }: { myComment: CommentWithNotifications }) => {
-  const { showSuccess } = useToast();
   const { handleReadNotifications, isLoading: isReadingNotification } = useReadNotifications();
 
   const handleCommentOpen = () => {
     if (myComment.read || isReadingNotification) return;
     if (myComment.notificationId) {
       handleReadNotifications(myComment.notificationId);
-
-      if (myComment.echos && myComment.echos.length > 0) {
-        showSuccess(`별조각 ${ECHO_REWARD_POINT} 개를 획득했습니다!`);
-      }
     }
   };
 

--- a/client/src/features/comment/ui/TodayCommentForm.styles.ts
+++ b/client/src/features/comment/ui/TodayCommentForm.styles.ts
@@ -26,17 +26,6 @@ export const LevelImage = styled.img`
   object-fit: contain;
 `;
 
-export const TimeWrapper = styled.div`
-  ${({ theme }) => css`
-    color: ${theme.colors['gray-400']};
-  `}
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 16px;
-  font-weight: 500;
-`;
-
 export const RefreshButton = styled.button`
   display: flex;
   align-items: center;

--- a/client/src/features/comment/ui/TodayCommentForm.tsx
+++ b/client/src/features/comment/ui/TodayCommentForm.tsx
@@ -2,11 +2,11 @@ import { LEVEL_MAP } from '@/app/layout/data/navItems';
 import { useCommentableMomentsQuery } from '@/features/comment/api/useCommentableMomentsQuery';
 import { Card, NotFound, SimpleCard } from '@/shared/ui';
 import { CommonSkeletonCard } from '@/shared/ui/skeleton';
-import { formatRelativeTime } from '@/shared/utils/formatRelativeTime';
-import { AlertCircle, Clock, RotateCcw } from 'lucide-react';
+import { AlertCircle, RotateCcw } from 'lucide-react';
 import * as S from './TodayCommentForm.styles';
 import { TodayCommentWriteContent } from './TodayCommentWriteContent';
 import { useCheckIfLoggedInQuery } from '@/features/auth/hooks/useCheckIfLoggedInQuery';
+import { WriteTime } from '@/shared/ui/writeTime';
 
 export function TodayCommentForm() {
   const { data: isLoggedIn, isLoading: isLoggedInLoading } = useCheckIfLoggedInQuery();
@@ -32,10 +32,7 @@ export function TodayCommentForm() {
                 <S.NotLoggedNickname>푸르른 물방울의 테리우스</S.NotLoggedNickname>
               </S.UserInfoWrapper>
               <S.ActionWrapper>
-                <S.TimeWrapper>
-                  <Clock size={16} />
-                  9시간 전
-                </S.TimeWrapper>
+                <WriteTime date="9시간 전" />
               </S.ActionWrapper>
             </S.TitleWrapper>
           }
@@ -80,10 +77,7 @@ export function TodayCommentForm() {
               <span>{momentData.nickname}</span>
             </S.UserInfoWrapper>
             <S.ActionWrapper>
-              <S.TimeWrapper>
-                <Clock size={16} />
-                {formatRelativeTime(momentData.createdAt)}
-              </S.TimeWrapper>
+              <WriteTime date={momentData.createdAt} />
               <S.RefreshButton onClick={() => refetch()}>
                 <RotateCcw size={28} />
               </S.RefreshButton>

--- a/client/src/features/echo/hooks/useEchoMutation.ts
+++ b/client/src/features/echo/hooks/useEchoMutation.ts
@@ -10,7 +10,7 @@ export const useEchoMutation = () => {
     mutationFn: sendEcho,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['moments'] });
-      showSuccess('에코가 성공적으로 전송되었습니다! 별조각 3개를 얻으셨습니다.');
+      showSuccess('에코가 성공적으로 전송되었습니다!');
     },
     onError: () => {
       showError('에코 전송에 실패했습니다. 다시 시도해주세요.');

--- a/client/src/features/echo/hooks/useEchoSelection.ts
+++ b/client/src/features/echo/hooks/useEchoSelection.ts
@@ -20,12 +20,13 @@ export const useEchoSelection = () => {
 
   const clearSelection = () => setSelectedEchos(new Set());
   const isSelected = (echoType: EchoKey) => selectedEchos.has(echoType);
+  const hasSelection = selectedEchos.size > 0;
 
   return {
     selectedEchos,
     toggleEcho,
     clearSelection,
     isSelected,
-    hasSelection: selectedEchos.size > 0,
+    hasSelection,
   };
 };

--- a/client/src/features/echo/ui/EchoButton.tsx
+++ b/client/src/features/echo/ui/EchoButton.tsx
@@ -1,28 +1,14 @@
 import styled from '@emotion/styled';
 
-export const EchoButton = ({
-  title,
-  onClick: handleClick,
-  isSelected,
-  isAlreadySent,
-  isDisabled = false,
-}: {
+interface EchoButton {
   title: string;
   onClick: () => void;
   isSelected: boolean;
-  isAlreadySent?: boolean | undefined;
-  isDisabled?: boolean;
-}) => {
+}
+
+export const EchoButton = ({ title, onClick: handleClick, isSelected }: EchoButton) => {
   return (
-    <EchoButtonStyle
-      type="button"
-      onClick={handleClick}
-      $isSelected={isSelected}
-      $isDisabled={isDisabled}
-      $isAlreadySent={isAlreadySent}
-      disabled={isDisabled}
-      aria-pressed={isSelected || !!isAlreadySent}
-    >
+    <EchoButtonStyle onClick={handleClick} $isSelected={isSelected} aria-pressed={isSelected}>
       {title}
     </EchoButtonStyle>
   );
@@ -30,20 +16,18 @@ export const EchoButton = ({
 
 const EchoButtonStyle = styled.button<{
   $isSelected: boolean;
-  $isDisabled: boolean;
-  $isAlreadySent: boolean | undefined;
 }>`
   border: 1px solid
-    ${({ $isSelected, $isAlreadySent, theme }) => {
-      if ($isSelected || $isAlreadySent) return theme.colors['yellow-500'];
+    ${({ $isSelected, theme }) => {
+      if ($isSelected) return theme.colors['yellow-500'];
       return theme.colors['gray-400'];
     }};
-  color: ${({ $isSelected, $isAlreadySent, theme }) => {
-    if ($isSelected || $isAlreadySent) return theme.colors['yellow-500'];
+  color: ${({ $isSelected, theme }) => {
+    if ($isSelected) return theme.colors['yellow-500'];
     return theme.colors['gray-400'];
   }};
   border-radius: 25px;
   padding: 4px 16px;
   font-size: 1rem;
-  cursor: ${({ $isDisabled }) => ($isDisabled ? 'not-allowed' : 'pointer')};
+  cursor: pointer;
 `;

--- a/client/src/features/echo/ui/SendEchoButton.tsx
+++ b/client/src/features/echo/ui/SendEchoButton.tsx
@@ -1,40 +1,25 @@
 import { CustomTheme, theme } from '@/app/styles/theme';
-import { useEchoMutation } from '../hooks/useEchoMutation';
 import { Button } from '@/shared/ui';
-import { EchoTypeKey } from '../type/echos';
 
 interface SendEchoButtonProps {
-  commentId: number;
-  selectedEchos: Set<EchoTypeKey>;
-  hasSelection: boolean;
-  isDisabled?: boolean;
+  isDisabled: boolean;
+  onClick: () => void;
 }
 
-export const SendEchoButton = ({
-  commentId,
-  selectedEchos,
-  hasSelection,
-  isDisabled,
-}: SendEchoButtonProps) => {
-  const { mutateAsync: sendEchos } = useEchoMutation();
-
-  const handleSendEchos = () => {
-    sendEchos({ echoTypes: Array.from(selectedEchos), commentId: commentId });
-  };
-
+export const SendEchoButton = ({ isDisabled, onClick: handleSendEchos }: SendEchoButtonProps) => {
   return (
     <Button
       title="전송"
       variant="primary"
-      disabled={!hasSelection || isDisabled}
-      externalVariant={() => buttonVariant(theme, hasSelection)}
+      disabled={isDisabled}
+      externalVariant={() => buttonVariant(theme, isDisabled)}
       onClick={handleSendEchos}
     />
   );
 };
 
-const buttonVariant = (theme: CustomTheme, isSelected: boolean) => `
-  width: 100%;
-  color: ${theme.colors['white']};
-  background-color: ${isSelected ? theme.colors['gray-600'] : theme.colors['gray-600_20']};
-`;
+const buttonVariant = (theme: CustomTheme, isDisabled: boolean) => `
+  width: 90%;
+  color: ${theme.colors['gray-200']};
+  background-color: ${isDisabled ? theme.colors['gray-600_20'] : theme.colors['yellow-300_30']};
+  `;

--- a/client/src/features/echo/ui/SendEchoForm.styles.ts
+++ b/client/src/features/echo/ui/SendEchoForm.styles.ts
@@ -1,0 +1,23 @@
+import styled from '@emotion/styled';
+
+export const TitleContainer = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 10px;
+`;
+
+export const EchoContainer = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+`;
+
+export const EchoButtonContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;

--- a/client/src/features/echo/ui/SendEchoForm.tsx
+++ b/client/src/features/echo/ui/SendEchoForm.tsx
@@ -1,0 +1,61 @@
+import * as S from './SendEchoForm.styles';
+import { Heart } from 'lucide-react';
+import { theme } from '@/app/styles/theme';
+import { ECHO_TYPE } from '../const/echoType';
+import { EchoButton } from './EchoButton';
+import { SendEchoButton } from './SendEchoButton';
+import type { EchoTypeKey } from '../type/echos';
+import type { Comment } from '@/features/moment/types/moments';
+import { Echo } from './Echo';
+import { useEchoSelection } from '../hooks/useEchoSelection';
+import { useEchoMutation } from '../hooks/useEchoMutation';
+
+interface SendEchoForm {
+  currentComment: Comment;
+}
+
+export const SendEchoForm = ({ currentComment }: SendEchoForm) => {
+  const { selectedEchos, toggleEcho, clearSelection, isSelected, hasSelection } =
+    useEchoSelection();
+
+  const { mutateAsync: sendEchos } = useEchoMutation();
+
+  const handleSendEchos = () => {
+    sendEchos({ echoTypes: Array.from(selectedEchos), commentId: currentComment.id });
+    clearSelection();
+  };
+
+  const echoType = currentComment?.echos.map(echo => echo.echoType);
+  const hasAnyEcho = echoType && echoType.length > 0;
+
+  return (
+    <S.EchoContainer>
+      <S.TitleContainer>
+        <Heart size={16} color={theme.colors['yellow-500']} />
+        <span>{hasAnyEcho ? '보낸 에코' : '에코 보내기'}</span>
+      </S.TitleContainer>
+
+      {hasAnyEcho ? (
+        <S.EchoButtonContainer>
+          {currentComment.echos.map(echo => (
+            <Echo key={echo.id} echo={echo.echoType as EchoTypeKey} />
+          ))}
+        </S.EchoButtonContainer>
+      ) : (
+        <>
+          <S.EchoButtonContainer>
+            {Object.entries(ECHO_TYPE).map(([key, title]) => (
+              <EchoButton
+                key={key}
+                title={title}
+                onClick={() => toggleEcho(key as EchoTypeKey)}
+                isSelected={isSelected(key as EchoTypeKey)}
+              />
+            ))}
+          </S.EchoButtonContainer>
+          <SendEchoButton isDisabled={!hasSelection} onClick={handleSendEchos} />
+        </>
+      )}
+    </S.EchoContainer>
+  );
+};

--- a/client/src/features/moment/types/moments.ts
+++ b/client/src/features/moment/types/moments.ts
@@ -18,7 +18,7 @@ export interface MyMomentsItem {
   comments: Comment[] | null;
 }
 
-interface Comment {
+export interface Comment {
   id: number;
   content: string;
   nickname: string;

--- a/client/src/features/moment/ui/MyMomentsCard.styles.ts
+++ b/client/src/features/moment/ui/MyMomentsCard.styles.ts
@@ -148,18 +148,6 @@ export const Title = styled.span`
   color: ${({ theme }) => theme.colors.white};
 `;
 
-export const EchoContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 10px;
-`;
-export const EchoButtonContainer = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 8px;
-`;
-
 export const NavigationContainer = styled.div`
   display: flex;
   justify-content: space-between;

--- a/client/src/features/moment/ui/MyMomentsCard.styles.ts
+++ b/client/src/features/moment/ui/MyMomentsCard.styles.ts
@@ -129,11 +129,6 @@ export const TitleWrapper = styled.div`
   gap: 4px;
 `;
 
-export const TimeStamp = styled.span`
-  font-size: 14px;
-  color: ${({ theme }) => theme.colors['gray-400']};
-`;
-
 export const Title = styled.span`
   font-size: ${({ theme }) => theme.typography.title.fontSize.small};
   font-weight: ${({ theme }) => theme.typography.fontWeight.large};

--- a/client/src/features/moment/ui/MyMomentsCard.styles.ts
+++ b/client/src/features/moment/ui/MyMomentsCard.styles.ts
@@ -31,6 +31,19 @@ export const MyMomentsCard = styled.div<{ $shadow: boolean; $hasComment: boolean
   }
 `;
 
+export const MyMomentsTitleWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+export const CommentCountWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: ${({ theme }) => theme.colors['gray-400']};
+`;
+
 export const MyMomentsContent = styled.p`
   height: 100%;
   width: 100%;

--- a/client/src/features/moment/ui/MyMomentsCard.tsx
+++ b/client/src/features/moment/ui/MyMomentsCard.tsx
@@ -1,14 +1,8 @@
 import { useMemo } from 'react';
-import { theme } from '@/app/styles/theme';
-import { ECHO_TYPE } from '@/features/echo/const/echoType';
 import { useEchoSelection } from '@/features/echo/hooks/useEchoSelection';
-import { EchoTypeKey } from '@/features/echo/type/echos';
-import { EchoButton } from '@/features/echo/ui/EchoButton';
-import { SendEchoButton } from '@/features/echo/ui/SendEchoButton';
-import { Echo } from '@/features/echo/ui/Echo'; // Echo 컴포넌트 import 추가
 import { useModal } from '@/shared/hooks/useModal';
 import { Modal } from '@/shared/ui/modal/Modal';
-import { ChevronLeft, ChevronRight, Heart, Mail } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Mail } from 'lucide-react';
 import { useReadNotifications } from '../../notification/hooks/useReadNotifications';
 import { useCommentNavigation } from '../hook/useCommentNavigation';
 import type { MomentWithNotifications } from '../types/momentsWithNotifications';
@@ -16,23 +10,20 @@ import * as S from './MyMomentsCard.styles';
 import { WriterInfo } from '@/widgets/writerInfo';
 import { useNotificationsQuery } from '@/features/notification/hooks/useNotificationsQuery';
 import { WriteTime } from '@/shared/ui/writeTime';
+import { SendEchoForm } from '@/features/echo/ui/SendEchoForm';
 
 export const MyMomentsCard = ({ myMoment }: { myMoment: MomentWithNotifications }) => {
   const { handleReadNotifications, isLoading: isReadingNotification } = useReadNotifications();
   const { handleOpen, handleClose, isOpen } = useModal();
-  const { selectedEchos, toggleEcho, clearSelection, isSelected, hasSelection } =
-    useEchoSelection();
+  useEchoSelection();
   const { data: notifications } = useNotificationsQuery();
   const sortedComments = useMemo(() => {
     return myMoment.comments?.slice().reverse() || [];
   }, [myMoment.comments]);
   const navigation = useCommentNavigation(sortedComments?.length || 0);
   const currentComment = sortedComments?.[navigation.currentIndex];
-  const echoType = currentComment?.echos.map(echo => echo.echoType);
-  const hasAnyEcho = echoType && echoType.length > 0;
 
   const handleModalClose = () => {
-    clearSelection();
     navigation.reset();
     handleClose();
   };
@@ -116,42 +107,7 @@ export const MyMomentsCard = ({ myMoment }: { myMoment: MomentWithNotifications 
                       </S.CommentNavigationButton>
                     )}
                   </S.CommentContainer>
-
-                  <S.EchoContainer>
-                    <S.TitleContainer>
-                      <Heart size={16} color={theme.colors['yellow-500']} />
-                      <span>{hasAnyEcho ? '보낸 에코' : '에코 보내기'}</span>
-                    </S.TitleContainer>
-
-                    {hasAnyEcho ? (
-                      <S.EchoButtonContainer>
-                        {currentComment.echos.map((echo, index) => (
-                          <Echo key={`${echo.id}-${index}`} echo={echo.echoType as EchoTypeKey} />
-                        ))}
-                      </S.EchoButtonContainer>
-                    ) : (
-                      <>
-                        <S.EchoButtonContainer>
-                          {Object.entries(ECHO_TYPE).map(([key, title]) => (
-                            <EchoButton
-                              key={key}
-                              onClick={() => toggleEcho(key as EchoTypeKey)}
-                              title={title}
-                              isSelected={isSelected(key as EchoTypeKey)}
-                              isAlreadySent={false}
-                              isDisabled={false}
-                            />
-                          ))}
-                        </S.EchoButtonContainer>
-                        <SendEchoButton
-                          commentId={currentComment.id || 0}
-                          selectedEchos={selectedEchos}
-                          hasSelection={hasSelection}
-                          isDisabled={false}
-                        />
-                      </>
-                    )}
-                  </S.EchoContainer>
+                  <SendEchoForm currentComment={currentComment} />
                 </S.MyMomentsModalContent>
               </>
             )}

--- a/client/src/features/moment/ui/MyMomentsCard.tsx
+++ b/client/src/features/moment/ui/MyMomentsCard.tsx
@@ -5,6 +5,7 @@ import { useEchoSelection } from '@/features/echo/hooks/useEchoSelection';
 import { EchoTypeKey } from '@/features/echo/type/echos';
 import { EchoButton } from '@/features/echo/ui/EchoButton';
 import { SendEchoButton } from '@/features/echo/ui/SendEchoButton';
+import { Echo } from '@/features/echo/ui/Echo'; // Echo 컴포넌트 import 추가
 import { useModal } from '@/shared/hooks/useModal';
 import { Modal } from '@/shared/ui/modal/Modal';
 import { ChevronLeft, ChevronRight, Heart, Mail } from 'lucide-react';
@@ -25,8 +26,8 @@ export const MyMomentsCard = ({ myMoment }: { myMoment: MomentWithNotifications 
   const sortedComments = useMemo(() => {
     return myMoment.comments?.slice().reverse() || [];
   }, [myMoment.comments]);
-  const navigation = useCommentNavigation(sortedComments.length);
-  const currentComment = sortedComments[navigation.currentIndex];
+  const navigation = useCommentNavigation(sortedComments?.length || 0);
+  const currentComment = sortedComments?.[navigation.currentIndex];
   const echoType = currentComment?.echos.map(echo => echo.echoType);
   const hasAnyEcho = echoType && echoType.length > 0;
 
@@ -121,30 +122,34 @@ export const MyMomentsCard = ({ myMoment }: { myMoment: MomentWithNotifications 
                       <Heart size={16} color={theme.colors['yellow-500']} />
                       <span>{hasAnyEcho ? '보낸 에코' : '에코 보내기'}</span>
                     </S.TitleContainer>
-                    <S.EchoButtonContainer>
-                      {Object.entries(ECHO_TYPE).map(([key, title]) => {
-                        const isAlreadySent = currentComment.echos
-                          .map(echo => echo.echoType)
-                          .includes(key as EchoTypeKey);
-                        return (
-                          <EchoButton
-                            key={key}
-                            onClick={() => toggleEcho(key as EchoTypeKey)}
-                            title={title}
-                            isSelected={isSelected(key as EchoTypeKey)}
-                            isAlreadySent={isAlreadySent}
-                            isDisabled={hasAnyEcho}
-                          />
-                        );
-                      })}
-                    </S.EchoButtonContainer>
-                    {!hasAnyEcho && (
-                      <SendEchoButton
-                        commentId={currentComment.id || 0}
-                        selectedEchos={selectedEchos}
-                        hasSelection={hasSelection}
-                        isDisabled={hasAnyEcho}
-                      />
+
+                    {hasAnyEcho ? (
+                      <S.EchoButtonContainer>
+                        {currentComment.echos.map((echo, index) => (
+                          <Echo key={`${echo.id}-${index}`} echo={echo.echoType as EchoTypeKey} />
+                        ))}
+                      </S.EchoButtonContainer>
+                    ) : (
+                      <>
+                        <S.EchoButtonContainer>
+                          {Object.entries(ECHO_TYPE).map(([key, title]) => (
+                            <EchoButton
+                              key={key}
+                              onClick={() => toggleEcho(key as EchoTypeKey)}
+                              title={title}
+                              isSelected={isSelected(key as EchoTypeKey)}
+                              isAlreadySent={false}
+                              isDisabled={false}
+                            />
+                          ))}
+                        </S.EchoButtonContainer>
+                        <SendEchoButton
+                          commentId={currentComment.id || 0}
+                          selectedEchos={selectedEchos}
+                          hasSelection={hasSelection}
+                          isDisabled={false}
+                        />
+                      </>
                     )}
                   </S.EchoContainer>
                 </S.MyMomentsModalContent>

--- a/client/src/features/moment/ui/MyMomentsCard.tsx
+++ b/client/src/features/moment/ui/MyMomentsCard.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { theme } from '@/app/styles/theme';
 import { ECHO_TYPE } from '@/features/echo/const/echoType';
 import { useEchoSelection } from '@/features/echo/hooks/useEchoSelection';
@@ -21,8 +22,14 @@ export const MyMomentsCard = ({ myMoment }: { myMoment: MomentWithNotifications 
   const { selectedEchos, toggleEcho, clearSelection, isSelected, hasSelection } =
     useEchoSelection();
   const { data: notifications } = useNotificationsQuery();
-  const comments = myMoment.comments;
-  const navigation = useCommentNavigation(comments?.length || 0);
+  const sortedComments = useMemo(() => {
+    return myMoment.comments?.slice().reverse() || [];
+  }, [myMoment.comments]);
+  const navigation = useCommentNavigation(sortedComments.length);
+  const currentComment = sortedComments[navigation.currentIndex];
+  const echoType = currentComment?.echos.map(echo => echo.echoType);
+  const hasAnyEcho = echoType && echoType.length > 0;
+
   const handleModalClose = () => {
     clearSelection();
     navigation.reset();
@@ -47,9 +54,6 @@ export const MyMomentsCard = ({ myMoment }: { myMoment: MomentWithNotifications 
   };
 
   const hasComments = myMoment.comments ? myMoment.comments.length > 0 : false;
-  const currentComment = comments?.[navigation.currentIndex];
-  const echoType = currentComment?.echos.map(echo => echo.echoType);
-  const hasAnyEcho = echoType && echoType.length > 0;
 
   return (
     <>
@@ -62,7 +66,7 @@ export const MyMomentsCard = ({ myMoment }: { myMoment: MomentWithNotifications 
         <S.MyMomentsTitleWrapper>
           <S.CommentCountWrapper>
             <Mail size={16} />
-            <span>{comments?.length}</span>
+            <span>{sortedComments?.length}</span>
           </S.CommentCountWrapper>
           <WriteTime date={myMoment.createdAt} />
         </S.MyMomentsTitleWrapper>
@@ -87,7 +91,7 @@ export const MyMomentsCard = ({ myMoment }: { myMoment: MomentWithNotifications 
                     </S.WriterInfoWrapper>
 
                     <S.CommentIndicator>
-                      {navigation.currentIndex + 1} / {comments?.length || 0}
+                      {navigation.currentIndex + 1} / {sortedComments?.length || 0}
                     </S.CommentIndicator>
                     <S.TitleWrapper>
                       <WriteTime date={currentComment.createdAt} />

--- a/client/src/features/moment/ui/MyMomentsCard.tsx
+++ b/client/src/features/moment/ui/MyMomentsCard.tsx
@@ -13,15 +13,16 @@ import { useCommentNavigation } from '../hook/useCommentNavigation';
 import type { MomentWithNotifications } from '../types/momentsWithNotifications';
 import * as S from './MyMomentsCard.styles';
 import { WriterInfo } from '@/widgets/writerInfo';
+import { useNotificationsQuery } from '@/features/notification/hooks/useNotificationsQuery';
 
 export const MyMomentsCard = ({ myMoment }: { myMoment: MomentWithNotifications }) => {
   const { handleReadNotifications, isLoading: isReadingNotification } = useReadNotifications();
   const { handleOpen, handleClose, isOpen } = useModal();
   const { selectedEchos, toggleEcho, clearSelection, isSelected, hasSelection } =
     useEchoSelection();
+  const { data: notifications } = useNotificationsQuery();
   const comments = myMoment.comments;
   const navigation = useCommentNavigation(comments?.length || 0);
-
   const handleModalClose = () => {
     clearSelection();
     navigation.reset();
@@ -32,9 +33,17 @@ export const MyMomentsCard = ({ myMoment }: { myMoment: MomentWithNotifications 
     handleOpen();
     navigation.reset();
     if (myMoment.read || isReadingNotification) return;
-    if (myMoment.notificationId) {
-      handleReadNotifications(myMoment.notificationId);
-    }
+
+    const unreadMomentNotifications =
+      notifications?.data.filter(
+        notification => notification.targetId === myMoment.id && !notification.isRead,
+      ) || [];
+
+    unreadMomentNotifications.forEach(notification => {
+      if (notification.id) {
+        handleReadNotifications(notification.id);
+      }
+    });
   };
 
   const hasComments = myMoment.comments ? myMoment.comments.length > 0 : false;

--- a/client/src/features/moment/ui/MyMomentsCard.tsx
+++ b/client/src/features/moment/ui/MyMomentsCard.tsx
@@ -6,7 +6,7 @@ import { EchoButton } from '@/features/echo/ui/EchoButton';
 import { SendEchoButton } from '@/features/echo/ui/SendEchoButton';
 import { useModal } from '@/shared/hooks/useModal';
 import { Modal } from '@/shared/ui/modal/Modal';
-import { ChevronLeft, ChevronRight, Heart } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Heart, Mail } from 'lucide-react';
 import { useReadNotifications } from '../../notification/hooks/useReadNotifications';
 import { useCommentNavigation } from '../hook/useCommentNavigation';
 import type { MomentWithNotifications } from '../types/momentsWithNotifications';
@@ -59,8 +59,13 @@ export const MyMomentsCard = ({ myMoment }: { myMoment: MomentWithNotifications 
         onClick={hasComments ? handleMomentClick : undefined}
         $shadow={!myMoment.read}
       >
-        <WriteTime date={myMoment.createdAt} />
-        <span>{comments?.length}</span>
+        <S.MyMomentsTitleWrapper>
+          <S.CommentCountWrapper>
+            <Mail size={16} />
+            <span>{comments?.length}</span>
+          </S.CommentCountWrapper>
+          <WriteTime date={myMoment.createdAt} />
+        </S.MyMomentsTitleWrapper>
         <S.MyMomentsContent>{myMoment.content}</S.MyMomentsContent>
       </S.MyMomentsCard>
       {isOpen && (

--- a/client/src/features/moment/ui/MyMomentsCard.tsx
+++ b/client/src/features/moment/ui/MyMomentsCard.tsx
@@ -6,14 +6,14 @@ import { EchoButton } from '@/features/echo/ui/EchoButton';
 import { SendEchoButton } from '@/features/echo/ui/SendEchoButton';
 import { useModal } from '@/shared/hooks/useModal';
 import { Modal } from '@/shared/ui/modal/Modal';
-import { formatRelativeTime } from '@/shared/utils/formatRelativeTime';
-import { ChevronLeft, ChevronRight, Heart, Timer } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Heart } from 'lucide-react';
 import { useReadNotifications } from '../../notification/hooks/useReadNotifications';
 import { useCommentNavigation } from '../hook/useCommentNavigation';
 import type { MomentWithNotifications } from '../types/momentsWithNotifications';
 import * as S from './MyMomentsCard.styles';
 import { WriterInfo } from '@/widgets/writerInfo';
 import { useNotificationsQuery } from '@/features/notification/hooks/useNotificationsQuery';
+import { WriteTime } from '@/shared/ui/writeTime';
 
 export const MyMomentsCard = ({ myMoment }: { myMoment: MomentWithNotifications }) => {
   const { handleReadNotifications, isLoading: isReadingNotification } = useReadNotifications();
@@ -59,6 +59,8 @@ export const MyMomentsCard = ({ myMoment }: { myMoment: MomentWithNotifications 
         onClick={hasComments ? handleMomentClick : undefined}
         $shadow={!myMoment.read}
       >
+        <WriteTime date={myMoment.createdAt} />
+        <span>{comments?.length}</span>
         <S.MyMomentsContent>{myMoment.content}</S.MyMomentsContent>
       </S.MyMomentsCard>
       {isOpen && (
@@ -83,10 +85,7 @@ export const MyMomentsCard = ({ myMoment }: { myMoment: MomentWithNotifications 
                       {navigation.currentIndex + 1} / {comments?.length || 0}
                     </S.CommentIndicator>
                     <S.TitleWrapper>
-                      <Timer size={16} color={theme.colors['gray-400']} />
-                      <S.TimeStamp>
-                        {formatRelativeTime(currentComment.createdAt || '')}
-                      </S.TimeStamp>
+                      <WriteTime date={currentComment.createdAt} />
                     </S.TitleWrapper>
                   </S.MyMomentsModalHeader>
 

--- a/client/src/features/notification/hooks/useNotificationsMutation.ts
+++ b/client/src/features/notification/hooks/useNotificationsMutation.ts
@@ -9,7 +9,6 @@ export const useNotificationsMutation = () => {
   return useMutation({
     mutationFn: patchNotifications,
     onSuccess: () => {
-      console.log('알림 읽음 처리 성공');
       queryClient.invalidateQueries({ queryKey: ['notifications'] });
     },
     onError: error => {

--- a/client/src/features/notification/hooks/useNotificationsMutation.ts
+++ b/client/src/features/notification/hooks/useNotificationsMutation.ts
@@ -9,6 +9,7 @@ export const useNotificationsMutation = () => {
   return useMutation({
     mutationFn: patchNotifications,
     onSuccess: () => {
+      console.log('알림 읽음 처리 성공');
       queryClient.invalidateQueries({ queryKey: ['notifications'] });
     },
     onError: error => {

--- a/client/src/features/notification/hooks/useSSENotifications.ts
+++ b/client/src/features/notification/hooks/useSSENotifications.ts
@@ -6,6 +6,8 @@ import { subscribeNotifications } from '../api/subscribeNotifications';
 import { NotificationItem, NotificationResponse } from '../types/notifications';
 import { SSENotification } from '../types/sseNotification';
 
+const ECHO_REWARD_POINT = 3;
+
 export const useSSENotifications = () => {
   const queryClient = useQueryClient();
   const { showError, showSuccess } = useToast();
@@ -60,7 +62,9 @@ export const useSSENotifications = () => {
         if (sseData.notificationType === 'NEW_COMMENT_ON_MOMENT') {
           showSuccess('나의 모멘트에 코멘트가 달렸습니다!');
         } else if (sseData.notificationType === 'NEW_REPLY_ON_COMMENT') {
-          showSuccess('나의 코멘트에 이모지가 달렸습니다!');
+          showSuccess(
+            `나의 코멘트에 에코가 달렸습니다! 별조각 ${ECHO_REWARD_POINT} 개를 획득했습니다!`,
+          );
         }
 
         if (sseData.targetType === 'MOMENT') {

--- a/client/src/features/notification/hooks/useSSENotifications.ts
+++ b/client/src/features/notification/hooks/useSSENotifications.ts
@@ -68,6 +68,7 @@ export const useSSENotifications = () => {
         } else if (sseData.targetType === 'COMMENT') {
           queryClient.invalidateQueries({ queryKey: ['comments'] });
         }
+        queryClient.invalidateQueries({ queryKey: ['notifications'] });
       } catch (error) {
         console.error(error);
         showError('실시간 알림 데이터 처리 중 오류가 발생했습니다.');

--- a/client/src/pages/collection/index.styles.ts
+++ b/client/src/pages/collection/index.styles.ts
@@ -20,7 +20,6 @@ export const CollectionHeaderContainer = styled.div`
   justify-content: center;
   gap: 60px;
   margin: 0 auto;
-  border: 1px solid #ccc;
   padding: 20px;
 
   @media (max-width: 768px) {
@@ -35,27 +34,48 @@ export const CollectionHeaderLinkContainer = styled(Link, {
   ${({ theme, $shadow }) =>
     $shadow &&
     css`
-      box-shadow: 0px 0px 15px ${theme.colors['yellow-300_80']};
-      animation: shadowPulse 2s ease-in-out infinite;
+      position: relative;
+      padding: 4px;
+      &::after {
+        content: '';
+        position: absolute;
+        top: -6px;
+        right: -6px;
+        width: 10px;
+        height: 10px;
+        background: ${theme.colors['yellow-300']};
+        border-radius: 50%;
+        box-shadow:
+          0 0 4px ${theme.colors['yellow-300']},
+          0 0 8px ${theme.colors['yellow-300_80']};
+        animation: dotPulse 2s ease-in-out infinite;
+      }
 
-      @keyframes shadowPulse {
+      @keyframes dotPulse {
         0%,
         100% {
-          box-shadow: 0px 0px 10px ${theme.colors['yellow-300_80']};
+          transform: scale(0.6);
+          box-shadow:
+            0 0 2px ${theme.colors['yellow-300']},
+            0 0 4px ${theme.colors['yellow-300_80']};
         }
         50% {
-          box-shadow: 0px 0px 25px ${theme.colors['yellow-300_80']};
+          transform: scale(1);
+          box-shadow:
+            0 0 4px ${theme.colors['yellow-300']},
+            0 0 8px ${theme.colors['yellow-300_80']};
         }
       }
     `}
 
-  color: white;
-  font-size: 1.5rem;
+  color: ${({ theme }) => theme.colors.white};
+  font-size: 2rem;
   font-weight: bold;
 
   &.active {
-    font-size: 1.8rem;
-    color: yellow;
+    font-size: 2.4rem;
+    color: ${({ theme }) => theme.colors['yellow-300']};
+    border-bottom: 2.5px solid ${({ theme }) => theme.colors['yellow-300']};
   }
 
   &:hover {
@@ -70,4 +90,11 @@ export const CollectionHeaderLinkContainer = styled(Link, {
       font-size: 1.4rem;
     }
   }
+`;
+
+export const Description = styled.span`
+  font-size: 1.4rem;
+  color: ${({ theme }) => theme.colors.white};
+  font-weight: bold;
+  margin: 0 auto;
 `;

--- a/client/src/pages/collection/index.styles.ts
+++ b/client/src/pages/collection/index.styles.ts
@@ -23,8 +23,8 @@ export const CollectionHeaderContainer = styled.div`
   padding: 20px;
 
   @media (max-width: 768px) {
-    width: 90%;
-    gap: 30px;
+    width: 100%;
+    gap: 20px;
   }
 `;
 
@@ -83,11 +83,19 @@ export const CollectionHeaderLinkContainer = styled(Link, {
     transition: all 0.2s ease-in-out;
   }
 
+  @media (max-width: 1024px) {
+    font-size: 1.6rem;
+
+    &.active {
+      font-size: 2rem;
+    }
+  }
+
   @media (max-width: 768px) {
     font-size: 1.2rem;
 
     &.active {
-      font-size: 1.4rem;
+      font-size: 1.6rem;
     }
   }
 `;
@@ -97,4 +105,8 @@ export const Description = styled.span`
   color: ${({ theme }) => theme.colors.white};
   font-weight: bold;
   margin: 0 auto;
+
+  @media (max-width: 768px) {
+    font-size: 1.2rem;
+  }
 `;

--- a/client/src/pages/collection/mycomment/index.tsx
+++ b/client/src/pages/collection/mycomment/index.tsx
@@ -1,5 +1,3 @@
-import { TitleContainer } from '@/shared/ui/titleContainer/TitleContainer';
-
 import { MyCommentsList } from '@/features/comment/ui/MyCommentsList';
 import { CollectionHeader } from '@/pages/collection/CollectionHeader';
 import * as S from '../index.styles';
@@ -8,10 +6,7 @@ export default function MyCommentCollectionPage() {
   return (
     <S.CollectionContainer>
       <CollectionHeader />
-      <TitleContainer
-        title="나의 코멘트"
-        subtitle={'내가 작성한 코멘트와 받은 공감을 확인해보세요'}
-      />
+      <S.Description>내가 작성한 코멘트와 받은 에코를 확인해보세요</S.Description>
       <MyCommentsList />
     </S.CollectionContainer>
   );

--- a/client/src/pages/collection/mymoment/index.tsx
+++ b/client/src/pages/collection/mymoment/index.tsx
@@ -1,16 +1,12 @@
 import { MyMomentsList } from '@/features/moment/ui/MyMomentsList';
 import { CollectionHeader } from '@/pages/collection/CollectionHeader';
-import { TitleContainer } from '@/shared/ui/titleContainer/TitleContainer';
 import * as S from '../index.styles';
 
 export default function MyMomentCollectionPage() {
   return (
     <S.CollectionContainer>
       <CollectionHeader />
-      <TitleContainer
-        title="나의 모멘트"
-        subtitle={'내가 공유한 모멘트와 받은 공감을 확인해보세요'}
-      />
+      <S.Description>내가 공유한 모멘트와 받은 코멘트를 확인해보세요</S.Description>
       <MyMomentsList />
     </S.CollectionContainer>
   );

--- a/client/src/shared/ui/writeTime/index.tsx
+++ b/client/src/shared/ui/writeTime/index.tsx
@@ -1,0 +1,24 @@
+import { formatRelativeTime } from '@/shared/utils/formatRelativeTime';
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import { Clock } from 'lucide-react';
+
+export const WriteTime = ({ date }: { date: string }) => {
+  return (
+    <TimeWrapper>
+      <Clock size={16} />
+      {formatRelativeTime(date)}
+    </TimeWrapper>
+  );
+};
+
+const TimeWrapper = styled.div`
+  ${({ theme }) => css`
+    color: ${theme.colors['gray-400']};
+  `}
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 16px;
+  font-weight: 500;
+`;

--- a/client/src/widgets/navigatorsBar/index.styles.ts
+++ b/client/src/widgets/navigatorsBar/index.styles.ts
@@ -13,7 +13,11 @@ export const NavigatorsBarContainer = styled.div<{ $isNavBar?: boolean }>`
   }
 `;
 
-export const LinkContainer = styled.div<{ $isNavBar?: boolean; $shadow?: boolean }>`
+export const LinkContainer = styled.div<{
+  $isNavBar?: boolean;
+  $shadow?: boolean;
+  $isActive: boolean;
+}>`
   ${({ theme, $shadow }) =>
     $shadow &&
     css`
@@ -50,11 +54,12 @@ export const IconImage = styled.img`
   height: 40px;
 `;
 
-export const IconText = styled.p`
+export const IconText = styled.p<{ $isActive?: boolean }>`
   font-size: 1.3rem;
   font-weight: 600;
   line-height: 14.52px;
   letter-spacing: -0.01em;
+  color: ${({ theme, $isActive }) => ($isActive ? theme.colors['yellow-300'] : theme.colors.white)};
 
   @media (max-width: 1024px) {
     font-size: 1.1rem;

--- a/client/src/widgets/navigatorsBar/index.tsx
+++ b/client/src/widgets/navigatorsBar/index.tsx
@@ -2,11 +2,16 @@ import { ROUTES } from '@/app/routes/routes';
 import { useNotificationsQuery } from '@/features/notification/hooks/useNotificationsQuery';
 import { sendEvent } from '@/shared/lib/ga';
 import { NavigatorsBarAnalyticsEvent } from '@/shared/lib/ga/analyticsEvent';
-import { Link } from 'react-router';
+import { Link, useLocation } from 'react-router';
 import * as S from './index.styles';
 
 export const NavigatorsBar = ({ $isNavBar }: { $isNavBar?: boolean }) => {
   const { data: notifications } = useNotificationsQuery();
+  const location = useLocation();
+
+  const isTodayMomentActive = location.pathname.startsWith('/today-moment');
+  const isTodayCommentActive = location.pathname.startsWith('/today-comment');
+  const isCollectionActive = location.pathname.startsWith('/collection');
 
   const isNotificationExisting =
     notifications?.data.length && notifications?.data.length > 0 ? true : false;
@@ -26,23 +31,23 @@ export const NavigatorsBar = ({ $isNavBar }: { $isNavBar?: boolean }) => {
   return (
     <S.NavigatorsBarContainer $isNavBar={$isNavBar}>
       <Link to={ROUTES.TODAY_MOMENT} onClick={handleTodayMomentClick}>
-        <S.LinkContainer $isNavBar={$isNavBar}>
+        <S.LinkContainer $isNavBar={$isNavBar} $isActive={isTodayMomentActive}>
           <S.IconImage src="/images/bluePlanet.png" alt="오늘의 모멘트 페이지로 이동 버튼" />
-          <S.IconText>오늘의 모멘트</S.IconText>
+          <S.IconText $isActive={isTodayMomentActive}>오늘의 모멘트</S.IconText>
         </S.LinkContainer>
       </Link>
 
       <Link to={ROUTES.TODAY_COMMENT} onClick={handleTodayCommentClick}>
-        <S.LinkContainer $isNavBar={$isNavBar}>
+        <S.LinkContainer $isNavBar={$isNavBar} $isActive={isTodayCommentActive}>
           <S.IconImage src="/images/orangePlanet.png" alt="오늘의 코멘트 페이지로 이동 버튼" />
-          <S.IconText>오늘의 코멘트</S.IconText>
+          <S.IconText $isActive={isTodayCommentActive}>오늘의 코멘트</S.IconText>
         </S.LinkContainer>
       </Link>
 
       <Link to={ROUTES.COLLECTION_MYMOMENT} onClick={handleCollectionClick}>
-        <S.LinkContainer $isNavBar={$isNavBar}>
+        <S.LinkContainer $isNavBar={$isNavBar} $isActive={isCollectionActive}>
           <S.IconImage src="/images/starPlanet.png" alt="나만의 모음집 페이지로 이동 버튼" />
-          <S.IconText>나만의 모음집</S.IconText>
+          <S.IconText $isActive={isCollectionActive}>나만의 모음집</S.IconText>
         </S.LinkContainer>
       </Link>
     </S.NavigatorsBarContainer>


### PR DESCRIPTION
# 📋 연관 이슈

- close #534 

# 🚀 작업 내용 
QA때 이야기한 내용대로 나만의 모음집 UI/UX 개선, 버그 수정을 진행했습니다.

##  나의 모멘트 모음집
### 1️⃣ **모멘트 카드**
  - [x] 코멘트 수 및 작성 시간 표시 추가
  - [x] 카드 클릭 시 해당 모멘트의 모든 미읽음 알림 일괄 읽음 처리(기존엔 받은 코멘트 개수만큼 클릭해야 알림이 제거됐음)
  - [x] 알림 읽음 표시가 실시간으로 반영되지 않는 문제 수정 (SSE 쿼리 무효화 추가)

<img width="1204" height="379" alt="image" src="https://github.com/user-attachments/assets/e9e0705f-cf22-4849-9b38-7224d9ee4527" />


### 2️⃣ **모멘트 모달**
  - [x] 코멘트를 최신순으로 정렬하여 표시
  - [x] 전송된 에코만 시각적으로 표시되도록 개선
  - [x] 코멘트 네비게이션 시 이전 코멘트의 에코 선택 상태가 유지되는 문제 수정(각 코멘트별 에코 상태관리로 분리하며 해결)
  - [x] `SendEchoForm` 컴포넌트로 분리하여 에코 관련 로직 모듈화

https://github.com/user-attachments/assets/21028d6b-88f7-4c13-9511-6337cd5ac179


## 나의 코멘트 모음집
### 1️⃣ **포인트 시스템**
  - [x] 코멘트 확인 버튼 클릭 시 "별조각 3개 받았습니다" 중복 알림 제거
  - [x] 포인트 획득 알림은 실제 에코를 받는 시점(SSE)에서만 표시하도록 개선

### 2️⃣ **UI 개선**
  - [x] 받은 에코가 없을 때 적절한 UI 상태 구현
<img width="1621" height="947" alt="스크린샷 2025-08-20 04 11 55" src="https://github.com/user-attachments/assets/5972655e-dfcf-4ee6-937b-a3dca75df6cf" />