### PR TITLE
[FEAT] 모바일에서 마이페이지 클릭 시 navbar 모달 꺼지도록 기능 개선

### DIFF
--- a/client/src/features/auth/ui/AuthButton.tsx
+++ b/client/src/features/auth/ui/AuthButton.tsx
@@ -50,6 +50,8 @@ export const AuthButton = ({ onClick, profile }: AuthButtonProps) => {
 
   const handleMyPageClick = () => {
     navigate('/my');
+    closeDropdown();
+    onClick?.();
   };
 
   if (!profile) {


### PR DESCRIPTION
# 📋 연관 이슈

- close #591 

# 🚀 작업 내용

모바일에서 마이페이지 클릭 시 navbar 모달 꺼지도록 `useOutsideClick` 코드에 아래 코드로 수정하였습니다.
handler에 `onClick?.();` 코드를 추가하여 해당 핸들러 발생 시 onClick을 호출하여 모달이 꺼지도록 하였습니다.

```tsx
  const handleLogoutClick = () => {
    logout();
    closeDropdown();
    onClick?.();
  };

  const handleMyPageClick = () => {
    navigate('/my');
    closeDropdown();
    onClick?.();
  };
```
