### PR TITLE
[FIX] 구글 로그인 리디렉션 주소 HTTPS로 설정

### DIFF
--- a/server/src/main/resources/application-dev.yml
+++ b/server/src/main/resources/application-dev.yml
@@ -56,8 +56,8 @@ auth:
   google:
     client-id: ${GOOGLE_CLIENT_ID}
     client-secret: ${GOOGLE_CLIENT_SECRET}
-    redirect-uri: http://api.dev.connectingmoment.com/api/v1/auth/callback/google
-    client-uri: http://dev.connectingmoment.com
+    redirect-uri: https://api.dev.connectingmoment.com/api/v1/auth/callback/google
+    client-uri: https://dev.connectingmoment.com
   password_update:
     uri: http://dev.connectingmoment.com/passwordUpdate?token=
 

--- a/server/src/main/resources/application-prod.yml
+++ b/server/src/main/resources/application-prod.yml
@@ -56,8 +56,8 @@ auth:
   google:
     client-id: ${GOOGLE_CLIENT_ID}
     client-secret: ${GOOGLE_CLIENT_SECRET}
-    redirect-uri: http://api.connectingmoment.com/api/v1/auth/callback/google
-    client-uri: http://www.connectingmoment.com
+    redirect-uri: https://api.connectingmoment.com/api/v1/auth/callback/google
+    client-uri: https://www.connectingmoment.com
   password_update:
     uri: https://connectingmoment.com/passwordUpdate?token=
 


### PR DESCRIPTION
# 📋 연관 이슈

- close #610 

# 🚀 작업 내용

- 1. 구글 로그인 리디렉션 주소를 앱 게시를 위해 HTTPS로 설정해주었습니다.