### PR TITLE
[FEAT] SSE 재연결 시 알림 데이터 재동기화 및 모바일 WebView 대응

### DIFF
--- a/client/src/features/notification/hooks/useSSENotifications.ts
+++ b/client/src/features/notification/hooks/useSSENotifications.ts
@@ -14,10 +14,7 @@ export const useSSENotifications = () => {
   const isFirstConnectRef = useRef(true);
 
   const connect = useCallback(() => {
-    if (
-      eventSourceRef.current &&
-      eventSourceRef.current.readyState !== EventSource.CLOSED
-    ) {
+    if (eventSourceRef.current && eventSourceRef.current.readyState !== EventSource.CLOSED) {
       return;
     }
 
@@ -87,10 +84,7 @@ export const useSSENotifications = () => {
 
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'visible') {
-        if (
-          !eventSourceRef.current ||
-          eventSourceRef.current.readyState === EventSource.CLOSED
-        ) {
+        if (!eventSourceRef.current || eventSourceRef.current.readyState === EventSource.CLOSED) {
           isFirstConnectRef.current = false;
           connect();
         }

--- a/client/src/features/notification/hooks/useSSENotifications.ts
+++ b/client/src/features/notification/hooks/useSSENotifications.ts
@@ -2,7 +2,7 @@ import { useCheckIfLoggedInQuery } from '@/features/auth/api/useCheckIfLoggedInQ
 import { queryKeys } from '@/shared/lib/queryKeys';
 import { toast } from '@/shared/store/toast';
 import { useQueryClient } from '@tanstack/react-query';
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { subscribeNotifications } from '../api/subscribeNotifications';
 import { NotificationItem, NotificationResponse } from '../types/notifications';
 import { SSENotification } from '../types/sseNotification';
@@ -11,26 +11,28 @@ export const useSSENotifications = () => {
   const queryClient = useQueryClient();
   const { data: isLoggedIn } = useCheckIfLoggedInQuery();
   const eventSourceRef = useRef<EventSource | null>(null);
+  const isFirstConnectRef = useRef(true);
 
-  useEffect(() => {
-    if (!isLoggedIn) {
-      return;
-    }
-
-    if (eventSourceRef.current) {
+  const connect = useCallback(() => {
+    if (
+      eventSourceRef.current &&
+      eventSourceRef.current.readyState !== EventSource.CLOSED
+    ) {
       return;
     }
 
     const eventSource = subscribeNotifications();
     eventSourceRef.current = eventSource;
 
-    eventSource.onopen = () => {};
+    const handleOpen = () => {
+      if (isFirstConnectRef.current) {
+        isFirstConnectRef.current = false;
+      } else {
+        queryClient.invalidateQueries({ queryKey: queryKeys.notifications.all });
+      }
+    };
 
-    eventSource.addEventListener('heartbeat', () => {});
-
-    eventSource.addEventListener('connect', () => {});
-
-    eventSource.addEventListener('notification', event => {
+    const handleNotification = (event: MessageEvent) => {
       try {
         const sseData: SSENotification = JSON.parse(event.data);
 
@@ -47,14 +49,10 @@ export const useSSENotifications = () => {
         );
         const currentNotifications = currentData?.data || [];
 
-        const updatedNotifications = [newNotification, ...currentNotifications];
-
-        const updatedData: NotificationResponse = {
+        queryClient.setQueryData(queryKeys.notifications.all, {
           status: 200,
-          data: updatedNotifications,
-        };
-
-        queryClient.setQueryData(queryKeys.notifications.all, updatedData);
+          data: [newNotification, ...currentNotifications],
+        } satisfies NotificationResponse);
 
         if (sseData.notificationType === 'NEW_COMMENT_ON_MOMENT') {
           toast.message('나의 모멘트에 코멘트가 달렸습니다!', 'moment', 5000, sseData.link);
@@ -69,15 +67,44 @@ export const useSSENotifications = () => {
       } catch {
         toast.error('실시간 알림 데이터 처리 중 오류가 발생했습니다.');
       }
-    });
+    };
 
-    eventSource.onerror = () => {};
+    const handleError = () => {
+      if (eventSource.readyState === EventSource.CLOSED) {
+        eventSourceRef.current = null;
+      }
+    };
+
+    eventSource.onopen = handleOpen;
+    eventSource.onerror = handleError;
+    eventSource.addEventListener('notification', handleNotification);
+  }, [queryClient]);
+
+  useEffect(() => {
+    if (!isLoggedIn) return;
+
+    connect();
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        if (
+          !eventSourceRef.current ||
+          eventSourceRef.current.readyState === EventSource.CLOSED
+        ) {
+          isFirstConnectRef.current = false;
+          connect();
+        }
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
 
     return () => {
-      eventSource.close();
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      eventSourceRef.current?.close();
       eventSourceRef.current = null;
     };
-  }, [isLoggedIn, queryClient]);
+  }, [isLoggedIn, connect]);
 
   return { isConnected: isLoggedIn };
 };


### PR DESCRIPTION
## 배경

기존 `useSSENotifications`는 `onopen`, `onerror`, `heartbeat`, `connect` 핸들러가 모두 빈 함수로 구현되어 있었습니다.

SSE는 HTTP 기반이라 브라우저가 자동으로 재연결을 시도하지만, 이는 **연결(transport) 복구**만 담당합니다. 연결이 끊긴 동안 서버에서 발송된 알림은 재연결 이후에도 클라이언트에 전달되지 않아 **누락**이 발생할 수 있습니다.

또한 모바일 WebView 환경에서는 앱이 백그라운드로 전환될 때 SSE 연결이 끊어지더라도 브라우저가 이를 감지하지 못하는 경우가 있어, 포그라운드 복귀 후에도 연결이 복구되지 않는 문제가 있었습니다.

이번 작업에서는 **연결 복구(브라우저 자동 재연결)** 와 **데이터 재동기화(invalidateQueries)** 를 분리하여 설계하고, 모바일 WebView 환경까지 명시적으로 대응했습니다.

## Summary

- `onopen`에서 최초 연결/재연결을 플래그(`isFirstConnectRef`)로 구분하여 재연결 시 `invalidateQueries`로 누락 알림 재동기화
- `visibilitychange` 이벤트로 모바일 WebView 백그라운드 복귀 시 연결 상태 확인 후 재연결
- `onerror`에서 `readyState === CLOSED`일 때만 ref 초기화 (브라우저 자동 재연결 중에는 사용자에게 오류 노출 안 함)
- 인라인 핸들러 → `handleOpen` / `handleNotification` / `handleError` / `handleVisibilityChange`로 네이밍 분리

## Test plan

- [ ] 네트워크를 끊었다가 복구했을 때 알림 목록이 재조회되는지 확인
- [ ] 탭을 백그라운드로 보냈다가 복귀 시 연결이 복구되는지 확인