### PR TITLE
[FIX] 에코 최대 갯수 제한 6개로 수정

### DIFF
--- a/server/src/main/java/moment/reply/dto/request/EchoCreateRequest.java
+++ b/server/src/main/java/moment/reply/dto/request/EchoCreateRequest.java
@@ -9,7 +9,7 @@ import java.util.Set;
 public record EchoCreateRequest(
         @Schema(description = "에코 타입 (중복 불허)", example = "[\"THANKS\", \"COMFORTED\"]")
         @NotEmpty(message = "에코 타입은 하나 이상 선택해야 합니다.")
-        @Size(min = 1, max = 3, message = "에코 타입은 최소 {min}개, 최대 {max}개까지 선택할 수 있습니다.")
+        @Size(min = 1, max = 6, message = "에코 타입은 최소 {min}개, 최대 {max}개까지 선택할 수 있습니다.")
         Set<String> echoTypes,
 
         @Schema(description = "코멘트 id", example = "1")


### PR DESCRIPTION
# 📋 연관 이슈

- close #595 

# 🚀 작업 내용

- 1. 에코 최대 작성 개수 6개로 수정
      (DTO 갯수 수정)