### PR TITLE
[FEAT] 비밀번호 변경 주소 개발, 운영 서버 분리

### DIFF
--- a/server/src/main/java/moment/auth/application/AuthEmailService.java
+++ b/server/src/main/java/moment/auth/application/AuthEmailService.java
@@ -19,6 +19,7 @@ import moment.global.exception.MomentException;
 import moment.user.application.UserQueryService;
 import moment.user.domain.ProviderType;
 import moment.user.domain.User;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.MailException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -38,6 +39,9 @@ public class AuthEmailService implements EmailService{
     private final JavaMailSender mailSender;
     private final Map<String, EmailVerification> verificationInfos = new ConcurrentHashMap<>();
     private final Map<String, EmailVerification> passwordUpdateInfos = new ConcurrentHashMap<>();
+
+    @Value("${auth.password_update.uri}")
+    private String passwordUpdateUri;
 
     @Override
     public void sendVerificationEmail(EmailRequest request) {
@@ -118,10 +122,15 @@ public class AuthEmailService implements EmailService{
 
     private void sendUpdateMail(MimeMessageHelper helper, String email, String token)
             throws MessagingException {
+        String fullUrl = passwordUpdateUri + token + "&email=" + email;
+
+        String htmlContent = String.format(
+                "<p>비밀번호를 재설정하려면 다음 링크를 클릭하세요:</p><a href=\"%s\">비밀번호 재설정하기</a>",
+                fullUrl
+        );
+
         helper.setTo(email);
         helper.setSubject("[Moment] 비밀번호 재설정 안내");
-        String htmlContent = "<p>비밀번호를 재설정하려면 다음 링크를 클릭하세요:</p>"
-                + "<a href=\"https://connectingmoment.com/passwordUpdate?token=" + token + "&email=" + email +"\">비밀번호 재설정하기</a>";
         helper.setText(htmlContent, true);
 
         mailSender.send(helper.getMimeMessage());

--- a/server/src/main/resources/application-dev.yml
+++ b/server/src/main/resources/application-dev.yml
@@ -58,6 +58,8 @@ auth:
     client-secret: ${GOOGLE_CLIENT_SECRET}
     redirect-uri: http://api.dev.connectingmoment.com/api/v1/auth/callback/google
     client-uri: http://d2rlxm2vzu73ry.cloudfront.net
+  password_update:
+    uri: http://d2rlxm2vzu73ry.cloudfront.net/passwordUpdate?token=
 
 logging:
   config: classpath:logback-dev.xml

--- a/server/src/main/resources/application-prod.yml
+++ b/server/src/main/resources/application-prod.yml
@@ -58,6 +58,8 @@ auth:
     client-secret: ${GOOGLE_CLIENT_SECRET}
     redirect-uri: http://api.connectingmoment.com/api/v1/auth/callback/google
     client-uri: http://www.connectingmoment.com
+  password_update:
+    uri: https://connectingmoment.com/passwordUpdate?token=
 
 logging:
   config: classpath:logback-prod.xml

--- a/server/src/test/resources/application-test.yml
+++ b/server/src/test/resources/application-test.yml
@@ -56,6 +56,8 @@ auth:
     client-secret: test-client-secret
     redirect-uri: test-redirect-uri
     client-uri: test-client-uri
+  password_update:
+    uri: test-mail-uri
 
 logging:
   config: classpath:logback-test.xml


### PR DESCRIPTION
# 📋 연관 이슈

- close #563 

# 🚀 작업 내용

- 1. 비밀번호 변경 uri 개발, 운영서버 분리 
(개발서버 테스트 용이성을 위해 개발, 운영 서버의 비밀번호 변경 uri를 분리하였습니다.)
