### PR TITLE
[FIX] 오늘의 모멘트에서 전송 안되는 문제 해결

### DIFF
--- a/client/src/features/moment/ui/TodayMomentForm.tsx
+++ b/client/src/features/moment/ui/TodayMomentForm.tsx
@@ -1,14 +1,14 @@
 import { ROUTES } from '@/app/routes/routes';
+import { checkProfanityWord } from '@/converter/util/checkProfanityWord';
 import { useCheckIfLoggedInQuery } from '@/features/auth/api/useCheckIfLoggedInQuery';
 import { useToast } from '@/shared/hooks/useToast';
 import { Card, FileUpload, TextArea } from '@/shared/ui';
 import { YellowSquareButton } from '@/shared/ui/button/YellowSquareButton';
+import { TagList } from '@/shared/ui/tag/TagList';
 import { Send, Star } from 'lucide-react';
 import { useNavigate } from 'react-router';
-import * as S from './TodayContent.styles';
-import { checkProfanityWord } from '@/converter/util/checkProfanityWord';
-import { TagList } from '@/shared/ui/tag/TagList';
 import { TAGS } from '../const/tags';
+import * as S from './TodayContent.styles';
 
 export function TodayMomentForm({
   handleContentChange,
@@ -32,13 +32,16 @@ export function TodayMomentForm({
   const handleNavigateToTodayMomentSuccess = () => {
     if (checkProfanityWord(content)) {
       showError('모멘트에 부적절한 단어가 포함되어 있습니다.');
-      if (tagNames.length === 0) {
-        showError('태그를 선택해주세요.');
-        return;
-      }
-      handleSendContent();
-      navigate(ROUTES.TODAY_MOMENT_SUCCESS);
+      return;
     }
+
+    if (tagNames.length === 0) {
+      showError('태그를 선택해주세요.');
+      return;
+    }
+
+    handleSendContent();
+    navigate(ROUTES.TODAY_MOMENT_SUCCESS);
   };
 
   const handleTextAreaFocus = (e: React.FocusEvent<HTMLTextAreaElement>) => {


### PR DESCRIPTION
# 📋 연관 이슈

- close #672 

## 기존 잘못된 로직
부적절한 단어가 있으면 if문 안으로 들어가서
 에러 메시지를 보여주지만
 여전히 `handleSendContent()`를 실행하고 페이지를 이동시켰습니다.

## 수정된 올바른 로직:
부적절한 단어가 있으면 → 에러 메시지 + early return
태그가 없으면 → 에러 메시지 + early return
모든 검증을 통과했을 때만 → `handleSendContent()`실행 + 페이지 이동