### PR TITLE
[FEAT] 이미지 보기 & 오늘의 코멘트, 나의 모음집 UI 개선, Footer 추가

### DIFF
--- a/client/src/app/layout/ui/Footer.styles.ts
+++ b/client/src/app/layout/ui/Footer.styles.ts
@@ -1,0 +1,20 @@
+import styled from '@emotion/styled';
+
+export const FooterWrapper = styled.div`
+  width: 100%;
+  height: 100px;
+  color: ${({ theme }) => theme.colors['gray-600']};
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+`;
+
+export const InquiryLink = styled.a`
+  color: ${({ theme }) => theme.colors['gray-600']};
+  text-decoration: underline;
+  &:hover {
+    color: ${({ theme }) => theme.colors['yellow-300_80']};
+  }
+`;

--- a/client/src/app/layout/ui/Footer.tsx
+++ b/client/src/app/layout/ui/Footer.tsx
@@ -1,34 +1,15 @@
-import styled from '@emotion/styled';
+import * as S from './Footer.styles';
 
 export const Footer = () => {
   return (
-    <FooterWrapper>
+    <S.FooterWrapper>
       <div>
         문의: &nbsp;
-        <InquiryLink href="https://open.kakao.com/o/shuZJySh" target="_blank">
+        <S.InquiryLink href="http://pf.kakao.com/_txihUn" target="_blank">
           카카오톡 오픈 채팅
-        </InquiryLink>
+        </S.InquiryLink>
       </div>
       <div>Copyright © 우아한테크코스 모멘트 팀 All Rights Reserved.</div>
-    </FooterWrapper>
+    </S.FooterWrapper>
   );
 };
-
-const FooterWrapper = styled.div`
-  width: 100%;
-  height: 100px;
-  color: ${({ theme }) => theme.colors['gray-600']};
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 4px;
-`;
-
-const InquiryLink = styled.a`
-  color: ${({ theme }) => theme.colors['gray-600']};
-  text-decoration: underline;
-  &:hover {
-    color: ${({ theme }) => theme.colors['yellow-300_80']};
-  }
-`;

--- a/client/src/app/layout/ui/Footer.tsx
+++ b/client/src/app/layout/ui/Footer.tsx
@@ -1,0 +1,34 @@
+import styled from '@emotion/styled';
+
+export const Footer = () => {
+  return (
+    <FooterWrapper>
+      <div>
+        문의: &nbsp;
+        <InquiryLink href="https://open.kakao.com/o/shuZJySh" target="_blank">
+          카카오톡 오픈 채팅
+        </InquiryLink>
+      </div>
+      <div>Copyright © 우아한테크코스 모멘트 팀 All Rights Reserved.</div>
+    </FooterWrapper>
+  );
+};
+
+const FooterWrapper = styled.div`
+  width: 100%;
+  height: 100px;
+  color: ${({ theme }) => theme.colors['gray-600']};
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+`;
+
+const InquiryLink = styled.a`
+  color: ${({ theme }) => theme.colors['gray-600']};
+  text-decoration: underline;
+  &:hover {
+    color: ${({ theme }) => theme.colors['yellow-300_80']};
+  }
+`;

--- a/client/src/app/layout/ui/Layout.tsx
+++ b/client/src/app/layout/ui/Layout.tsx
@@ -9,6 +9,7 @@ import { ErrorBoundary } from '@/shared/ui';
 import React, { useEffect } from 'react';
 import { Outlet, useLocation } from 'react-router';
 import * as S from './Layout.styles';
+import { Footer } from './Footer';
 
 const GATracker = () => {
   const location = useLocation();
@@ -43,6 +44,7 @@ const LayoutContent: React.FC = () => {
           <Outlet />
         </ErrorBoundary>
       </S.Main>
+      <Footer />
     </S.Wrapper>
   );
 };

--- a/client/src/features/comment/ui/MyCommentsCard.styles.ts
+++ b/client/src/features/comment/ui/MyCommentsCard.styles.ts
@@ -49,6 +49,25 @@ export const ContentContainer = styled.div`
   margin-bottom: 10px;
 `;
 
+export const MomentContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: 10px;
+  margin-bottom: 10px;
+  text-align: left;
+  padding: 0 16px;
+`;
+
+export const MyCommentsContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: 10px;
+  margin-bottom: 10px;
+  text-align: left;
+`;
+
 export const MyCommentsTagWrapper = styled.div`
   display: flex;
   align-items: center;
@@ -71,14 +90,40 @@ export const NoEchoContent = styled.p`
 
 export const CommentImageContainer = styled.div`
   display: flex;
-  justify-content: center;
+  justify-content: left;
   margin-top: 8px;
 `;
 
 export const CommentImage = styled.img`
-  max-width: 200px;
-  max-height: 200px;
+  width: 80px;
+  height: 80px;
   border-radius: 8px;
   object-fit: cover;
   border: 1px solid ${({ theme }) => theme.colors['gray-600']};
+  cursor: pointer;
+  transition: transform 0.2s ease;
+
+  &:hover {
+    transform: scale(1.05);
+  }
+`;
+
+export const ImageOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.8);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+  cursor: pointer;
+`;
+
+export const FullscreenImage = styled.img`
+  max-width: 80vw;
+  max-height: 80vh;
+  object-fit: contain;
 `;

--- a/client/src/features/comment/ui/MyCommentsCard.tsx
+++ b/client/src/features/comment/ui/MyCommentsCard.tsx
@@ -9,9 +9,11 @@ import { WriterInfo } from '@/widgets/writerInfo';
 import { Heart, Send } from 'lucide-react';
 import type { CommentWithNotifications } from '../types/commentsWithNotifications';
 import * as S from './MyCommentsCard.styles';
+import { useShowFullImage } from '@/shared/hooks/useShowFullImage';
 
 export const MyCommentsCard = ({ myComment }: { myComment: CommentWithNotifications }) => {
   const { handleReadNotifications, isLoading: isReadingNotification } = useReadNotifications();
+  const { fullImageSrc, handleImageClick, closeFullImage, ImageOverlayPortal } = useShowFullImage();
 
   const handleCommentOpen = () => {
     if (myComment.read || isReadingNotification) return;
@@ -21,59 +23,85 @@ export const MyCommentsCard = ({ myComment }: { myComment: CommentWithNotificati
   };
 
   return (
-    <Card width="medium" key={`card-${myComment.id}`} shadow={!myComment.read}>
-      <Card.TitleContainer
-        title={
-          <S.TitleWrapper>
-            <WriterInfo writer={myComment.moment.nickName} level={myComment.moment.level} />
-            <WriteTime date={myComment.createdAt} />
-          </S.TitleWrapper>
-        }
-        subtitle={''}
-      />
-      <Card.Content>
-        <S.ContentContainer>
-          <S.MyMomentContent>{myComment.moment.content}</S.MyMomentContent>
-          {myComment.moment.imageUrl && (
-            <S.CommentImageContainer>
-              <S.CommentImage src={myComment.moment.imageUrl} alt="모멘트 이미지" />
-            </S.CommentImageContainer>
-          )}
-        </S.ContentContainer>
-        <S.ContentContainer>
-          <S.TitleContainer>
-            <Send size={20} color={theme.colors['yellow-500']} />
-            <p>보낸 코멘트</p>
-          </S.TitleContainer>
-          <SimpleCard height="small" content={myComment.content} />
-          {myComment.imageUrl && (
-            <S.CommentImageContainer>
-              <S.CommentImage src={myComment.imageUrl} alt="코멘트 이미지" />
-            </S.CommentImageContainer>
-          )}
-        </S.ContentContainer>
-        <S.ContentContainer>
-          <S.TitleContainer>
-            <Heart size={20} color={theme.colors['yellow-500']} />
-            <p>받은 에코</p>
-          </S.TitleContainer>
-          <S.EchoContainer>
-            {myComment.echos && myComment.echos.length > 0 ? (
-              myComment.echos.map(echo => (
-                <Echo key={echo.id} echo={echo.echoType as EchoTypeKey} />
-              ))
-            ) : (
-              <S.NoEchoContent>아직 받은 에코가 없습니다.</S.NoEchoContent>
-            )}
-          </S.EchoContainer>
-          <S.MyCommentsTagWrapper>
-            {myComment.moment.tagNames.map((tag: string) => (
-              <Tag key={tag} tag={tag} />
-            ))}
-          </S.MyCommentsTagWrapper>
-          {!myComment.read && <Button onClick={handleCommentOpen} title="확인" />}
-        </S.ContentContainer>
-      </Card.Content>
-    </Card>
+    <>
+      <Card width="medium" key={`card-${myComment.id}`} shadow={!myComment.read}>
+        <Card.TitleContainer
+          title={
+            <S.TitleWrapper>
+              <WriterInfo writer={myComment.moment.nickName} level={myComment.moment.level} />
+              <WriteTime date={myComment.createdAt} />
+            </S.TitleWrapper>
+          }
+          subtitle={''}
+        />
+        <Card.Content>
+          <S.ContentContainer>
+            <S.MomentContentWrapper>
+              <S.MyMomentContent>{myComment.moment.content}</S.MyMomentContent>
+              {myComment.moment.imageUrl && (
+                <S.CommentImageContainer>
+                  <S.CommentImage
+                    src={myComment.moment.imageUrl}
+                    alt="모멘트 이미지"
+                    onClick={e => handleImageClick(myComment.moment.imageUrl!, e)}
+                  />
+                </S.CommentImageContainer>
+              )}
+            </S.MomentContentWrapper>
+          </S.ContentContainer>
+          <S.ContentContainer>
+            <S.TitleContainer>
+              <Send size={20} color={theme.colors['yellow-500']} />
+              <p>보낸 코멘트</p>
+            </S.TitleContainer>
+            <SimpleCard
+              height="small"
+              content={
+                <S.MyCommentsContentWrapper>
+                  <p>{myComment.content}</p>
+                  {myComment.imageUrl && (
+                    <S.CommentImageContainer>
+                      <S.CommentImage
+                        src={myComment.imageUrl}
+                        alt="코멘트 이미지"
+                        onClick={e => handleImageClick(myComment.imageUrl!, e)}
+                      />
+                    </S.CommentImageContainer>
+                  )}
+                </S.MyCommentsContentWrapper>
+              }
+            />
+          </S.ContentContainer>
+          <S.ContentContainer>
+            <S.TitleContainer>
+              <Heart size={20} color={theme.colors['yellow-500']} />
+              <p>받은 에코</p>
+            </S.TitleContainer>
+            <S.EchoContainer>
+              {myComment.echos && myComment.echos.length > 0 ? (
+                myComment.echos.map(echo => (
+                  <Echo key={echo.id} echo={echo.echoType as EchoTypeKey} />
+                ))
+              ) : (
+                <S.NoEchoContent>아직 받은 에코가 없습니다.</S.NoEchoContent>
+              )}
+            </S.EchoContainer>
+            <S.MyCommentsTagWrapper>
+              {myComment.moment.tagNames.map((tag: string) => (
+                <Tag key={tag} tag={tag} />
+              ))}
+            </S.MyCommentsTagWrapper>
+            {!myComment.read && <Button onClick={handleCommentOpen} title="확인" />}
+          </S.ContentContainer>
+        </Card.Content>
+      </Card>
+      {fullImageSrc && (
+        <ImageOverlayPortal>
+          <S.ImageOverlay onClick={closeFullImage}>
+            <S.FullscreenImage src={fullImageSrc} alt="전체 이미지" />
+          </S.ImageOverlay>
+        </ImageOverlayPortal>
+      )}
+    </>
   );
 };

--- a/client/src/features/comment/ui/TodayCommentForm.styles.ts
+++ b/client/src/features/comment/ui/TodayCommentForm.styles.ts
@@ -60,16 +60,49 @@ export const NotLoggedNickname = styled.p`
   color: ${({ theme }) => theme.colors['yellow-500']};
 `;
 
+export const MyCommentsContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: 10px;
+  text-align: left;
+`;
+
 export const MomentImageContainer = styled.div`
   display: flex;
-  justify-content: center;
-  margin: 12px 0;
+  margin: 8px 0;
 `;
 
 export const MomentImage = styled.img`
-  max-width: 200px;
-  max-height: 150px;
+  width: 80px;
+  height: 80px;
   border-radius: 8px;
   object-fit: cover;
   border: 1px solid ${({ theme }) => theme.colors['gray-600']};
+  cursor: pointer;
+  transition: transform 0.2s ease;
+
+  &:hover {
+    transform: scale(1.05);
+  }
+`;
+
+export const ImageOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.8);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+  cursor: pointer;
+`;
+
+export const FullscreenImage = styled.img`
+  max-width: 80vw;
+  max-height: 80vh;
+  object-fit: contain;
 `;

--- a/client/src/features/comment/ui/TodayCommentForm.tsx
+++ b/client/src/features/comment/ui/TodayCommentForm.tsx
@@ -6,6 +6,7 @@ import { AlertCircle, Loader, RotateCcw } from 'lucide-react';
 import { GetCommentableMoments } from '../types/comments';
 import * as S from './TodayCommentForm.styles';
 import { TodayCommentWriteContent } from './TodayCommentWriteContent';
+import { useShowFullImage } from '@/shared/hooks/useShowFullImage';
 
 export function TodayCommentForm({
   momentData,
@@ -22,6 +23,8 @@ export function TodayCommentForm({
   error: Error | null;
   refetch: () => void;
 }) {
+  const { fullImageSrc, handleImageClick, closeFullImage, ImageOverlayPortal } = useShowFullImage();
+
   if (isLoggedInLoading) {
     return <CommonSkeletonCard variant="comment" />;
   }
@@ -72,32 +75,54 @@ export function TodayCommentForm({
   }
 
   return (
-    <Card width="medium">
-      <Card.TitleContainer
-        title={
-          <S.TitleWrapper>
-            <WriterInfo writer={momentData.nickname} level={momentData.level} />
-            <S.ActionWrapper>
-              <WriteTime date={momentData.createdAt} />
-              <S.RefreshButton onClick={() => refetch()}>
-                <RotateCcw size={28} />
-              </S.RefreshButton>
-            </S.ActionWrapper>
-          </S.TitleWrapper>
-        }
-        subtitle=""
-      />
-      <SimpleCard height="small" content={momentData.content} />
-      {momentData.imageUrl && (
-        <S.MomentImageContainer>
-          <S.MomentImage src={momentData.imageUrl} alt="모멘트 이미지" />
-        </S.MomentImageContainer>
+    <>
+      <Card width="medium">
+        <Card.TitleContainer
+          title={
+            <S.TitleWrapper>
+              <WriterInfo writer={momentData.nickname} level={momentData.level} />
+              <S.ActionWrapper>
+                <WriteTime date={momentData.createdAt} />
+                <S.RefreshButton onClick={() => refetch()}>
+                  <RotateCcw size={28} />
+                </S.RefreshButton>
+              </S.ActionWrapper>
+            </S.TitleWrapper>
+          }
+          subtitle=""
+        />
+        <SimpleCard
+          height="small"
+          content={
+            <S.MyCommentsContentWrapper>
+              <p>{momentData.content}</p>
+              {momentData.imageUrl && (
+                <S.MomentImageContainer>
+                  <S.MomentImage
+                    src={momentData.imageUrl}
+                    alt="코멘트 이미지"
+                    onClick={e => handleImageClick(momentData.imageUrl!, e)}
+                  />
+                </S.MomentImageContainer>
+              )}
+            </S.MyCommentsContentWrapper>
+          }
+        />
+
+        <TodayCommentWriteContent
+          momentId={momentData.id}
+          isLoggedIn={isLoggedIn}
+          key={momentData.id}
+        />
+      </Card>
+
+      {fullImageSrc && (
+        <ImageOverlayPortal>
+          <S.ImageOverlay onClick={closeFullImage}>
+            <S.FullscreenImage src={fullImageSrc} alt="전체 이미지" />
+          </S.ImageOverlay>
+        </ImageOverlayPortal>
       )}
-      <TodayCommentWriteContent
-        momentId={momentData.id}
-        isLoggedIn={isLoggedIn}
-        key={momentData.id}
-      />
-    </Card>
+    </>
   );
 }

--- a/client/src/features/moment/ui/MyMomentsCard.styles.ts
+++ b/client/src/features/moment/ui/MyMomentsCard.styles.ts
@@ -212,11 +212,17 @@ export const CommentImageContainer = styled.div`
 `;
 
 export const CommentImage = styled.img`
-  max-width: 150px;
-  max-height: 150px;
+  width: 80px;
+  height: 80px;
   border-radius: 8px;
   object-fit: cover;
   border: 1px solid ${({ theme }) => theme.colors['gray-600']};
+  cursor: pointer !important;
+  transition: transform 0.2s ease;
+
+  &:hover {
+    transform: scale(1.05);
+  }
 `;
 
 export const MomentImageContainer = styled.div`

--- a/client/src/features/moment/ui/MyMomentsCard.styles.ts
+++ b/client/src/features/moment/ui/MyMomentsCard.styles.ts
@@ -63,11 +63,19 @@ export const MyMomentsContent = styled.p`
   word-break: break-all;
 `;
 
+export const MyMomentsBottomWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+`;
+
 export const MyMomentsTagWrapper = styled.div`
   display: flex;
   align-items: center;
   gap: 4px;
   justify-content: flex-end;
+  flex-wrap: wrap;
 `;
 
 export const MyMomentsModalContent = styled.div`

--- a/client/src/features/moment/ui/MyMomentsCard.styles.ts
+++ b/client/src/features/moment/ui/MyMomentsCard.styles.ts
@@ -226,9 +226,35 @@ export const MomentImageContainer = styled.div`
 `;
 
 export const MomentImage = styled.img`
-  max-width: 120px;
-  max-height: 80px;
+  width: 80px;
+  height: 80px;
   border-radius: 6px;
   object-fit: cover;
   border: 1px solid ${({ theme }) => theme.colors['gray-600']};
+  cursor: pointer;
+  transition: transform 0.2s ease;
+
+  &:hover {
+    transform: scale(1.05);
+  }
+`;
+
+export const ImageOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.6);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+  cursor: pointer;
+`;
+
+export const FullscreenImage = styled.img`
+  max-width: 80vw;
+  max-height: 80vh;
+  object-fit: contain;
 `;

--- a/client/src/features/moment/ui/MyMomentsCard.styles.ts
+++ b/client/src/features/moment/ui/MyMomentsCard.styles.ts
@@ -85,6 +85,28 @@ export const MyMomentsModalContent = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: space-between;
+  overflow-y: auto;
+
+  &::-webkit-scrollbar {
+    width: 12px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: rgba(0, 0, 0, 0.05);
+    border-radius: 6px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: rgba(0, 0, 0, 0.6);
+    border-radius: 6px;
+
+    &:hover {
+      background: rgba(0, 0, 0, 0.8);
+    }
+  }
+
+  scrollbar-width: auto;
+  scrollbar-color: rgba(0, 0, 0, 0.3) rgba(0, 0, 0, 0.1);
 `;
 
 export const CommentContainer = styled.div`

--- a/client/src/features/moment/ui/MyMomentsCard.tsx
+++ b/client/src/features/moment/ui/MyMomentsCard.tsx
@@ -12,12 +12,14 @@ import { useReadNotifications } from '../../notification/hooks/useReadNotificati
 import { useCommentNavigation } from '../hook/useCommentNavigation';
 import type { MomentWithNotifications } from '../types/momentsWithNotifications';
 import * as S from './MyMomentsCard.styles';
+import { useShowFullImage } from '@/shared/hooks/useShowFullImage';
 
 export const MyMomentsCard = ({ myMoment }: { myMoment: MomentWithNotifications }) => {
   const { handleReadNotifications, isLoading: isReadingNotification } = useReadNotifications();
   const { handleOpen, handleClose, isOpen } = useModal();
   useEchoSelection();
   const { data: notifications } = useNotificationsQuery();
+  const { fullImageSrc, handleImageClick, closeFullImage, ImageOverlayPortal } = useShowFullImage();
   const sortedComments = useMemo(() => {
     return myMoment.comments?.slice().reverse() || [];
   }, [myMoment.comments]);
@@ -67,7 +69,11 @@ export const MyMomentsCard = ({ myMoment }: { myMoment: MomentWithNotifications 
         <S.MyMomentsBottomWrapper>
           {myMoment.imageUrl ? (
             <S.MomentImageContainer>
-              <S.MomentImage src={myMoment.imageUrl} alt="모멘트 이미지" />
+              <S.MomentImage
+                src={myMoment.imageUrl}
+                alt="모멘트 이미지"
+                onClick={e => handleImageClick(myMoment.imageUrl!, e)}
+              />
             </S.MomentImageContainer>
           ) : (
             <div />
@@ -136,6 +142,13 @@ export const MyMomentsCard = ({ myMoment }: { myMoment: MomentWithNotifications 
             )}
           </Modal.Content>
         </Modal>
+      )}
+      {fullImageSrc && (
+        <ImageOverlayPortal>
+          <S.ImageOverlay onClick={closeFullImage}>
+            <S.FullscreenImage src={fullImageSrc} alt="전체 이미지" />
+          </S.ImageOverlay>
+        </ImageOverlayPortal>
       )}
     </>
   );

--- a/client/src/features/moment/ui/MyMomentsCard.tsx
+++ b/client/src/features/moment/ui/MyMomentsCard.tsx
@@ -121,7 +121,11 @@ export const MyMomentsCard = ({ myMoment }: { myMoment: MomentWithNotifications 
                         <div>{currentComment.content}</div>
                         {currentComment.imageUrl && (
                           <S.CommentImageContainer>
-                            <S.CommentImage src={currentComment.imageUrl} alt="코멘트 이미지" />
+                            <S.CommentImage
+                              src={currentComment.imageUrl}
+                              alt="코멘트 이미지"
+                              onClick={e => handleImageClick(currentComment.imageUrl!, e)}
+                            />
                           </S.CommentImageContainer>
                         )}
                       </S.CommentContent>

--- a/client/src/features/moment/ui/MyMomentsCard.tsx
+++ b/client/src/features/moment/ui/MyMomentsCard.tsx
@@ -64,16 +64,20 @@ export const MyMomentsCard = ({ myMoment }: { myMoment: MomentWithNotifications 
           <WriteTime date={myMoment.createdAt} />
         </S.MyMomentsTitleWrapper>
         <S.MyMomentsContent>{myMoment.content}</S.MyMomentsContent>
-        {myMoment.imageUrl && (
-          <S.MomentImageContainer>
-            <S.MomentImage src={myMoment.imageUrl} alt="모멘트 이미지" />
-          </S.MomentImageContainer>
-        )}
-        <S.MyMomentsTagWrapper>
-          {myMoment.tagNames.map((tag: string) => (
-            <Tag key={tag} tag={tag} />
-          ))}
-        </S.MyMomentsTagWrapper>
+        <S.MyMomentsBottomWrapper>
+          {myMoment.imageUrl ? (
+            <S.MomentImageContainer>
+              <S.MomentImage src={myMoment.imageUrl} alt="모멘트 이미지" />
+            </S.MomentImageContainer>
+          ) : (
+            <div />
+          )}
+          <S.MyMomentsTagWrapper>
+            {myMoment.tagNames.map((tag: string) => (
+              <Tag key={tag} tag={tag} />
+            ))}
+          </S.MyMomentsTagWrapper>
+        </S.MyMomentsBottomWrapper>
       </S.MyMomentsCard>
       {isOpen && (
         <Modal

--- a/client/src/features/moment/ui/TodayMomentForm.tsx
+++ b/client/src/features/moment/ui/TodayMomentForm.tsx
@@ -40,6 +40,11 @@ export function TodayMomentForm({
       return;
     }
 
+    if (tagNames.length > 3) {
+      showError('태그는 최대 3개까지 선택할 수 있습니다.');
+      return;
+    }
+
     handleSendContent();
     navigate(ROUTES.TODAY_MOMENT_SUCCESS);
   };

--- a/client/src/shared/hooks/useShowFullImage.ts
+++ b/client/src/shared/hooks/useShowFullImage.ts
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+import { createPortal } from 'react-dom';
+
+export const useShowFullImage = () => {
+  const [fullImageSrc, setFullImageSrc] = useState<string | null>(null);
+
+  const handleImageClick = (imageUrl: string, event: React.MouseEvent) => {
+    event.stopPropagation();
+    setFullImageSrc(imageUrl);
+  };
+
+  const closeFullImage = () => {
+    setFullImageSrc(null);
+  };
+
+  const ImageOverlayPortal = ({ children }: { children: React.ReactNode }) => {
+    return createPortal(children, document.body);
+  };
+
+  return {
+    fullImageSrc,
+    handleImageClick,
+    closeFullImage,
+    ImageOverlayPortal,
+  };
+};


### PR DESCRIPTION
# 📋 연관 이슈

- close #692 

# 🚀 작업 내용
사용자 피드백, QA 기반으로 나온 개선안 작업 진행했습니다.

1. 태그 개수 제한 설정
  - 최대 3개만 등록할 수 있도록 수정

2. 이미지 UI 개선
  - 기본적으로 80x80 미리보기 이미지가 보이도록 함
  - 미리보기 이미지 클릭시 전체 이미지가 큰 화면으로 보이도록 함

3. 오늘의 코멘트, 나의 모음집 UI 개선
  - 위 변경사항에 따른 UI 개선
  - 나의 모멘트 모달에서 스크롤 디자인 개선

4. Footer 추가
  - 카카오 문의하기 추가

## 📸 Test Screenshot
### 오늘의 코멘트
전
<img width="1728" height="956" alt="image" src="https://github.com/user-attachments/assets/1feb33ff-3a44-47fb-bd98-34858bb1996d" />
후
<img width="1728" height="956" alt="image" src="https://github.com/user-attachments/assets/7ea0e88a-b9d8-4497-8077-551b044cd9f3" />
이미지 클릭시
<img width="1728" height="956" alt="image" src="https://github.com/user-attachments/assets/1bc47ec5-65de-4dee-bdf6-759ae2bc13fd" />

## 나의 모멘트 모음집
전
<img width="300" height="349" alt="image" src="https://github.com/user-attachments/assets/2d461993-e46e-418f-a87b-7e685e0010e0" />
<img width="300" height="502" alt="image" src="https://github.com/user-attachments/assets/106407c4-e0a3-4974-911d-3981c9989c73" />

후
<img width="300" height="375" alt="image" src="https://github.com/user-attachments/assets/faa454c8-72b6-4203-90a1-68434bf0e8f2" />
<img width="300" height="563" alt="image" src="https://github.com/user-attachments/assets/13b2a001-5127-49fb-8628-a57f4af7d940" />



## 나의 코멘트 모음집
전
<img width="1072" height="844" alt="image" src="https://github.com/user-attachments/assets/8fd660eb-3e1d-4ad1-ac7d-40a4365dab9e" />

후
<img width="1072" height="717" alt="image" src="https://github.com/user-attachments/assets/049f9835-97c5-463e-8994-fbb8652f815e" />

## Footer
<img width="1728" height="957" alt="image" src="https://github.com/user-attachments/assets/77fb07f3-6992-41c4-9e8e-7f88743923f7" />

