### PR TITLE
[FEAT] Storybook Chromatic CD 구축

### DIFF
--- a/.github/workflows/prod-client-storybook.yml
+++ b/.github/workflows/prod-client-storybook.yml
@@ -1,4 +1,4 @@
-name: Deploy Storybook to GitHub Pages
+name: Deploy Storybook to Chromatic
 
 on:
   push:
@@ -7,10 +7,16 @@ on:
     paths:
       - 'client/src/**/*.stories.tsx'
       - 'client/src/shared/ui/**'
+      - 'client/.storybook/**'
+  pull_request:
+    paths:
+      - 'client/src/**/*.stories.tsx'
+      - 'client/src/shared/ui/**'
+      - 'client/.storybook/**'
   workflow_dispatch:
 
 jobs:
-  deploy:
+  chromatic:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -19,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -33,11 +41,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Build Storybook
-        run: pnpm run build-storybook
-
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Publish to Chromatic
+        uses: chromaui/action@latest
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./client/storybook-static
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          workingDir: ./client

--- a/client/package.json
+++ b/client/package.json
@@ -73,6 +73,7 @@
     "@types/react-dom": "^19.1.6",
     "babel-jest": "^30.0.4",
     "babel-loader": "^10.0.0",
+    "chromatic": "^16.6.3",
     "compression-webpack-plugin": "^11.1.0",
     "copy-webpack-plugin": "^13.0.0",
     "css-loader": "^7.1.2",

--- a/client/package.json
+++ b/client/package.json
@@ -25,7 +25,8 @@
     "converter:csv": "node src/shared/utils/csvToTs.js",
     "analyze:design": "tsx scripts/analyze-design/index.ts",
     "codemod": "tsx scripts/codemod/index.ts",
-    "codemod:apply": "tsx scripts/codemod/index.ts --apply"
+    "codemod:apply": "tsx scripts/codemod/index.ts --apply",
+    "chromatic": "chromatic --project-token=$CHROMATIC_PROJECT_TOKEN"
   },
   "license": "MIT",
   "sideEffects": [

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       babel-loader:
         specifier: ^10.0.0
         version: 10.0.0(@babel/core@7.28.4)(webpack@5.102.1)
+      chromatic:
+        specifier: ^16.6.3
+        version: 16.6.3
       compression-webpack-plugin:
         specifier: ^11.1.0
         version: 11.1.0(webpack@5.102.1)
@@ -3001,6 +3004,21 @@ packages:
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
+
+  chromatic@16.6.3:
+    resolution: {integrity: sha512-N9WCRuezqrxujRvgnAlE9XKxXcF6q2kowKH2Ba82FYkRc4xlY9g8r+ESEph9jLv500s43/9oDmB/kZ9r24BcgQ==}
+    hasBin: true
+    peerDependencies:
+      '@chromatic-com/cypress': ^0.*.* || ^1.0.0
+      '@chromatic-com/playwright': ^0.*.* || ^1.0.0
+      '@chromatic-com/vitest': ^0.*.* || ^1.0.0
+    peerDependenciesMeta:
+      '@chromatic-com/cypress':
+        optional: true
+      '@chromatic-com/playwright':
+        optional: true
+      '@chromatic-com/vitest':
+        optional: true
 
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
@@ -8782,7 +8800,7 @@ snapshots:
 
   '@testing-library/dom@10.4.1':
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.0
       '@babel/runtime': 7.28.4
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
@@ -9692,6 +9710,10 @@ snapshots:
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
+
+  chromatic@16.6.3:
+    dependencies:
+      semver: 7.7.3
 
   chrome-trace-event@1.0.4: {}
 


### PR DESCRIPTION
## 관련 이슈
close #1137

## 배경

기존 GitHub Pages 방식은 main 브랜치에 머지된 이후에만 배포되어, PR 단계에서 스토리북 변경 사항을 미리 확인할 수 없었습니다.

또한 `.storybook/**` 설정 변경이 트리거 paths에 포함되지 않아, 스토리북 설정을 수정해도 자동 배포가 동작하지 않는 문제가 있었습니다.

Chromatic으로 전환하면 PR을 열 때마다 미리보기 URL이 자동으로 코멘트에 등록되어, 머지 전에 컴포넌트 변경을 바로 확인할 수 있습니다.

## 변경 사항
- GitHub Pages 기반 Storybook 배포 → Chromatic으로 전환
- `pull_request` 트리거 추가 (PR마다 미리보기 URL 자동 제공)
- `.storybook/**` 경로 변경 시 트리거 추가
- `fetch-depth: 0` 추가 (Chromatic 변경 감지에 전체 히스토리 필요)
- `chromatic` 패키지 추가

## 사전 작업
- [x] GitHub Secrets에 `CHROMATIC_PROJECT_TOKEN` 등록