### PR TITLE
[FIX] p6spy 로그 수집 경로 수정

### DIFF
--- a/server/src/main/resources/logback-dev.xml
+++ b/server/src/main/resources/logback-dev.xml
@@ -45,7 +45,7 @@
         <appender-ref ref="CUSTOM_FILE"/>
     </logger>
 
-    <logger name="com.p6spy" level="INFO" additivity="false">
+    <logger name="p6spy" level="INFO" additivity="false">
         <appender-ref ref="P6SPY_FILE"/>
     </logger>
 


### PR DESCRIPTION
# 📋 연관 이슈

- close #698 

# 🚀 작업 내용

- 1. logback에서 p6spy와 관련한 로그를 잘 수집할 수 있도록 logger 경로를 수정해주었습니다.

