### PR TITLE
[FEAT] 이메일 구독 설정 기능 추가

### DIFF
--- a/server/src/main/java/moment/global/exception/ErrorCode.java
+++ b/server/src/main/java/moment/global/exception/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     USER_NOT_ENOUGH_STAR("U-011", "사용 가능한 별조각을 확인해주세요.", HttpStatus.BAD_REQUEST),
     PASSWORD_SAME_AS_OLD("U-012", "새 비밀번호가 기존의 비밀번호와 동일합니다.", HttpStatus.BAD_REQUEST),
     PASSWORD_CHANGE_UNSUPPORTED_PROVIDER("U-013", "일반 회원가입 사용자가 아닌 경우 비밀번호를 변경할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    EMAIL_SUBSCRIPTION_INVALID("U-013", "유효하지 않은 이메일 구독 설정 정보입니다.", HttpStatus.BAD_REQUEST),
 
     TOKEN_INVALID("T-001", "유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
     TOKEN_EXPIRED("T-002", "만료된 토큰입니다.", HttpStatus.UNAUTHORIZED),

--- a/server/src/main/java/moment/user/application/MyPageService.java
+++ b/server/src/main/java/moment/user/application/MyPageService.java
@@ -9,7 +9,9 @@ import moment.reward.domain.RewardHistory;
 import moment.user.domain.ProviderType;
 import moment.user.domain.User;
 import moment.user.dto.request.ChangePasswordRequest;
+import moment.user.dto.request.EmailSubscriptionChangeRequest;
 import moment.user.dto.request.NicknameChangeRequest;
+import moment.user.dto.response.EmailSubscriptionChangeResponse;
 import moment.user.dto.response.MyPageProfileResponse;
 import moment.user.dto.response.MyRewardHistoryPageResponse;
 import moment.user.dto.response.NicknameChangeResponse;
@@ -100,5 +102,12 @@ public class MyPageService {
         if (!user.checkProviderType(ProviderType.EMAIL)) {
             throw new MomentException(ErrorCode.PASSWORD_CHANGE_UNSUPPORTED_PROVIDER);
         }
+    }
+
+    @Transactional
+    public EmailSubscriptionChangeResponse changeEmailSubscription(EmailSubscriptionChangeRequest request, Long id) {
+        User user = userQueryService.getUserById(id);
+        boolean updatedEmailSubscription = user.updateEmailSubscription(request.emailSubscription());
+        return new EmailSubscriptionChangeResponse(updatedEmailSubscription);
     }
 }

--- a/server/src/main/java/moment/user/domain/User.java
+++ b/server/src/main/java/moment/user/domain/User.java
@@ -146,4 +146,9 @@ public class User extends BaseEntity {
     public boolean checkProviderType(ProviderType providerType) {
         return this.providerType == providerType;
     }
+
+    public boolean updateEmailSubscription(Boolean emailSubscription) {
+        this.emailSubscription = emailSubscription;
+        return emailSubscription;
+    }
 }

--- a/server/src/main/java/moment/user/domain/User.java
+++ b/server/src/main/java/moment/user/domain/User.java
@@ -59,6 +59,9 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Level level = Level.ASTEROID_WHITE;
 
+    @Column(nullable = false)
+    private Boolean emailSubscription;
+
     private LocalDateTime deletedAt;
 
     public User(String email, String password, String nickname, ProviderType providerType) {
@@ -67,6 +70,16 @@ public class User extends BaseEntity {
         this.password = password;
         this.nickname = nickname;
         this.providerType = providerType;
+        this.emailSubscription = false;
+    }
+
+    public User(String email, String password, String nickname, ProviderType providerType, Boolean emailSubscription) {
+        validate(email, password, nickname);
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+        this.providerType = providerType;
+        this.emailSubscription = emailSubscription;
     }
 
     private void validate(String email, String password, String nickname) {

--- a/server/src/main/java/moment/user/dto/request/EmailSubscriptionChangeRequest.java
+++ b/server/src/main/java/moment/user/dto/request/EmailSubscriptionChangeRequest.java
@@ -1,0 +1,12 @@
+package moment.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "이메일 구독 설정 변경 요청")
+public record EmailSubscriptionChangeRequest(
+        @Schema(description = "이메일 구독 설정", example = "false")
+        @NotBlank(message = "EMAIL_SUBSCRIPTION_INVALID")
+        Boolean emailSubscription
+) {
+}

--- a/server/src/main/java/moment/user/dto/response/EmailSubscriptionChangeResponse.java
+++ b/server/src/main/java/moment/user/dto/response/EmailSubscriptionChangeResponse.java
@@ -1,0 +1,11 @@
+package moment.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "이메일 구독 설정 변경 응답")
+public record EmailSubscriptionChangeResponse(
+        @Schema(description = "변경된 이메일 구독 설정 정보", example = "false")
+        Boolean emailSubscription
+) {
+}
+

--- a/server/src/main/java/moment/user/dto/response/MyPageProfileResponse.java
+++ b/server/src/main/java/moment/user/dto/response/MyPageProfileResponse.java
@@ -26,7 +26,10 @@ public record MyPageProfileResponse(
         Integer nextStepExp,
 
         @Schema(description = "사용자 가입 유형", example = "EMAIL")
-        ProviderType loginType
+        ProviderType loginType,
+
+        @Schema(description = "이메일 구독 여부", example = "false")
+        Boolean emailSubscription
 ) {
     public static MyPageProfileResponse from(User user) {
         return new MyPageProfileResponse(
@@ -36,7 +39,8 @@ public record MyPageProfileResponse(
                 user.getAvailableStar(),
                 user.getExpStar(),
                 user.getLevel().getNextLevelRequiredStars(),
-                user.getProviderType()
+                user.getProviderType(),
+                user.getEmailSubscription()
         );
     }
 }

--- a/server/src/main/java/moment/user/presentation/MyPageController.java
+++ b/server/src/main/java/moment/user/presentation/MyPageController.java
@@ -174,7 +174,7 @@ public class MyPageController {
                     """,
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
     })
-    @PostMapping("/nickname")
+    @PostMapping("/email-subscription")
     public ResponseEntity<SuccessResponse<EmailSubscriptionChangeResponse>> changeEmailSubscription(
             @Valid @RequestBody EmailSubscriptionChangeRequest request,
             @AuthenticationPrincipal Authentication authentication

--- a/server/src/main/java/moment/user/presentation/MyPageController.java
+++ b/server/src/main/java/moment/user/presentation/MyPageController.java
@@ -16,7 +16,9 @@ import moment.global.dto.response.SuccessResponse;
 import moment.user.application.MyPageService;
 import moment.user.dto.request.Authentication;
 import moment.user.dto.request.ChangePasswordRequest;
+import moment.user.dto.request.EmailSubscriptionChangeRequest;
 import moment.user.dto.request.NicknameChangeRequest;
+import moment.user.dto.response.EmailSubscriptionChangeResponse;
 import moment.user.dto.response.MyPageProfileResponse;
 import moment.user.dto.response.MyRewardHistoryPageResponse;
 import moment.user.dto.response.NicknameChangeResponse;
@@ -161,5 +163,24 @@ public class MyPageController {
                 .header(HttpHeaders.SET_COOKIE, accessCookie.toString())
                 .header(HttpHeaders.SET_COOKIE, refreshCookie.toString())
                 .body(SuccessResponse.of(status, null));
+    }
+
+    @Operation(summary = "마이페이지 이메일 구독 설정", description = "유저의 이메일 구독 설정을 변경합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "이메일 구독 설정 변경 성공"),
+            @ApiResponse(responseCode = "404", description = """
+                    - [U-013] "유효하지 않은 이메일 구독 설정 정보입니다."
+                    - [U-002] 존재하지 않는 사용자입니다.
+                    """,
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+    })
+    @PostMapping("/nickname")
+    public ResponseEntity<SuccessResponse<EmailSubscriptionChangeResponse>> changeEmailSubscription(
+            @Valid @RequestBody EmailSubscriptionChangeRequest request,
+            @AuthenticationPrincipal Authentication authentication
+    ) {
+        EmailSubscriptionChangeResponse response = myPageService.changeEmailSubscription(request, authentication.id());
+        HttpStatus status = HttpStatus.OK;
+        return ResponseEntity.status(status).body(SuccessResponse.of(status, response));
     }
 }

--- a/server/src/main/resources/db/migration/mysql/V22__alter_users__mysql.sql
+++ b/server/src/main/resources/db/migration/mysql/V22__alter_users__mysql.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+    ADD COLUMN email_subscription BOOLEAN NOT NULL DEFAULT false;

--- a/server/src/test/resources/db/migration/h2/V22__alter_users__h2.sql
+++ b/server/src/test/resources/db/migration/h2/V22__alter_users__h2.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+    ADD COLUMN email_subscription BOOLEAN NOT NULL DEFAULT false;


### PR DESCRIPTION
# 📋 연관 이슈

- close #763 

# 🚀 작업 내용

- 1. 마이페이지에서 이메일 구독 설정을 변경할 수 있도록 관련 API 기능 추가 

마이페이지 이메일 구독 설정 변경 API

`/api/v1/me/email-subscription`

요청

```
{
  "emailSubscription" : "false"
}
```

응답
```
{
  "emailSubscription" : "false"
}
```


API 기능 설명

마이페이지에서 변경하고자 하는 이메일 구독 설정 상태를 요청 데이터로 전송하면 해당 상태에 맞게 유저의 이메일 구독 설정을 변경하고 현재 설정 상태를 응답합니다.

---

변경된 관련 기능

1. /api/v1/me/profile 조회 시 유저의 현재 emailSubscription 함께 반환하도록 응답 데이터 수정 

```
{
  "status": 200,
  "data": {
    "nickname": "신비로운 해성의 이카루스",
    "email": "test123@gmail.com",
    "level": "METEOR",
    "availableStar": 180,
    "expStar": 150,
    "nextStepExp": 200,
    "loginType": "EMAIL",
    "emailSubscription":"false"
  }
}
```

# 💬 리뷰 중점 사항

- 이메일 구독 설정 로직의 논리적 흐름에 문제가 없는지 확인 부탁드립니다.