### PR TITLE
[FIX] navBar 프로필, ExtraMoment 캐시 무효화안되는 이슈 수정

### DIFF
--- a/client/src/features/comment/api/useSendCommentsMutation.ts
+++ b/client/src/features/comment/api/useSendCommentsMutation.ts
@@ -15,6 +15,8 @@ export const useSendCommentsMutation = () => {
       queryClient.invalidateQueries({ queryKey: ['commentableMoments'] });
       queryClient.invalidateQueries({ queryKey: ['comments'] });
 
+      queryClient.invalidateQueries({ queryKey: ['profile'] });
+
       queryClient.invalidateQueries({ queryKey: ['my', 'profile'] });
       queryClient.invalidateQueries({ queryKey: ['rewardHistory'] });
       showSuccess(`별조각 ${COMMENTS_REWARD_POINT} 개를 획득했습니다!`);

--- a/client/src/features/moment/hook/useMomentsExtraMutation.ts
+++ b/client/src/features/moment/hook/useMomentsExtraMutation.ts
@@ -10,7 +10,12 @@ export const useMomentsExtraMutation = () => {
     mutationFn: sendExtraMoments,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['moments'] });
-      // TODO: 추후 별조각 포인트 invalidateQueries 추가해야 함
+
+      queryClient.invalidateQueries({ queryKey: ['profile'] });
+
+      queryClient.invalidateQueries({ queryKey: ['my', 'profile'] });
+      queryClient.invalidateQueries({ queryKey: ['rewardHistory'] });
+
       showSuccess('추가 모멘트가 성공적으로 등록되었습니다!');
     },
     onError: () => {

--- a/client/src/features/moment/hook/useMomentsMutation.ts
+++ b/client/src/features/moment/hook/useMomentsMutation.ts
@@ -14,6 +14,8 @@ export const useMomentsMutation = () => {
       queryClient.invalidateQueries({ queryKey: ['moments'] });
       queryClient.invalidateQueries({ queryKey: ['momentWritingStatus'] });
 
+      queryClient.invalidateQueries({ queryKey: ['profile'] });
+
       queryClient.invalidateQueries({ queryKey: ['my', 'profile'] });
       queryClient.invalidateQueries({ queryKey: ['rewardHistory'] });
       showSuccess(`별조각 ${MOMENTS_REWARD_POINT} 개를 획득했습니다!`);


### PR DESCRIPTION
# 📋 연관 이슈

- close #583 

# 🚀 작업 내용

- `useMomentsExtraMutation` 다음 추가
```
queryClient.invalidateQueries({ queryKey: ['profile'] });

queryClient.invalidateQueries({ queryKey: ['my', 'profile'] });
queryClient.invalidateQueries({ queryKey: ['rewardHistory'] });
```

-  `useSendCommentsMutation`, `useMomentsMutation` 다음 추가
```
queryClient.invalidateQueries({ queryKey: ['profile'] });
```

## 📸 Test Screenshot

<!-- 테스트 결과나 UI 변경 사항의 스크린샷을 첨부하세요 -->
1. 사용가능한 별조각 42 -> 32 적용 확인


https://github.com/user-attachments/assets/7007560a-b737-4368-8150-e7128f53ab96



## 📝 Additional Description

<!-- 추가적인 설명이나 고려사항이 있다면 작성하세요 -->
레벨 아이콘 변화는 등급업을 해봐야 확인할 수 있을 것 같습니다.
