### PR TITLE
[FEAT] 디바이스 엔드포인트 삭제 API 구현

### DIFF
--- a/server/src/main/java/moment/notification/infrastructure/PushNotificationRepository.java
+++ b/server/src/main/java/moment/notification/infrastructure/PushNotificationRepository.java
@@ -14,4 +14,6 @@ public interface PushNotificationRepository extends JpaRepository<PushNotificati
     void deleteByDeviceEndpoint(String deviceEndpoint);
 
     boolean existsByUserAndDeviceEndpoint(User user, String deviceEndpoint);
+
+    void deleteByUser(User user);
 }

--- a/server/src/main/java/moment/notification/presentation/PushNotificationController.java
+++ b/server/src/main/java/moment/notification/presentation/PushNotificationController.java
@@ -14,6 +14,7 @@ import moment.notification.dto.request.DeviceEndPointRegisterRequest;
 import moment.notification.service.application.PushNotificationApplicationService;
 import moment.user.dto.request.Authentication;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -41,6 +42,14 @@ public class PushNotificationController {
             @AuthenticationPrincipal Authentication authentication
             ) {
         pushNotificationApplicationService.registerDeviceEndpoint(deviceEndPointRegisterRequest, authentication.id());
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping
+    public ResponseEntity<SuccessResponse<Void>> deleteDeviceEndpoint(
+            @AuthenticationPrincipal Authentication authentication
+    ) {
+        pushNotificationApplicationService.deleteDeviceEndpoint(authentication.id());
         return ResponseEntity.ok().build();
     }
 }

--- a/server/src/main/java/moment/notification/service/application/PushNotificationApplicationService.java
+++ b/server/src/main/java/moment/notification/service/application/PushNotificationApplicationService.java
@@ -30,4 +30,10 @@ public class PushNotificationApplicationService {
         User user = userService.getUserBy(userId);
         pushNotificationSender.send(new PushNotificationCommand(user, message));
     }
+
+    @Transactional
+    public void deleteDeviceEndpoint(Long userId) {
+        User user = userService.getUserBy(userId);
+        pushNotificationService.deleteBy(user);
+    }
 }

--- a/server/src/main/java/moment/notification/service/notification/PushNotificationService.java
+++ b/server/src/main/java/moment/notification/service/notification/PushNotificationService.java
@@ -21,4 +21,9 @@ public class PushNotificationService {
         }
         pushNotificationRepository.save(new PushNotification(user, deviceEndpoint));
     }
+
+    @Transactional
+    public void deleteBy(User user) {
+        pushNotificationRepository.deleteByUser(user);
+    }
 }

--- a/server/src/test/java/moment/notification/infrastructure/PushNotificationRepositoryTest.java
+++ b/server/src/test/java/moment/notification/infrastructure/PushNotificationRepositoryTest.java
@@ -102,4 +102,19 @@ class PushNotificationRepositoryTest {
         assertThat(shouldExist).isTrue();
         assertThat(shouldNotExist).isFalse();
     }
+
+    @Test
+    void 사용자로_푸시_알림_정보를_성공적으로_삭제한다() {
+        // given
+        String deviceToken = "test-device-token";
+        PushNotification pushNotification = new PushNotification(user, deviceToken);
+        pushNotificationRepository.save(pushNotification);
+
+        // when
+        pushNotificationRepository.deleteByUser(user);
+
+        // then
+        List<PushNotification> foundNotification = pushNotificationRepository.findByUserId(user.getId());
+        assertThat(foundNotification).isEmpty();
+    }
 }

--- a/server/src/test/java/moment/notification/presentation/PushNotificationControllerTest.java
+++ b/server/src/test/java/moment/notification/presentation/PushNotificationControllerTest.java
@@ -79,4 +79,22 @@ class PushNotificationControllerTest {
             () -> assertThat(notifications.get(0).getDeviceEndpoint()).isEqualTo("test-endpoint-arn")
         );
     }
+
+    @Test
+    void 사용자_디바이스_정보_삭제에_성공하면_DB에서_해당_정보가_삭제된다() {
+        // given
+        pushNotificationRepository.save(new PushNotification(user, "test-endpoint-arn"));
+
+        // when
+        RestAssured.given().log().all()
+            .contentType(ContentType.JSON)
+            .cookie("accessToken", accessToken)
+            .when().delete("/api/v1/push-notifications")
+            .then().log().all()
+            .statusCode(HttpStatus.OK.value());
+
+        // then
+        List<PushNotification> notifications = pushNotificationRepository.findByUserId(user.getId());
+        assertThat(notifications).isEmpty();
+    }
 }

--- a/server/src/test/java/moment/notification/service/notification/PushNotificationServiceTest.java
+++ b/server/src/test/java/moment/notification/service/notification/PushNotificationServiceTest.java
@@ -1,0 +1,88 @@
+package moment.notification.service.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.List;
+import moment.notification.domain.PushNotification;
+import moment.notification.infrastructure.PushNotificationRepository;
+import moment.user.domain.ProviderType;
+import moment.user.domain.User;
+import moment.user.infrastructure.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+@Transactional
+@ActiveProfiles("test")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class PushNotificationServiceTest {
+
+    @Autowired
+    private PushNotificationService pushNotificationService;
+
+    @Autowired
+    private PushNotificationRepository pushNotificationRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = new User("test@moment.com", "password123!", "tester", ProviderType.EMAIL);
+        userRepository.save(user);
+    }
+
+    @Test
+    void 푸시_알림_정보를_성공적으로_저장한다() {
+        // given
+        String deviceEndpoint = "test-device-endpoint";
+
+        // when
+        pushNotificationService.save(user, deviceEndpoint);
+
+        // then
+        List<PushNotification> notifications = pushNotificationRepository.findByUserId(user.getId());
+        assertAll(
+            () -> assertThat(notifications).hasSize(1),
+            () -> assertThat(notifications.get(0).getDeviceEndpoint()).isEqualTo(deviceEndpoint)
+        );
+    }
+
+    @Test
+    void 이미_존재하는_푸시_알림_정보는_저장하지_않는다() {
+        // given
+        String deviceEndpoint = "test-device-endpoint";
+        pushNotificationService.save(user, deviceEndpoint);
+
+        // when
+        pushNotificationService.save(user, deviceEndpoint);
+
+        // then
+        List<PushNotification> notifications = pushNotificationRepository.findByUserId(user.getId());
+        assertThat(notifications).hasSize(1);
+    }
+
+    @Test
+    void 사용자로_푸시_알림_정보를_성공적으로_삭제한다() {
+        // given
+        String deviceEndpoint = "test-device-endpoint";
+        pushNotificationService.save(user, deviceEndpoint);
+
+        // when
+        pushNotificationService.deleteBy(user);
+
+        // then
+        List<PushNotification> notifications = pushNotificationRepository.findByUserId(user.getId());
+        assertThat(notifications).isEmpty();
+    }
+}


### PR DESCRIPTION
# 📋 연관 이슈

- close #

# 🚀 작업 내용

- 1. 디바이스 엔드포인트 삭제를 요청할 수 있는 API를 구현하였습니다.

로그아웃 시 사용자가 푸시알림을 받지 않도록 하려면 로그아웃시 해당 기기의 디바이스 엔드포인트를 삭제해주어야 합니다.
따라서 클라이언트에서 디바이스 엔드포인트를 삭제할 수 있는 API를 요청할 수 있도록 해당 기능을 구현하였습니다.
