### PR TITLE
[REFACTOR] 디바이스 엔드포인트 없는 경우만 저장하도록 로직 변경

### DIFF
--- a/server/src/main/java/moment/notification/infrastructure/PushNotificationRepository.java
+++ b/server/src/main/java/moment/notification/infrastructure/PushNotificationRepository.java
@@ -2,6 +2,7 @@ package moment.notification.infrastructure;
 
 import java.util.List;
 import moment.notification.domain.PushNotification;
+import moment.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,4 +12,6 @@ public interface PushNotificationRepository extends JpaRepository<PushNotificati
 
     @Transactional
     void deleteByDeviceEndpoint(String deviceEndpoint);
+
+    boolean existsByUserAndDeviceEndpoint(User user, String deviceEndpoint);
 }

--- a/server/src/main/java/moment/notification/service/application/PushNotificationApplicationService.java
+++ b/server/src/main/java/moment/notification/service/application/PushNotificationApplicationService.java
@@ -28,6 +28,6 @@ public class PushNotificationApplicationService {
 
     public void sendToDeviceEndpoint(long userId, PushNotificationMessage message) {
         User user = userService.getUserBy(userId);
-        pushNotificationSender.send(new PushNotificationCommand(user, PushNotificationMessage.REPLY_TO_MOMENT));
+        pushNotificationSender.send(new PushNotificationCommand(user, message));
     }
 }

--- a/server/src/main/java/moment/notification/service/notification/PushNotificationService.java
+++ b/server/src/main/java/moment/notification/service/notification/PushNotificationService.java
@@ -16,6 +16,9 @@ public class PushNotificationService {
 
     @Transactional
     public void save(User user, String deviceEndpoint) {
+        if(pushNotificationRepository.existsByUserAndDeviceEndpoint(user, deviceEndpoint)) {
+            return;
+        }
         pushNotificationRepository.save(new PushNotification(user, deviceEndpoint));
     }
 }

--- a/server/src/test/java/moment/notification/infrastructure/PushNotificationRepositoryTest.java
+++ b/server/src/test/java/moment/notification/infrastructure/PushNotificationRepositoryTest.java
@@ -4,14 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
-import java.util.Optional;
 import moment.notification.domain.PushNotification;
 import moment.user.domain.ProviderType;
 import moment.user.domain.User;
 import moment.user.infrastructure.UserRepository;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
@@ -80,5 +77,29 @@ class PushNotificationRepositoryTest {
 
         // then
         assertThat(foundNotification).isEmpty();
+    }
+
+    @Test
+    void 특정_user의_디바이스_엔드포인트_존재_여부를_판단한다() {
+        // given
+        User anotherUser = new User("cookie@gmail.com",  "cookie123!", "cookie", ProviderType.EMAIL);
+        userRepository.save(anotherUser);
+
+        String existingDeviceEndpoint = "existing-device-endpoint";
+        String nonExistingDeviceEndpoint = "non-existing-device-endpoint";
+
+        PushNotification pushNotification = new PushNotification(user, existingDeviceEndpoint);
+        PushNotification anotherUserPushNotification = new PushNotification(anotherUser, nonExistingDeviceEndpoint);
+
+        pushNotificationRepository.save(pushNotification);
+        pushNotificationRepository.save(anotherUserPushNotification);
+
+        // when
+        boolean shouldExist = pushNotificationRepository.existsByUserAndDeviceEndpoint(user, existingDeviceEndpoint);
+        boolean shouldNotExist = pushNotificationRepository.existsByUserAndDeviceEndpoint(user, nonExistingDeviceEndpoint);
+
+        // then
+        assertThat(shouldExist).isTrue();
+        assertThat(shouldNotExist).isFalse();
     }
 }


### PR DESCRIPTION
# 📋 연관 이슈

- close #

# 🚀 작업 내용

- 1. 푸시 알림을 위한 디바이스 엔드포인트를 저장할 시, 이미 저장된 디바이스면 저장하지 않도록 로직 수정