### PR TITLE
[FEAT] device endpoint 삭제 API 수정

### DIFF
--- a/server/src/main/java/moment/notification/dto/request/DeviceEndpointRequest.java
+++ b/server/src/main/java/moment/notification/dto/request/DeviceEndpointRequest.java
@@ -3,8 +3,8 @@ package moment.notification.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
-@Schema(description = "디바이스 정보 등록 요청")
-public record DeviceEndPointRegisterRequest(
+@Schema(description = "디바이스 정보 요청")
+public record DeviceEndpointRequest(
         @Schema(description = "디바이스 정보", example = "a1b2c3d4f5")
         @NotBlank
         String deviceEndpoint) {

--- a/server/src/main/java/moment/notification/infrastructure/PushNotificationRepository.java
+++ b/server/src/main/java/moment/notification/infrastructure/PushNotificationRepository.java
@@ -15,5 +15,5 @@ public interface PushNotificationRepository extends JpaRepository<PushNotificati
 
     boolean existsByUserAndDeviceEndpoint(User user, String deviceEndpoint);
 
-    void deleteByUser(User user);
+    void deleteByUserAndDeviceEndpoint(User user, String deviceEndpoint);
 }

--- a/server/src/main/java/moment/notification/presentation/PushNotificationController.java
+++ b/server/src/main/java/moment/notification/presentation/PushNotificationController.java
@@ -10,7 +10,7 @@ import lombok.RequiredArgsConstructor;
 import moment.auth.presentation.AuthenticationPrincipal;
 import moment.global.dto.response.ErrorResponse;
 import moment.global.dto.response.SuccessResponse;
-import moment.notification.dto.request.DeviceEndPointRegisterRequest;
+import moment.notification.dto.request.DeviceEndpointRequest;
 import moment.notification.service.application.PushNotificationApplicationService;
 import moment.user.dto.request.Authentication;
 import org.springframework.http.ResponseEntity;
@@ -38,18 +38,19 @@ public class PushNotificationController {
     })
     @PostMapping
     public ResponseEntity<SuccessResponse<Void>> registerDeviceEndpoint(
-            @RequestBody DeviceEndPointRegisterRequest deviceEndPointRegisterRequest,
+            @RequestBody DeviceEndpointRequest deviceEndpointRequest,
             @AuthenticationPrincipal Authentication authentication
-            ) {
-        pushNotificationApplicationService.registerDeviceEndpoint(deviceEndPointRegisterRequest, authentication.id());
+    ) {
+        pushNotificationApplicationService.registerDeviceEndpoint(authentication.id(), deviceEndpointRequest);
         return ResponseEntity.ok().build();
     }
 
     @DeleteMapping
     public ResponseEntity<SuccessResponse<Void>> deleteDeviceEndpoint(
+            @RequestBody DeviceEndpointRequest deviceEndpointRequest,
             @AuthenticationPrincipal Authentication authentication
     ) {
-        pushNotificationApplicationService.deleteDeviceEndpoint(authentication.id());
+        pushNotificationApplicationService.deleteDeviceEndpoint(authentication.id(), deviceEndpointRequest);
         return ResponseEntity.ok().build();
     }
 }

--- a/server/src/main/java/moment/notification/service/application/PushNotificationApplicationService.java
+++ b/server/src/main/java/moment/notification/service/application/PushNotificationApplicationService.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import moment.notification.domain.PushNotificationCommand;
 import moment.notification.domain.PushNotificationMessage;
 import moment.notification.domain.PushNotificationSender;
-import moment.notification.dto.request.DeviceEndPointRegisterRequest;
+import moment.notification.dto.request.DeviceEndpointRequest;
 import moment.notification.service.notification.PushNotificationService;
 import moment.user.domain.User;
 import moment.user.service.user.UserService;
@@ -21,7 +21,7 @@ public class PushNotificationApplicationService {
     private final PushNotificationSender pushNotificationSender;
 
     @Transactional
-    public void registerDeviceEndpoint(DeviceEndPointRegisterRequest request, long userId) {
+    public void registerDeviceEndpoint(long userId, DeviceEndpointRequest request) {
         User user = userService.getUserBy(userId);
         pushNotificationService.save(user, request.deviceEndpoint());
     }
@@ -32,8 +32,8 @@ public class PushNotificationApplicationService {
     }
 
     @Transactional
-    public void deleteDeviceEndpoint(Long userId) {
+    public void deleteDeviceEndpoint(long userId, DeviceEndpointRequest request) {
         User user = userService.getUserBy(userId);
-        pushNotificationService.deleteBy(user);
+        pushNotificationService.deleteBy(user, request.deviceEndpoint());
     }
 }

--- a/server/src/main/java/moment/notification/service/notification/PushNotificationService.java
+++ b/server/src/main/java/moment/notification/service/notification/PushNotificationService.java
@@ -23,7 +23,7 @@ public class PushNotificationService {
     }
 
     @Transactional
-    public void deleteBy(User user) {
-        pushNotificationRepository.deleteByUser(user);
+    public void deleteBy(User user, String deviceEndpoint) {
+        pushNotificationRepository.deleteByUserAndDeviceEndpoint(user, deviceEndpoint);
     }
 }

--- a/server/src/test/java/moment/notification/infrastructure/PushNotificationRepositoryTest.java
+++ b/server/src/test/java/moment/notification/infrastructure/PushNotificationRepositoryTest.java
@@ -8,6 +8,7 @@ import moment.notification.domain.PushNotification;
 import moment.user.domain.ProviderType;
 import moment.user.domain.User;
 import moment.user.infrastructure.UserRepository;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -80,7 +81,7 @@ class PushNotificationRepositoryTest {
     }
 
     @Test
-    void 특정_user의_디바이스_엔드포인트_존재_여부를_판단한다() {
+    void 사용자의_디바이스_엔드포인트_존재_여부를_판단한다() {
         // given
         User anotherUser = new User("cookie@gmail.com",  "cookie123!", "cookie", ProviderType.EMAIL);
         userRepository.save(anotherUser);
@@ -104,17 +105,25 @@ class PushNotificationRepositoryTest {
     }
 
     @Test
-    void 사용자로_푸시_알림_정보를_성공적으로_삭제한다() {
+    void 사용자와_디바이스_엔드포인트로_푸시_알림_정보를_성공적으로_삭제한다() {
         // given
         String deviceToken = "test-device-token";
+        String anotherToken = "another-test-device-token";
+
         PushNotification pushNotification = new PushNotification(user, deviceToken);
         pushNotificationRepository.save(pushNotification);
 
+        PushNotification anotherPushNotification = new PushNotification(user, anotherToken);
+        pushNotificationRepository.save(anotherPushNotification);
+
         // when
-        pushNotificationRepository.deleteByUser(user);
+        pushNotificationRepository.deleteByUserAndDeviceEndpoint(user, deviceToken);
 
         // then
         List<PushNotification> foundNotification = pushNotificationRepository.findByUserId(user.getId());
-        assertThat(foundNotification).isEmpty();
+        assertAll(
+                () -> assertThat(foundNotification).hasSize(1),
+                () -> assertThat(foundNotification.getFirst().getDeviceEndpoint()).isEqualTo(anotherToken)
+        );
     }
 }

--- a/server/src/test/java/moment/notification/presentation/PushNotificationControllerTest.java
+++ b/server/src/test/java/moment/notification/presentation/PushNotificationControllerTest.java
@@ -9,7 +9,7 @@ import java.util.List;
 import moment.auth.infrastructure.JwtTokenManager;
 import moment.common.DatabaseCleaner;
 import moment.notification.domain.PushNotification;
-import moment.notification.dto.request.DeviceEndPointRegisterRequest;
+import moment.notification.dto.request.DeviceEndpointRequest;
 import moment.notification.infrastructure.PushNotificationRepository;
 import moment.user.domain.ProviderType;
 import moment.user.domain.User;
@@ -61,7 +61,7 @@ class PushNotificationControllerTest {
     @Test
     void 사용자_디바이스_정보_저장에_성공하면_DB에_해당_정보가_저장된다() {
         // given
-        DeviceEndPointRegisterRequest request = new DeviceEndPointRegisterRequest("test-endpoint-arn");
+        DeviceEndpointRequest request = new DeviceEndpointRequest("test-endpoint-arn");
 
         // when
         RestAssured.given().log().all()
@@ -84,11 +84,13 @@ class PushNotificationControllerTest {
     void 사용자_디바이스_정보_삭제에_성공하면_DB에서_해당_정보가_삭제된다() {
         // given
         pushNotificationRepository.save(new PushNotification(user, "test-endpoint-arn"));
+        DeviceEndpointRequest request = new DeviceEndpointRequest("test-endpoint-arn");
 
         // when
         RestAssured.given().log().all()
             .contentType(ContentType.JSON)
             .cookie("accessToken", accessToken)
+            .body(request)
             .when().delete("/api/v1/push-notifications")
             .then().log().all()
             .statusCode(HttpStatus.OK.value());

--- a/server/src/test/java/moment/notification/service/notification/PushNotificationServiceTest.java
+++ b/server/src/test/java/moment/notification/service/notification/PushNotificationServiceTest.java
@@ -79,7 +79,7 @@ class PushNotificationServiceTest {
         pushNotificationService.save(user, deviceEndpoint);
 
         // when
-        pushNotificationService.deleteBy(user);
+        pushNotificationService.deleteBy(user, deviceEndpoint);
 
         // then
         List<PushNotification> notifications = pushNotificationRepository.findByUserId(user.getId());


### PR DESCRIPTION
# 📋 연관 이슈

- close #

# 🚀 작업 내용

- 1. 어제 빼먹은 커밋 추가했습니다. 어제 push한 요소에는 사용자의 device endpoint를 전부 삭제하도록 구현한 커밋만 올라갔는데, requestbody에 device endpoint를 담아서 특정 device endpoint만 삭제할 수 있도록 API를 변경한 커밋을 푸시해요...^^ 호호