### PR TITLE
[FEAT] 이미지 url 생성 api 명세 및 사용자 인증 기능 추가

### DIFF
--- a/server/src/main/java/moment/storage/application/FileStorageService.java
+++ b/server/src/main/java/moment/storage/application/FileStorageService.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import moment.storage.dto.request.UploadUrlRequest;
 import moment.storage.dto.response.UploadUrlResponse;
 import moment.storage.infrastructure.AwsS3Client;
+import moment.user.application.UserQueryService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -13,11 +14,14 @@ import org.springframework.stereotype.Service;
 public class FileStorageService {
 
     private final AwsS3Client awsS3Client;
+    private final UserQueryService userQueryService;
 
     @Value("${s3.bucket-path}")
     private String bucketPath;
 
-    public UploadUrlResponse getUploadUrl(UploadUrlRequest request) {
+    public UploadUrlResponse getUploadUrl(UploadUrlRequest request, Long id) {
+        userQueryService.getUserById(id);
+
         String filePath = bucketPath + UUID.randomUUID() + request.imageName();
 
         return awsS3Client.getUploadUrl(filePath);

--- a/server/src/main/java/moment/storage/application/FileStorageService.java
+++ b/server/src/main/java/moment/storage/application/FileStorageService.java
@@ -2,6 +2,7 @@ package moment.storage.application;
 
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import moment.storage.dto.request.UploadUrlRequest;
 import moment.storage.dto.response.UploadUrlResponse;
 import moment.storage.infrastructure.AwsS3Client;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,8 +17,8 @@ public class FileStorageService {
     @Value("${s3.bucket-path}")
     private String bucketPath;
 
-    public UploadUrlResponse getUploadUrl(String fileName) {
-        String filePath = bucketPath + UUID.randomUUID() + fileName;
+    public UploadUrlResponse getUploadUrl(UploadUrlRequest request) {
+        String filePath = bucketPath + UUID.randomUUID() + request.imageName();
 
         return awsS3Client.getUploadUrl(filePath);
     }

--- a/server/src/main/java/moment/storage/presentation/FileStorageController.java
+++ b/server/src/main/java/moment/storage/presentation/FileStorageController.java
@@ -26,7 +26,7 @@ public class FileStorageController {
     public ResponseEntity<SuccessResponse<UploadUrlResponse>> getUploadUrl(
             @Valid @RequestBody UploadUrlRequest request
     ) {
-        UploadUrlResponse response = fileStorageService.getUploadUrl(request.imageName());
+        UploadUrlResponse response = fileStorageService.getUploadUrl(request);
         HttpStatus status = HttpStatus.OK;
 
         return ResponseEntity.status(status).body(SuccessResponse.of(status, response));

--- a/server/src/main/java/moment/storage/presentation/FileStorageController.java
+++ b/server/src/main/java/moment/storage/presentation/FileStorageController.java
@@ -1,12 +1,20 @@
 package moment.storage.presentation;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import moment.auth.presentation.AuthenticationPrincipal;
+import moment.global.dto.response.ErrorResponse;
 import moment.global.dto.response.SuccessResponse;
 import moment.storage.application.FileStorageService;
 import moment.storage.dto.request.UploadUrlRequest;
 import moment.storage.dto.response.UploadUrlResponse;
+import moment.user.dto.request.Authentication;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,11 +30,25 @@ public class FileStorageController {
 
     private final FileStorageService fileStorageService;
 
+    @Operation(summary = "이미지 업로드 url 생성", description = "s3에 업로드 하기 위한 url을 생성합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "이미지 업로드 url 생성 성공"),
+            @ApiResponse(responseCode = "401", description = """
+                    - [T-005] 토큰을 찾을 수 없습니다.
+                    """,
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(responseCode = "404", description = """
+                    - [U-002] 존재하지 않는 사용자입니다.
+                    """,
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+    })
     @GetMapping("/upload-url")
     public ResponseEntity<SuccessResponse<UploadUrlResponse>> getUploadUrl(
-            @Valid @RequestBody UploadUrlRequest request
-    ) {
-        UploadUrlResponse response = fileStorageService.getUploadUrl(request);
+            @Valid @RequestBody UploadUrlRequest request,
+            @AuthenticationPrincipal Authentication authentication
+            ) {
+        UploadUrlResponse response = fileStorageService.getUploadUrl(request, authentication.id());
         HttpStatus status = HttpStatus.OK;
 
         return ResponseEntity.status(status).body(SuccessResponse.of(status, response));

--- a/server/src/test/java/moment/storage/application/FileStorageServiceTest.java
+++ b/server/src/test/java/moment/storage/application/FileStorageServiceTest.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 import moment.storage.dto.request.UploadUrlRequest;
 import moment.storage.dto.response.UploadUrlResponse;
 import moment.storage.infrastructure.AwsS3Client;
+import moment.user.application.UserQueryService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -27,6 +28,9 @@ class FileStorageServiceTest {
     @Mock
     AwsS3Client awsS3Client;
 
+    @Mock
+    UserQueryService userQueryService;
+
     @Test
     void 이미지_업로드_url을_생성한다() {
         // given
@@ -43,7 +47,7 @@ class FileStorageServiceTest {
         // when
         try (MockedStatic<UUID> mockedUuid = Mockito.mockStatic(UUID.class)) {
             mockedUuid.when(UUID::randomUUID).thenReturn(fixedUuid);
-            uploadUrl = fileStorageService.getUploadUrl(request);
+            uploadUrl = fileStorageService.getUploadUrl(request, 1L);
         }
 
         // that

--- a/server/src/test/java/moment/storage/application/FileStorageServiceTest.java
+++ b/server/src/test/java/moment/storage/application/FileStorageServiceTest.java
@@ -1,0 +1,52 @@
+package moment.storage.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import java.util.UUID;
+import moment.storage.dto.request.UploadUrlRequest;
+import moment.storage.dto.response.UploadUrlResponse;
+import moment.storage.infrastructure.AwsS3Client;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+class FileStorageServiceTest {
+
+    @InjectMocks
+    FileStorageService fileStorageService;
+
+    @Mock
+    AwsS3Client awsS3Client;
+
+    @Test
+    void 이미지_업로드_url을_생성한다() {
+        // given
+        String fixedUuidString = "a1b2c3d4-e5f6-7890-1234-567890abcdef";
+        UUID fixedUuid = UUID.fromString(fixedUuidString);
+        String originalFilename = "test-image.jpg";
+        UploadUrlRequest request = new UploadUrlRequest(originalFilename, "jpg");
+        String expectedUrl = "http://ap2-northest-s3/test-bucket/images/test-image.jpg";
+        String expectedFilePath = "test-bucket/images/test-image.jpg";
+        UploadUrlResponse expected = new UploadUrlResponse(expectedUrl, expectedFilePath);
+        UploadUrlResponse uploadUrl;
+        given(awsS3Client.getUploadUrl(any(String.class))).willReturn(expected);
+
+        // when
+        try (MockedStatic<UUID> mockedUuid = Mockito.mockStatic(UUID.class)) {
+            mockedUuid.when(UUID::randomUUID).thenReturn(fixedUuid);
+            uploadUrl = fileStorageService.getUploadUrl(request);
+        }
+
+        // that
+        assertThat(uploadUrl).isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
# 📋 연관 이슈

- close #618 

# 🚀 작업 내용

- 1. 이미지 url 생성 api 명세 추가
- 2. 사용자 인증 추가
- 3. 테스트 코드 추가 