### PR TITLE
[FIX] S3 파일 접근 URL CloudFront URL로 변경

### DIFF
--- a/server/src/main/resources/application-dev.yml
+++ b/server/src/main/resources/application-dev.yml
@@ -95,6 +95,7 @@ s3:
   bucket-name: ${S3_BUCKET_NAME}
   bucket-path: ${S3_DEV_BUCKET_PATH}
   optimized-bucket-path: ${S3_DEV_BUCKET_OPTIMIZED_PATH}
+  cloudfront-domain: ${CLOUDFRONT_DOMAIN}
 
 fcm:
   service-account-json: ${FCM_CREDENTIALS}

--- a/server/src/main/resources/application-prod.yml
+++ b/server/src/main/resources/application-prod.yml
@@ -128,6 +128,7 @@ s3:
   bucket-name: ${S3_BUCKET_NAME}
   bucket-path: ${S3_PROD_BUCKET_PATH}
   optimized-bucket-path: ${S3_PROD_BUCKET_OPTIMIZED_PATH}
+  cloudfront-domain: ${CLOUDFRONT_DOMAIN}
 
 fcm:
   service-account-json: ${FCM_CREDENTIALS}

--- a/server/src/test/java/moment/storage/application/FileStorageServiceTest.java
+++ b/server/src/test/java/moment/storage/application/FileStorageServiceTest.java
@@ -45,7 +45,7 @@ class FileStorageServiceTest {
         String originalFilename = "test-image.jpg";
         UploadUrlRequest request = new UploadUrlRequest(originalFilename, "jpg");
         String expectedUrl = "http://ap2-northest-s3/test-bucket/images/test-image.jpg";
-        String expectedFilePath = "test-bucket/images/test-image.jpg";
+        String expectedFilePath = "https://test-cloudfront.example.com/test/images/test-image.jpg";
         UploadUrlResponse expected = new UploadUrlResponse(expectedUrl, expectedFilePath);
         UploadUrlResponse uploadUrl;
         given(awsS3Client.getUploadUrl(any(String.class))).willReturn(expected);

--- a/server/src/test/resources/application-test.yml
+++ b/server/src/test/resources/application-test.yml
@@ -73,6 +73,7 @@ s3:
   bucket-name: test-bucket-1
   bucket-path: test/images
   optimized-bucket-path: test/optimized-images
+  cloudfront-domain: https://test-cloudfront.example.com
 
 fcm:
   service-account-json: ""


### PR DESCRIPTION
# 📋 연관 이슈

close #978 

# 🚀 작업 내용

- 1. 기존 S3로 바로 접근 가능했던 이미지 URL을 CloudFront를 경유하는 URL로 변경합니다.

# 추가

- 기존 dev, prod server에 CLOUDFRONT_DOMAIN 환경 변수를 추가 해야 합니다. 
- 저장되어 있던 이미지 URL을 CloudFront를 경우하는 URL 로 변경합니다.