### PR TITLE
refactor: 나의 코멘트 다음 페이지 쿼리 최적화

### DIFF
--- a/server/src/main/java/moment/comment/application/CommentService.java
+++ b/server/src/main/java/moment/comment/application/CommentService.java
@@ -154,15 +154,19 @@ public class CommentService {
 
     private List<Comment> getRawComments(Cursor cursor, User commenter, PageSize pageSize) {
         if (cursor.isFirstPage()) {
-            List<Long> commentIds = commentRepository.findCommentIdsByCommenter(commenter, pageSize.getPageRequest());
+            List<Long> commentIds = commentRepository.findFirstPageCommentIdsByCommenter(
+                    commenter,
+                    pageSize.getPageRequest());
 
             return commentRepository.findCommentsWithDetailsByIds(commentIds);
         }
-        return commentRepository.findCommentsNextPage(
+        List<Long> nextCommentIds = commentRepository.findNextPageCommentIdsByCommenter(
                 commenter,
                 cursor.dateTime(),
                 cursor.id(),
                 pageSize.getPageRequest());
+
+        return commentRepository.findCommentsWithDetailsByIds(nextCommentIds);
     }
 
     private List<Comment> removeCursor(List<Comment> commentsWithinCursor, PageSize pageSize) {

--- a/server/src/main/java/moment/comment/infrastructure/CommentRepository.java
+++ b/server/src/main/java/moment/comment/infrastructure/CommentRepository.java
@@ -16,40 +16,41 @@ import org.springframework.data.repository.query.Param;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @Query("""
-        SELECT c.id
-        FROM comments c
-        WHERE c.commenter = :commenter
-        ORDER BY c.createdAt DESC, c.id DESC
-    """)
-    List<Long> findCommentIdsByCommenter(@Param("commenter") User commenter, Pageable pageable);
+                SELECT c.id
+                FROM comments c
+                WHERE c.commenter = :commenter
+                ORDER BY c.createdAt DESC, c.id DESC
+            """)
+    List<Long> findFirstPageCommentIdsByCommenter(@Param("commenter") User commenter, Pageable pageable);
 
     @EntityGraph(attributePaths = {"moment.momenter"})
     @Query("""
-        SELECT c
-        FROM comments c
-        WHERE c.id IN :ids
-        ORDER BY c.createdAt DESC, c.id DESC
-    """)
+                SELECT c
+                FROM comments c
+                WHERE c.id IN :ids
+                ORDER BY c.createdAt DESC, c.id DESC
+            """)
     List<Comment> findCommentsWithDetailsByIds(@Param("ids") List<Long> ids);
 
     @EntityGraph(attributePaths = {"moment.momenter"})
     @Query("""
-            SELECT c FROM comments c
+            SELECT c
+            FROM comments c
             WHERE c.id IN :ids
             ORDER BY c.createdAt DESC, c.id DESC
             """)
     List<Comment> findUnreadCommentsFirstPage(@Param("ids") Set<Long> ids, Pageable pageable);
 
-    @EntityGraph(attributePaths = {"moment.momenter"})
     @Query("""
-            SELECT c FROM comments c
-            WHERE c.commenter = :commenter AND (c.createdAt < :cursorTime OR (c.createdAt = :cursorTime AND c.id < :cursorId))
-            ORDER BY c.createdAt DESC, c.id DESC
+                SELECT c.id
+                FROM comments c
+                WHERE c.commenter = :commenter AND (c.createdAt < :cursorTime OR (c.createdAt = :cursorTime AND c.id < :cursorId))
+                ORDER BY c.createdAt DESC, c.id DESC
             """)
-    List<Comment> findCommentsNextPage(@Param("commenter") User commenter,
-                                       @Param("cursorTime") LocalDateTime cursorDateTime,
-                                       @Param("cursorId") Long cursorId,
-                                       Pageable pageable);
+    List<Long> findNextPageCommentIdsByCommenter(@Param("commenter") User commenter,
+                                                 @Param("cursorTime") LocalDateTime cursorDateTime,
+                                                 @Param("cursorId") Long cursorId,
+                                                 Pageable pageable);
 
     @EntityGraph(attributePaths = {"moment.momenter"})
     @Query("""
@@ -58,9 +59,9 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             ORDER BY c.createdAt DESC, c.id DESC
             """)
     List<Comment> findUnreadCommentsNextPage(@Param("ids") Set<Long> ids,
-                                       @Param("cursorTime") LocalDateTime cursorDateTime,
-                                       @Param("cursorId") Long cursorId,
-                                       Pageable pageable);
+                                             @Param("cursorTime") LocalDateTime cursorDateTime,
+                                             @Param("cursorId") Long cursorId,
+                                             Pageable pageable);
 
     @EntityGraph(attributePaths = {"moment"})
     List<Comment> findAllByMomentIn(List<Moment> moments);

--- a/server/src/test/java/moment/comment/application/CommentServiceTest.java
+++ b/server/src/test/java/moment/comment/application/CommentServiceTest.java
@@ -51,7 +51,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -184,7 +183,7 @@ class CommentServiceTest {
 
         List<Comment> expectedComments = List.of(comment2, comment1);
 
-        given(commentRepository.findCommentIdsByCommenter(any(), any())).willReturn(List.of());
+        given(commentRepository.findFirstPageCommentIdsByCommenter(any(), any())).willReturn(List.of());
         given(commentRepository.findCommentsWithDetailsByIds(any(List.class))).willReturn(expectedComments);
         given(userQueryService.getUserById(any(Long.class))).willReturn(commenter);
         given(echoQueryService.getAllByCommentIn(any(List.class))).willReturn(Collections.emptyList());
@@ -325,7 +324,8 @@ class CommentServiceTest {
         assertAll(
                 () -> assertThat(response.items().myCommentsResponse()).hasSize(2),
                 () -> assertThat(response.hasNextPage()).isFalse(),
-                () -> then(notificationQueryService).should(times(1)).getUnreadContentsNotifications(commenter, TargetType.COMMENT),
+                () -> then(notificationQueryService).should(times(1))
+                        .getUnreadContentsNotifications(commenter, TargetType.COMMENT),
                 () -> then(commentRepository).should(times(1)).findUnreadCommentsFirstPage(any(), any())
         );
     }

--- a/server/src/test/java/moment/comment/infrastructure/CommentRepositoryTest.java
+++ b/server/src/test/java/moment/comment/infrastructure/CommentRepositoryTest.java
@@ -62,7 +62,8 @@ class CommentRepositoryTest {
         Comment savedComment2 = commentRepository.save(comment2);
 
         // when
-        List<Long> commentsIds = commentRepository.findCommentIdsByCommenter(savedCommenter, PageRequest.of(0, 2));
+        List<Long> commentsIds = commentRepository.findFirstPageCommentIdsByCommenter(savedCommenter,
+                PageRequest.of(0, 2));
         List<Comment> comments = commentRepository.findCommentsWithDetailsByIds(commentsIds);
 
         // then
@@ -114,10 +115,12 @@ class CommentRepositoryTest {
         Comment savedComment4 = commentRepository.save(comment4);
 
         // when
-        List<Comment> comments = commentRepository.findCommentsNextPage(savedCommenter,
+        List<Long> commentIds = commentRepository.findNextPageCommentIdsByCommenter(savedCommenter,
                 savedComment4.getCreatedAt(),
                 savedComment4.getId(),
                 PageRequest.of(0, 3));
+        
+        List<Comment> comments = commentRepository.findCommentsWithDetailsByIds(commentIds);
 
         // then
         assertAll(


### PR DESCRIPTION
# 📋 연관 이슈

- close #742 

# 🚀 작업 내용

- 1. 지연 조인을 사용해 나의 코멘트 다음 페이지 불러오는 쿼리를 최적화했습니다!

