### PR TITLE
[FIX] 이미지 테이블 외래키 제약조건 수정

### DIFF
--- a/server/src/main/resources/db/migration/mysql/V14__alter_images__mysql.sql
+++ b/server/src/main/resources/db/migration/mysql/V14__alter_images__mysql.sql
@@ -1,0 +1,17 @@
+-- 1. 기존의 잘못된 제약조건 삭제
+ALTER TABLE moment_images
+DROP FOREIGN KEY fk_moment_images_moments;
+
+-- 2. 새로운 올바른 제약조건 추가
+ALTER TABLE moment_images
+    ADD CONSTRAINT fk_moment_images_moments
+        FOREIGN KEY (moment_id) REFERENCES moments (id);
+
+-- 1. 기존의 잘못된 제약조건 삭제
+ALTER TABLE comment_images
+DROP FOREIGN KEY fk_comment_images_comment;
+
+-- 2. 새로운 올바른 제약조건 추가
+ALTER TABLE comment_images
+    ADD CONSTRAINT fk_comment_images_comments -- 새 이름
+        FOREIGN KEY (comment_id) REFERENCES comments (id);

--- a/server/src/test/resources/db/migration/h2/V14__alter_images__h2.sql
+++ b/server/src/test/resources/db/migration/h2/V14__alter_images__h2.sql
@@ -1,0 +1,17 @@
+-- 1. 기존의 잘못된 제약조건 삭제
+ALTER TABLE moment_images
+DROP FOREIGN KEY fk_moment_images_moments;
+
+-- 2. 새로운 올바른 제약조건 추가
+ALTER TABLE moment_images
+    ADD CONSTRAINT fk_moment_images_moments
+        FOREIGN KEY (moment_id) REFERENCES moments (id);
+
+-- 1. 기존의 잘못된 제약조건 삭제
+ALTER TABLE comment_images
+DROP FOREIGN KEY fk_comment_images_comment;
+
+-- 2. 새로운 올바른 제약조건 추가
+ALTER TABLE comment_images
+    ADD CONSTRAINT fk_comment_images_comments -- 새 이름
+        FOREIGN KEY (comment_id) REFERENCES comments (id);

--- a/server/src/test/resources/db/migration/h2/V14__alter_images__h2.sql
+++ b/server/src/test/resources/db/migration/h2/V14__alter_images__h2.sql
@@ -1,6 +1,6 @@
 -- 1. 기존의 잘못된 제약조건 삭제
 ALTER TABLE moment_images
-DROP FOREIGN KEY fk_moment_images_moments;
+DROP CONSTRAINT fk_moment_images_moments;
 
 -- 2. 새로운 올바른 제약조건 추가
 ALTER TABLE moment_images
@@ -9,7 +9,7 @@ ALTER TABLE moment_images
 
 -- 1. 기존의 잘못된 제약조건 삭제
 ALTER TABLE comment_images
-DROP FOREIGN KEY fk_comment_images_comment;
+DROP CONSTRAINT fk_comment_images_comment;
 
 -- 2. 새로운 올바른 제약조건 추가
 ALTER TABLE comment_images


### PR DESCRIPTION
# 📋 연관 이슈

- close #650 

# 🚀 작업 내용

- 1. 모멘트 이미지, 코멘트 이미지 테이블의 잘못된 외래키 제약조건을 수정한다.