### PR TITLE
[FIX] 불필요 인덱스 삭제 및 해당 인덱스 사용하는 fk 인덱스 별도로 추가

### DIFF
--- a/server/src/main/resources/db/migration/mysql/V19__create_comments__mysql.sql
+++ b/server/src/main/resources/db/migration/mysql/V19__create_comments__mysql.sql
@@ -1,0 +1,2 @@
+ALTER TABLE comments ADD INDEX idx_commenter_id (commenter_id);
+ALTER TABLE comments DROP INDEX idx_comments_commenter_created_id;

--- a/server/src/main/resources/db/migration/mysql/V19__create_comments_mysql.sql
+++ b/server/src/main/resources/db/migration/mysql/V19__create_comments_mysql.sql
@@ -1,2 +1,0 @@
-DROP INDEX idx_comments_commenter_created_id ON comments;
-CREATE INDEX idx_comments_commenter_deleted_created_id ON comments (commenter_id, deleted_at, created_at DESC, id DESC);

--- a/server/src/main/resources/db/migration/mysql/V20__create_comments__mysql.sql
+++ b/server/src/main/resources/db/migration/mysql/V20__create_comments__mysql.sql
@@ -1,2 +1,0 @@
-DROP INDEX idx_comments_commenter_deleted_created_id ON comments;
-CREATE INDEX idx_comments_commenter_deleted_created_id_moment ON comments (commenter_id, deleted_at, created_at DESC, id DESC, moment_id);

--- a/server/src/test/resources/db/migration/h2/V19__create_comments.mysql.sql
+++ b/server/src/test/resources/db/migration/h2/V19__create_comments.mysql.sql
@@ -1,2 +1,0 @@
-DROP INDEX idx_comments_commenter_created_id ON comments;
-CREATE INDEX idx_comments_commenter_deleted_created_id ON comments (commenter_id, deleted_at, created_at DESC, id DESC);

--- a/server/src/test/resources/db/migration/h2/V19__create_comments__h2.sql
+++ b/server/src/test/resources/db/migration/h2/V19__create_comments__h2.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_commenter_id ON comments(commenter_id);
+DROP INDEX idx_comments_commenter_created_id;


### PR DESCRIPTION
# 📋 연관 이슈

- close #724 

# 🚀 작업 내용

- 1. 쿼리 최적화에 사용되지 않는 인덱스를 삭제하였습니다. 이때 운영 서버에서 해당 인덱스를 외래키 제약에 사용하고 있어, 외래 키 인덱스를 별도로 추가해주었습니다.
