### PR TITLE
[FEAT] Sentry 개발/운영서버 환경 명시적 설정

### DIFF
--- a/client/instrument.js
+++ b/client/instrument.js
@@ -1,11 +1,23 @@
 import * as Sentry from '@sentry/react';
 
+function getEnvironmentFromDomain() {
+  if (typeof window === 'undefined') return 'development'; // SSR 대응
+
+  const hostname = window.location.hostname;
+
+  if (hostname === 'connectingmoment.com') {
+    return 'production';
+  }
+
+  return 'development';
+}
+
 Sentry.init({
   dsn: process.env.REACT_APP_SENTRY_DSN,
-  enabled: process.env.NODE_ENV === 'production',
+  enabled: getEnvironmentFromDomain() === 'production',
   sendDefaultPii: true,
   enableLogs: true,
-  environment: process.env.NODE_ENV,
+  environment: getEnvironmentFromDomain(),
 
   integrations: [],
 });


### PR DESCRIPTION
# 📋 연관 이슈

- close #737 

# 🚀 작업 내용

- 기존엔 개발/운영서버 모두 Sentry가 추적되도록 설정 되어 있어서 이를 분리했습니다.