### PR TITLE
[FIX] CI 무한 빌드 현상 해결

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "pnpm exec webpack serve --config webpack.dev.js",
+    "dev:analyze": "ANALYZE_BUNDLE=true pnpm exec webpack serve --config webpack.dev.js",
     "build": "pnpm exec webpack --config webpack.prod.js",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",

--- a/client/webpack.common.js
+++ b/client/webpack.common.js
@@ -5,7 +5,6 @@ import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import webpack from 'webpack';
-import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 
 dotenv.config();
 
@@ -77,7 +76,6 @@ const config = {
       'process.env.REACT_APP_GA_ID': JSON.stringify(process.env.REACT_APP_GA_ID || ''),
       'process.env.REACT_APP_SENTRY_DSN': JSON.stringify(process.env.REACT_APP_SENTRY_DSN || ''),
     }),
-    new BundleAnalyzerPlugin(),
   ],
 };
 

--- a/client/webpack.dev.js
+++ b/client/webpack.dev.js
@@ -2,6 +2,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { merge } from 'webpack-merge';
 import common from './webpack.common.js';
+import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -43,4 +44,5 @@ export default merge(common, {
       overlay: true,
     },
   },
+  plugins: [...(process.env.ANALYZE_BUNDLE === 'true' ? [new BundleAnalyzerPlugin()] : [])],
 });


### PR DESCRIPTION
# 📋 연관 이슈

- close #715 

# 🚀 작업 내용

- `BundleAnalyzerPlugin`을 개발 환경에서만 사용할 수 있도록 수정
- `package.json`에 `dev:analyze` 명령어를 등록해, BundleAnalyzer를 사용하고 싶을 때만 열리도록 함


## 📝 Additional Description

<!-- 추가적인 설명이나 고려사항이 있다면 작성하세요 -->

- `BundleAnalyzerPlugin`은 기본적으로 웹 서버를 실행하고 브라우저를 열어 번들 분석 결과를 시각화하려고 하는데, 
CI 환경에서는 브라우저가 없고 서버가 계속 대기 상태에 머무르기 때문에 무한 대기를 일으킨다고 합니다.

## 🔗 Related Links

<!-- 관련된 문서나 참고 자료 링크 -->

- https://github.com/webpack-contrib/webpack-bundle-analyzer/discussions/614
  > By default, webpack bundle analyzer starts a server, which means that the webpack process will never terminate.
This is undesirable in CI and other non-interactive environments - your jobs will hang indefinitely. Currently (as far as I can tell) there's no way to prevent this from happening without changing the webpack configuration code. 
