### PR TITLE
[REFACTOR] moment 등록 시 tagName 유효성 검사 로직 추가 & 리마인드 메일 전송 시간 수정

### DIFF
--- a/server/src/main/java/moment/comment/dto/response/MyCommentsResponse.java
+++ b/server/src/main/java/moment/comment/dto/response/MyCommentsResponse.java
@@ -1,5 +1,6 @@
 package moment.comment.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -14,7 +15,8 @@ public record MyCommentsResponse(List<MyCommentResponse> myCommentsResponse) {
                                         Map<Moment, List<MomentTag>> momentTagsOfMoment) {
 
         return new MyCommentsResponse(comments.stream()
-                .map(comment -> MyCommentResponse.from(comment, momentTagsOfMoment.getOrDefault(comment.getMoment(), Collections.emptyList())))
+                .map(comment -> MyCommentResponse.from(comment,
+                        momentTagsOfMoment.getOrDefault(comment.getMoment(), Collections.emptyList())))
                 .toList());
     }
 
@@ -25,8 +27,14 @@ public record MyCommentsResponse(List<MyCommentResponse> myCommentsResponse) {
         return new MyCommentsResponse(comments.stream()
                 .map(comment -> {
                     List<Echo> echoes = commentAndEchos.getOrDefault(comment, Collections.emptyList());
-                    List<MomentTag> momentTags = momentTagsOfMoment.getOrDefault(comment.getMoment(), Collections.emptyList());
+                    List<MomentTag> momentTags = momentTagsOfMoment.getOrDefault(comment.getMoment(),
+                            Collections.emptyList());
                     return MyCommentResponse.from(comment, echoes, momentTags);
                 }).toList());
+    }
+
+    @JsonValue
+    public List<MyCommentResponse> getMyCommentsResponse() {
+        return myCommentsResponse;
     }
 }

--- a/server/src/main/java/moment/global/exception/ErrorCode.java
+++ b/server/src/main/java/moment/global/exception/ErrorCode.java
@@ -48,7 +48,7 @@ public enum ErrorCode {
     MOMENT_ALREADY_EXIST("M-003", "오늘 작성한 모멘트가 이미 존재합니다.", HttpStatus.BAD_REQUEST),
     MOMENT_LENGTH_INVALID("M-004", "모멘트는 1자 이상, 100자 이하로만 작성 가능합니다.", HttpStatus.BAD_REQUEST),
     MOMENTS_LIMIT_INVALID("M-005", "유효하지 않은 페이지 사이즈입니다.", HttpStatus.BAD_REQUEST),
-    TAG_NAME_EMPTY("M-006", "태그 이름이 비어있습니다.", HttpStatus.BAD_REQUEST),
+    TAG_INVALID("M-006", "유효하지 않은 태그 형식입니다.", HttpStatus.BAD_REQUEST),
     TAG_NAME_INVALID_LENGTH("M-007", "태그 이름은 1자 이상, 30자 이하로만 작성 가능합니다.", HttpStatus.BAD_REQUEST),
 
     NOTIFICATION_NOT_FOUND("N-001", "존재하지 않는 알림입니다.", HttpStatus.NOT_FOUND),
@@ -56,7 +56,8 @@ public enum ErrorCode {
     EMAIL_VERIFY_FAILED("V-001", "이메일 인증에 실패했습니다.", HttpStatus.BAD_REQUEST),
     EMAIL_COOL_DOWN_NOT_PASSED("V-002", "이메일 요청은 1분에 한번만 요청 할 수 있습니다.", HttpStatus.BAD_REQUEST),
     EMAIL_SEND_FAILURE("V-003", "이메일 전송에 실패했습니다.", HttpStatus.BAD_REQUEST),
-    INVALID_PASSWORD_RESET_TOKEN("V-004", "유효하지 않은 비밀번호 재설정 요청입니다.", HttpStatus.BAD_REQUEST),;
+    INVALID_PASSWORD_RESET_TOKEN("V-004", "유효하지 않은 비밀번호 재설정 요청입니다.", HttpStatus.BAD_REQUEST),
+    ;
 
     private final String code;
     private final String message;

--- a/server/src/main/java/moment/moment/dto/request/MomentCreateRequest.java
+++ b/server/src/main/java/moment/moment/dto/request/MomentCreateRequest.java
@@ -3,6 +3,7 @@ package moment.moment.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 
@@ -14,8 +15,9 @@ public record MomentCreateRequest(
         String content,
 
         @Schema(description = "모멘트 태그 이름 목록", example = "[\"일상/여가\", \"운동\"]")
-        @NotNull(message = "TAG_NAME_EMPTY")
-        List<String> tagNames,
+        @NotNull(message = "TAG_INVALID")
+        @Size(min = 1, message = "TAG_INVALID")
+        List<@NotBlank(message = "TAG_INVALID") @Pattern(regexp = "^[^\\s]+$", message = "TAG_INVALID") String> tagNames,
 
         @Schema(
                 description = "모멘트 사진 저장 경로",

--- a/server/src/main/java/moment/moment/dto/response/MyMomentsResponse.java
+++ b/server/src/main/java/moment/moment/dto/response/MyMomentsResponse.java
@@ -1,5 +1,6 @@
 package moment.moment.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -50,5 +51,10 @@ public record MyMomentsResponse(List<MyMomentResponse> myMomentsResponse) {
                 .toList();
 
         return new MyMomentsResponse(myMomentResponses);
+    }
+
+    @JsonValue
+    public List<MyMomentResponse> getMyMomentsResponse() {
+        return myMomentsResponse;
     }
 }

--- a/server/src/main/java/moment/notification/application/EmailNotificationService.java
+++ b/server/src/main/java/moment/notification/application/EmailNotificationService.java
@@ -35,7 +35,7 @@ public class EmailNotificationService {
     private final MomentRepository momentRepository;
     private final CommentRepository commentRepository;
 
-    @Scheduled(cron = "0 0 16 * * ?", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0 21 * * ?", zone = "Asia/Seoul")
     public void schedule() {
         List<User> users = userQueryService.findAll();
         LocalDateTime startOfDay = LocalDate.now().atStartOfDay();

--- a/server/src/test/java/moment/moment/presentation/MomentControllerTest.java
+++ b/server/src/test/java/moment/moment/presentation/MomentControllerTest.java
@@ -19,7 +19,6 @@ import moment.moment.dto.response.MomentCreationStatusResponse;
 import moment.moment.dto.response.MyMomentPageResponse;
 import moment.moment.dto.response.MyMomentResponse;
 import moment.moment.infrastructure.MomentRepository;
-import moment.reward.infrastructure.RewardRepository;
 import moment.user.domain.ProviderType;
 import moment.user.domain.User;
 import moment.user.infrastructure.UserRepository;
@@ -54,9 +53,6 @@ class MomentControllerTest {
 
     @Autowired
     private TokenManager tokenManager;
-
-    @Autowired
-    private RewardRepository rewardRepository;
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
# 📋 연관 이슈

- close #653 

# 🚀 작업 내용

- 1.  moment 등록 시 tagName 유효성 검사 로직 추가
  - tagName 이 null 로 전송되는 경우 예외 발생
  - tagName 이 빈 목록으로 전송되는 경우 예외 발생
  - tagName 내부에 빈칸을 포함하는 경우 예외 발생

- 2. 리마인드 메일 전송 시간 수정
  - 21시로 수정

- 3. 나의 모음집 응답 값 반환 시 List 필드를 배열로 응답되도록 수정 (MyMomentsPageResponse, MyComentsPageResponse 