### PR TITLE
[REFACTOR] comments 인덱스 수정

### DIFF
--- a/server/src/main/resources/db/migration/mysql/V19__create_comments_mysql.sql
+++ b/server/src/main/resources/db/migration/mysql/V19__create_comments_mysql.sql
@@ -1,0 +1,2 @@
+DROP INDEX idx_comments_commenter_created_id ON comments;
+CREATE INDEX idx_comments_commenter_deleted_created_id ON comments (commenter_id, deleted_at, created_at DESC, id DESC);

--- a/server/src/test/resources/db/migration/h2/V19__create_comments.mysql.sql
+++ b/server/src/test/resources/db/migration/h2/V19__create_comments.mysql.sql
@@ -1,0 +1,2 @@
+DROP INDEX idx_comments_commenter_created_id ON comments;
+CREATE INDEX idx_comments_commenter_deleted_created_id ON comments (commenter_id, deleted_at, created_at DESC, id DESC);


### PR DESCRIPTION
# 📋 연관 이슈

- close #724 

# 🚀 작업 내용

- 1. Mysql 옵티마이저가 조회 쿼리 실행 시 인덱스를 선택하지 않는 경우가 있어, where & order by 절의 컬럼을 모두 인덱스로 묶어주어 옵티마이저가 실행 계획 판단 시 인덱스를 사용할 수 있도록 수정하였습니다.
