### PR TITLE
[FIX] 코멘트, 모멘트 삭제 플로우 변경

### DIFF
--- a/server/src/main/java/moment/comment/application/CommentService.java
+++ b/server/src/main/java/moment/comment/application/CommentService.java
@@ -210,10 +210,15 @@ public class CommentService {
                 comment.getId(),
                 request.reason());
 
-        commentRepository.delete(comment);
-        echoService.deleteByComment(comment);
-        commentImageService.deleteByComment(comment);
+        deleteComment(comment);
 
         return CommentReportCreateResponse.from(savedReport);
+    }
+
+    @Transactional
+    public void deleteComment(Comment comment) {
+        echoService.deleteByComment(comment);
+        commentImageService.deleteByComment(comment);
+        commentRepository.delete(comment);
     }
 }

--- a/server/src/main/java/moment/moment/application/MomentService.java
+++ b/server/src/main/java/moment/moment/application/MomentService.java
@@ -56,7 +56,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MomentService {
 
     private static final int MOMENT_DELETE_THRESHOLD = 3;
-    
+
     private final MomentRepository momentRepository;
     private final CommentQueryService commentQueryService;
     private final EchoQueryService echoQueryService;
@@ -237,7 +237,8 @@ public class MomentService {
             commentableMoments = momentRepository.findCommentableMoments(user, threeDaysAgo, reportedMomentIds);
         }
         if (!tagNames.isEmpty()) {
-            commentableMoments = momentRepository.findCommentableMomentsByTagNames(user, threeDaysAgo, tagNames, reportedMomentIds);
+            commentableMoments = momentRepository.findCommentableMomentsByTagNames(user, threeDaysAgo, tagNames,
+                    reportedMomentIds);
         }
 
         if (commentableMoments.isEmpty()) {
@@ -288,11 +289,15 @@ public class MomentService {
         long reportCount = reportService.countReportsByTarget(TargetType.MOMENT, moment.getId());
 
         if (reportCount >= MOMENT_DELETE_THRESHOLD) {
-            momentRepository.delete(moment);
-            momentImageService.deleteByMoment(moment);
-            momentTagService.deleteByMoment(moment);
+            deleteMoment(moment);
         }
 
         return MomentReportCreateResponse.from(report);
+    }
+
+    public void deleteMoment(Moment moment) {
+        momentImageService.deleteByMoment(moment);
+        momentTagService.deleteByMoment(moment);
+        momentRepository.delete(moment);
     }
 }


### PR DESCRIPTION
# 📋 연관 이슈

- close #735 

# 🚀 작업 내용

- 1. 코멘트 삭제 시, 연관관계가 한번에 삭제되도록 메서드로 분리했습니다.
- 2. 모멘트 삭제 시, 연관관계가 한번에 삭제되도록 메서드로 분리했습니다.