### PR TITLE
[FIX] application.yml forward-headers-strategy 설정 native로 변경

### DIFF
--- a/server/src/main/resources/application-dev.yml
+++ b/server/src/main/resources/application-dev.yml
@@ -67,10 +67,10 @@ auth:
     redirect-uri: https://dev.connectingmoment.com/api/v1/auth/callback/google
     client-uri: https://dev.connectingmoment.com
   password_update:
-    uri: http://dev.connectingmoment.com/passwordUpdate?token=
+    uri: https://dev.connectingmoment.com/passwordUpdate?token=
 
 server:
-  forward-headers-strategy: none
+  forward-headers-strategy: native
 
 management:
   metrics:

--- a/server/src/main/resources/application-prod.yml
+++ b/server/src/main/resources/application-prod.yml
@@ -73,12 +73,12 @@ auth:
     client-id: ${GOOGLE_CLIENT_ID}
     client-secret: ${GOOGLE_CLIENT_SECRET}
     redirect-uri: https://connectingmoment.com/api/v1/auth/callback/google
-    client-uri: https://www.connectingmoment.com
+    client-uri: https://connectingmoment.com
   password_update:
     uri: https://connectingmoment.com/passwordUpdate?token=
 
 server:
-  forward-headers-strategy: none
+  forward-headers-strategy: native
   tomcat:
     mbeanregistry:
       enabled: true


### PR DESCRIPTION
# 📋 연관 이슈

- close #

# 🚀 작업 내용

- 1.application.yml forward-headers-strategy 설정 native로 변경

Cloud Front에서 Https 요청을 처리하고 Http요청으로 변환해서 Server에게 전달했다는 것을 알려주는 X-Forwarded-Proto 헤더를 Spring Boot가 정확하게 인식하게 하기 위해서   forward-headers-strategy: naive 설정 적용

application.yml
```
server:
  forward-headers-strategy: naive
```

## 📝 Additional Description

🧐 왜 native인가요?
이 설정에는 3가지 옵션이 있습니다. 차이를 알면 이해가 빠릅니다.

none (또는 설정 삭제 시 기본값):

"나는 앞단에 누가 있든 상관 안 해. 내가 직접 받은 요청(HTTP)만 믿을 거야."

결과: Nginx가 보낸 헤더를 싹 무시합니다. (리다이렉트 문제 발생)

native (추천):

"나는 내장 WAS(Tomcat)의 기능을 믿을게."

Tomcat이 자체적으로 X-Forwarded-* 헤더를 해석해서, request.getRemoteAddr()이나 request.getScheme()의 결과를 Nginx가 보낸 값으로 바꿔치기 해줍니다.

성능이 가장 좋고 깔끔합니다.

framework:

Tomcat 기능 말고, Spring Framework가 직접 필터(ForwardedHeaderFilter)를 돌려서 처리합니다.

보통 native가 안 먹히는 특수한 WAS를 쓸 때 사용합니다.
