### PR TITLE
[FIX] admin 모듈 prod 환경 Swagger UI 활성화

### DIFF
--- a/server/admin/src/main/resources/application-prod.yml
+++ b/server/admin/src/main/resources/application-prod.yml
@@ -35,10 +35,9 @@ spring:
     timeout: ${ADMIN_SESSION_TIMEOUT:3600s}
 
 springdoc:
-  api-docs:
-    enabled: false
   swagger-ui:
-    enabled: false
+    disable-swagger-default-url: true
+    url: /v3/api-docs
 
 server:
   port: 8081


### PR DESCRIPTION
# 📋 연관 이슈

close #1089

# 🚀 작업 내용

- `admin/src/main/resources/application-prod.yml`에서 springdoc 비활성화 설정 제거 및 API 모듈과 동일한 설정으로 통일
  - 제거: `api-docs.enabled: false`, `swagger-ui.enabled: false`
  - 추가: `swagger-ui.disable-swagger-default-url: true`, `swagger-ui.url: /v3/api-docs`
  ```yaml
  # Before
  springdoc:
    api-docs:
      enabled: false
    swagger-ui:
      enabled: false

  # After
  springdoc:
    swagger-ui:
      disable-swagger-default-url: true
      url: /v3/api-docs
  ```

# 💬 리뷰 중점 사항

- **운영 환경 Swagger 노출**: `application-prod.yml:37-40` — prod에서 Swagger UI가 활성화됨. 별도 개발 서버가 없어 의도된 설정이나, CloudFront + Nginx 커스텀 헤더(`x-origin-verify`)로 직접 접근이 차단되는지 확인 필요

## 📝 Additional Description

API 모듈(`api/src/main/resources/application-prod.yml:78-81`)은 이미 동일한 springdoc 설정으로 Swagger가 활성화되어 있었으나, admin 모듈만 `enabled: false`로 비활성화되어 있었음. 두 모듈 간 설정 통일.