### PR TITLE
[FIX] 이미지 경로 오타 수정

### DIFF
--- a/client/src/pages/home/index.tsx
+++ b/client/src/pages/home/index.tsx
@@ -41,7 +41,7 @@ export default function HomePage() {
           <S.IntroImagesWrapper>
             <S.IntroIcon src="/images/rocket.webp" alt="" />
             <S.IntroIcon src="/images/paperAirplane.webp" alt="" />
-            <S.IntroIcon src="/images/spaceman.webp" alt="" />
+            <S.IntroIcon src="/images/spaceMan.webp" alt="" />
           </S.IntroImagesWrapper>
         </S.IntroSection>
       </AnimatedIntroSection>


### PR DESCRIPTION
# 📋 연관 이슈

- close #846 

# 🚀 작업 내용

이미지 경로 오타로 인해 이미지 깨짐 현상이 발생해여 수정했습니다. 
로컬에서는 잘 보였어서 오타 있음을 인지하지 못했습니다..  개발 서버에서는 깨지더라고요.

신기해서 찾아보니 로컬과 배포환경에서의 파일 시스템 관리방법 차이 때문에 발생한 것 같습니다.

환경 | 파일 시스템 | 대소문자 구분 | 결과
-- | -- | -- | --
로컬 (Windows/macOS 기본) | NTFS / APFS (case-insensitive) | 구분 안 함 | spaceman.webp도 spaceMan.webp로 인식되어 표시됨
배포 서버 (Linux) | ext4 등 | 구분함 | spaceman.webp는 spaceMan.webp와 다른 파일로 간주되어 이미지 깨짐 ​




<img width="565" height="592" alt="스크린샷 2025-10-18 20 17 31" src="https://github.com/user-attachments/assets/8eedcd07-240f-4982-a950-afeac1c97677" />

## 📝 Additional Description

<!-- 추가적인 설명이나 고려사항이 있다면 작성하세요 -->
