### PR TITLE
[FEAT] admin Vite manualChunks로 vendor 번들 분리

### DIFF
--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -9,7 +9,7 @@ const ReactQueryDevtools = import.meta.env.DEV
   ? lazy(() =>
       import("@tanstack/react-query-devtools").then((m) => ({
         default: m.ReactQueryDevtools,
-      }))
+      })),
     )
   : () => null;
 

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -1,10 +1,17 @@
-import { StrictMode } from "react";
+import { StrictMode, lazy, Suspense } from "react";
 import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./index.css";
+
+const ReactQueryDevtools = import.meta.env.DEV
+  ? lazy(() =>
+      import("@tanstack/react-query-devtools").then((m) => ({
+        default: m.ReactQueryDevtools,
+      }))
+    )
+  : () => null;
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -21,7 +28,9 @@ createRoot(document.getElementById("root")!).render(
       <BrowserRouter>
         <App />
       </BrowserRouter>
-      <ReactQueryDevtools initialIsOpen={false} />
+      <Suspense>
+        <ReactQueryDevtools initialIsOpen={false} />
+      </Suspense>
     </QueryClientProvider>
   </StrictMode>,
 );

--- a/admin/vite.config.ts
+++ b/admin/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
           "vendor-react": ["react", "react-dom", "react-router-dom"],
           "vendor-query": ["@tanstack/react-query"],
           "vendor-emotion": ["@emotion/react", "@emotion/styled"],
+          "vendor-axios": ["axios"],
         },
       },
     },

--- a/admin/vite.config.ts
+++ b/admin/vite.config.ts
@@ -9,6 +9,17 @@ interface VitestConfigExport extends UserConfig {
 
 export default defineConfig({
   plugins: [react()],
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          "vendor-react": ["react", "react-dom", "react-router-dom"],
+          "vendor-query": ["@tanstack/react-query"],
+          "vendor-emotion": ["@emotion/react", "@emotion/styled"],
+        },
+      },
+    },
+  },
   server: {
     proxy: {
       "/api": {


### PR DESCRIPTION
## 관련 이슈
closes #1140

## 도입 배경
Vite 기본 설정은 앱 코드와 모든 vendor 라이브러리를 하나의 번들로 합침. 이 경우 앱 코드 한 줄만 바뀌어도 react, axios 같은 변경 없는 라이브러리까지 새 해시로 번들링되어 브라우저 캐시가 무효화됨.

추가로 `ReactQueryDevtools`가 프로덕션 번들에 그대로 포함되어 있어 불필요한 코드가 배포되고 있었음.

## 변경 사항

### 1. manualChunks로 vendor 번들 분리
자주 바뀌지 않는 라이브러리를 별도 청크로 분리해 앱 코드 변경 시에도 vendor 캐시 유지

| 청크 | 포함 라이브러리 |
|------|----------------|
| `vendor-react` | react, react-dom, react-router-dom |
| `vendor-query` | @tanstack/react-query |
| `vendor-emotion` | @emotion/react, @emotion/styled |
| `vendor-axios` | axios |

### 2. ReactQueryDevtools 프로덕션 제거
dynamic import + `import.meta.env.DEV` 조건으로 개발 환경에서만 로드되도록 수정

## 결과

| | 변경 전 | 변경 후 |
|---|---|---|
| `index.js` | 89.79 kB (gzip 26.31 kB) | 53.38 kB (gzip 11.96 kB) |
| devtools | 프로덕션 포함 | 개발 환경에서만 로드 |
| axios | index 청크에 혼재 | 별도 청크 분리 |

초기 로딩 JS 크기 gzip 기준 **26KB → 12KB**, 약 54% 감소

### 전
<img width="724" height="337" alt="Screenshot 2026-05-05 at 1 21 23 AM" src="https://github.com/user-attachments/assets/2457f108-942e-4d7a-ae5c-244dcee354ce" />
- JS 파일 1개: index.js 104 kB   

### 후
<img width="724" height="304" alt="image" src="https://github.com/user-attachments/assets/7fc21e9f-01fb-44f8-81a6-3e0d22f50afa" />
                                                                                                                                    
- index.js: 11.7 kB (앱 코드만)                                                                                                         
- vendor-react: 55.1 kB                                                                                                                 
- vendor-axios: 14.9 kB
- vendor-query: 15.3 kB                                                                                                                 
- vendor-emotion: 11.1 kB  

=>   앱 코드(index.js)만 변경되면 → vendor-* 4개는 해시 불변 → 브라우저 캐시에서 그대로 사용. 재방문 시 11.7 kB만 새로 받음

## 테스트
- [ ] 프로덕션 빌드 후 네트워크 탭에서 청크 분리 및 초기 JS 크기 확인
- [ ] 재방문 시 vendor 청크 캐시 히트 확인
- [ ] 개발 환경에서 ReactQueryDevtools 정상 동작 확인