### PR TITLE
[FIX] SSE 알림 데이터 처리 경계 정리 및 toast 누락 수정

### DIFF
--- a/client/src/features/comment/hooks/useMyCommentsCard.ts
+++ b/client/src/features/comment/hooks/useMyCommentsCard.ts
@@ -1,16 +1,16 @@
-import { useReadNotifications } from '@/features/notification/hooks/useReadNotifications';
+import { useReadAllNotifications } from '@/features/notification/hooks/useReadAllNotifications';
 import { useShowFullImage } from '@/shared/hooks/useShowFullImage';
 import { CommentItem } from '../types/comments';
 
 export const useMyCommentsCard = (myComment: CommentItem, groupId?: number | string) => {
-  const { handleReadNotifications, isLoading: isReadingNotification } =
-    useReadNotifications(groupId);
+  const { handleReadAllNotifications, isLoading: isReadingNotification } =
+    useReadAllNotifications(groupId);
   const { fullImageSrc, handleImageClick, closeFullImage, ImageOverlayPortal } = useShowFullImage();
 
   const handleCommentOpen = () => {
     if (myComment.commentNotification.isRead || isReadingNotification) return;
-    if (myComment.commentNotification.notificationIds) {
-      handleReadNotifications(myComment.commentNotification.notificationIds[0]);
+    if (myComment.commentNotification.notificationIds.length > 0) {
+      handleReadAllNotifications(myComment.commentNotification.notificationIds);
     }
   };
 

--- a/client/src/features/notification/api/useReadAllNotificationsMutation.ts
+++ b/client/src/features/notification/api/useReadAllNotificationsMutation.ts
@@ -13,7 +13,13 @@ export const useReadAllNotificationsMutation = (groupId?: number | string) => {
       if (groupId) {
         const numericGroupId = Number(groupId);
         queryClient.invalidateQueries({ queryKey: queryKeys.group.comments(numericGroupId) });
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.group.commentsUnread(numericGroupId),
+        });
         queryClient.invalidateQueries({ queryKey: queryKeys.group.moments(numericGroupId) });
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.group.momentsUnread(numericGroupId),
+        });
         queryClient.invalidateQueries({ queryKey: queryKeys.group.myMoments(numericGroupId) });
       }
     },

--- a/client/src/features/notification/api/useReadAllNotificationsMutation.ts
+++ b/client/src/features/notification/api/useReadAllNotificationsMutation.ts
@@ -10,8 +10,8 @@ export const useReadAllNotificationsMutation = (groupId?: number | string) => {
     mutationFn: patchReadAllNotifications,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.notifications.all });
-      if (groupId) {
-        const numericGroupId = Number(groupId);
+      const numericGroupId = Number(groupId);
+      if (groupId != null && groupId !== '' && Number.isFinite(numericGroupId)) {
         queryClient.invalidateQueries({ queryKey: queryKeys.group.comments(numericGroupId) });
         queryClient.invalidateQueries({
           queryKey: queryKeys.group.commentsUnread(numericGroupId),

--- a/client/src/features/notification/api/useReadNotificationsMutation.ts
+++ b/client/src/features/notification/api/useReadNotificationsMutation.ts
@@ -10,8 +10,8 @@ export const useReadNotificationsMutation = (groupId?: number | string) => {
     mutationFn: patchReadNotifications,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.notifications.all });
-      if (groupId) {
-        const numericGroupId = Number(groupId);
+      const numericGroupId = Number(groupId);
+      if (groupId != null && groupId !== '' && Number.isFinite(numericGroupId)) {
         queryClient.invalidateQueries({ queryKey: queryKeys.group.comments(numericGroupId) });
         queryClient.invalidateQueries({
           queryKey: queryKeys.group.commentsUnread(numericGroupId),

--- a/client/src/features/notification/hooks/useSSENotifications.ts
+++ b/client/src/features/notification/hooks/useSSENotifications.ts
@@ -7,6 +7,7 @@ import { subscribeNotifications } from '../api/subscribeNotifications';
 import { NotificationResponse } from '../types/notifications';
 import {
   getNotificationInvalidationTargets,
+  getSseNotificationToast,
   isSseNotificationPayload,
   mapSsePayloadToNotificationItem,
   parseSsePayload,
@@ -60,10 +61,11 @@ export const useSSENotifications = () => {
           prependNotificationToCache(currentData, newNotification),
         );
 
-        if (sseData.notificationType === 'NEW_COMMENT_ON_MOMENT') {
+        const notificationToast = getSseNotificationToast(sseData);
+        if (notificationToast) {
           toast.message(
-            '나의 모멘트에 코멘트가 달렸습니다!',
-            sseData.link ? 'moment' : undefined,
+            notificationToast.message,
+            sseData.link ? notificationToast.routeType : undefined,
             5000,
             sseData.link ?? undefined,
           );

--- a/client/src/features/notification/hooks/useSSENotifications.ts
+++ b/client/src/features/notification/hooks/useSSENotifications.ts
@@ -4,13 +4,14 @@ import { toast } from '@/shared/store/toast';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useRef } from 'react';
 import { subscribeNotifications } from '../api/subscribeNotifications';
-import { NotificationItem, NotificationResponse } from '../types/notifications';
-import { SSENotification } from '../types/sseNotification';
-
-const getGroupIdFromLink = (link: string) => {
-  const match = link.match(/\/groups\/(\d+)/);
-  return match ? Number(match[1]) : null;
-};
+import { NotificationResponse } from '../types/notifications';
+import {
+  getNotificationInvalidationTargets,
+  isSseNotificationPayload,
+  mapSsePayloadToNotificationItem,
+  parseSsePayload,
+  prependNotificationToCache,
+} from '../utils/sseNotificationPayload';
 
 export const useSSENotifications = () => {
   const queryClient = useQueryClient();
@@ -35,41 +36,41 @@ export const useSSENotifications = () => {
     };
 
     const handleNotification = (event: MessageEvent) => {
+      const parsedPayload = parseSsePayload(event.data);
+      if (!parsedPayload.ok) {
+        toast.error('실시간 알림 데이터 처리 중 오류가 발생했습니다.');
+        return;
+      }
+
       try {
-        const sseData: SSENotification = JSON.parse(event.data);
+        if (!isSseNotificationPayload(parsedPayload.value)) {
+          toast.error('실시간 알림 데이터 처리 중 오류가 발생했습니다.');
+          return;
+        }
 
-        const newNotification: NotificationItem = {
-          notificationType: sseData.notificationType,
-          targetType: sseData.targetType || 'MOMENT',
-          targetId: sseData.targetId || 0,
-          message: sseData.message,
-          isRead: false,
-        };
-
+        const sseData = parsedPayload.value;
+        const newNotification = mapSsePayloadToNotificationItem(sseData);
         const currentData = queryClient.getQueryData<NotificationResponse>(
           queryKeys.notifications.all,
         );
-        const currentNotifications = currentData?.data || [];
 
-        queryClient.setQueryData(queryKeys.notifications.all, {
-          status: 200,
-          data: [newNotification, ...currentNotifications],
-        } satisfies NotificationResponse);
-
-        const groupId = getGroupIdFromLink(sseData.link);
+        queryClient.setQueryData(
+          queryKeys.notifications.all,
+          prependNotificationToCache(currentData, newNotification),
+        );
 
         if (sseData.notificationType === 'NEW_COMMENT_ON_MOMENT') {
-          toast.message('나의 모멘트에 코멘트가 달렸습니다!', 'moment', 5000, sseData.link);
-          if (groupId) {
-            queryClient.invalidateQueries({ queryKey: queryKeys.group.myMoments(groupId) });
-            queryClient.invalidateQueries({ queryKey: queryKeys.group.momentsUnread(groupId) });
-          }
-        } else if (sseData.notificationType === 'NEW_REPLY_ON_COMMENT' && groupId) {
-          queryClient.invalidateQueries({ queryKey: queryKeys.group.comments(groupId) });
-          queryClient.invalidateQueries({ queryKey: queryKeys.group.commentsUnread(groupId) });
+          toast.message(
+            '나의 모멘트에 코멘트가 달렸습니다!',
+            sseData.link ? 'moment' : undefined,
+            5000,
+            sseData.link ?? undefined,
+          );
         }
 
-        queryClient.invalidateQueries({ queryKey: queryKeys.notifications.all });
+        getNotificationInvalidationTargets(sseData).forEach(queryKey => {
+          queryClient.invalidateQueries({ queryKey });
+        });
       } catch {
         toast.error('실시간 알림 데이터 처리 중 오류가 발생했습니다.');
       }

--- a/client/src/features/notification/hooks/useSSENotifications.ts
+++ b/client/src/features/notification/hooks/useSSENotifications.ts
@@ -12,6 +12,7 @@ import {
   parseSsePayload,
   prependNotificationToCache,
 } from '../utils/sseNotificationPayload';
+import { reportSseNotificationError } from '../utils/sseNotificationError';
 
 export const useSSENotifications = () => {
   const queryClient = useQueryClient();
@@ -38,13 +39,13 @@ export const useSSENotifications = () => {
     const handleNotification = (event: MessageEvent) => {
       const parsedPayload = parseSsePayload(event.data);
       if (!parsedPayload.ok) {
-        toast.error('실시간 알림 데이터 처리 중 오류가 발생했습니다.');
+        reportSseNotificationError(parsedPayload.reason);
         return;
       }
 
       try {
         if (!isSseNotificationPayload(parsedPayload.value)) {
-          toast.error('실시간 알림 데이터 처리 중 오류가 발생했습니다.');
+          reportSseNotificationError('invalid-payload');
           return;
         }
 
@@ -71,8 +72,8 @@ export const useSSENotifications = () => {
         getNotificationInvalidationTargets(sseData).forEach(queryKey => {
           queryClient.invalidateQueries({ queryKey });
         });
-      } catch {
-        toast.error('실시간 알림 데이터 처리 중 오류가 발생했습니다.');
+      } catch (error) {
+        reportSseNotificationError('unknown', error);
       }
     };
 

--- a/client/src/features/notification/hooks/useSSENotifications.ts
+++ b/client/src/features/notification/hooks/useSSENotifications.ts
@@ -7,6 +7,11 @@ import { subscribeNotifications } from '../api/subscribeNotifications';
 import { NotificationItem, NotificationResponse } from '../types/notifications';
 import { SSENotification } from '../types/sseNotification';
 
+const getGroupIdFromLink = (link: string) => {
+  const match = link.match(/\/groups\/(\d+)/);
+  return match ? Number(match[1]) : null;
+};
+
 export const useSSENotifications = () => {
   const queryClient = useQueryClient();
   const { data: isLoggedIn } = useCheckIfLoggedInQuery();
@@ -51,15 +56,19 @@ export const useSSENotifications = () => {
           data: [newNotification, ...currentNotifications],
         } satisfies NotificationResponse);
 
+        const groupId = getGroupIdFromLink(sseData.link);
+
         if (sseData.notificationType === 'NEW_COMMENT_ON_MOMENT') {
           toast.message('나의 모멘트에 코멘트가 달렸습니다!', 'moment', 5000, sseData.link);
+          if (groupId) {
+            queryClient.invalidateQueries({ queryKey: queryKeys.group.myMoments(groupId) });
+            queryClient.invalidateQueries({ queryKey: queryKeys.group.momentsUnread(groupId) });
+          }
+        } else if (sseData.notificationType === 'NEW_REPLY_ON_COMMENT' && groupId) {
+          queryClient.invalidateQueries({ queryKey: queryKeys.group.comments(groupId) });
+          queryClient.invalidateQueries({ queryKey: queryKeys.group.commentsUnread(groupId) });
         }
 
-        if (sseData.targetType === 'MOMENT') {
-          queryClient.invalidateQueries({ queryKey: ['moments'] });
-        } else if (sseData.targetType === 'COMMENT') {
-          queryClient.invalidateQueries({ queryKey: ['comments'] });
-        }
         queryClient.invalidateQueries({ queryKey: queryKeys.notifications.all });
       } catch {
         toast.error('실시간 알림 데이터 처리 중 오류가 발생했습니다.');

--- a/client/src/features/notification/types/notifications.ts
+++ b/client/src/features/notification/types/notifications.ts
@@ -1,5 +1,10 @@
-export type NotificationType = 'NEW_REPLY_ON_COMMENT' | 'NEW_COMMENT_ON_MOMENT';
-export type TargetType = 'COMMENT' | 'MOMENT';
+export type NotificationType =
+  | 'NEW_COMMENT_ON_MOMENT'
+  | 'GROUP_JOIN_REQUEST'
+  | 'GROUP_JOIN_APPROVED'
+  | 'GROUP_KICKED'
+  | 'MOMENT_LIKED'
+  | 'COMMENT_LIKED';
 
 export interface NotificationResponse {
   status: number;
@@ -7,10 +12,9 @@ export interface NotificationResponse {
 }
 
 export interface NotificationItem {
-  id?: number;
+  id: number;
   notificationType: NotificationType;
-  targetType: TargetType;
-  targetId: number;
   message: string;
   isRead: boolean;
+  link: string | null;
 }

--- a/client/src/features/notification/types/sseNotification.ts
+++ b/client/src/features/notification/types/sseNotification.ts
@@ -1,11 +1,8 @@
-import { NotificationType, TargetType } from './notifications';
+import { NotificationType } from './notifications';
 
 export interface SSENotification {
-  notificationId?: number;
+  notificationId: number;
   notificationType: NotificationType;
   message: string;
-  link: string;
-  targetType?: TargetType;
-  targetId?: number;
-  isRead?: boolean;
+  link: string | null;
 }

--- a/client/src/features/notification/utils/sseNotificationError.ts
+++ b/client/src/features/notification/utils/sseNotificationError.ts
@@ -1,0 +1,29 @@
+import * as Sentry from '@sentry/react';
+
+export type SseNotificationErrorReason = 'parse-error' | 'invalid-payload' | 'unknown';
+
+const normalizeError = (error: unknown): Error => {
+  if (error instanceof Error) return error;
+
+  return new Error('SSE notification processing failed');
+};
+
+/**
+ * SSE 알림 데이터 처리 실패를 개발자 관측성 도구로 보고한다.
+ *
+ * @param reason - SSE 알림 데이터 처리 실패 원인
+ * @param error - 후처리 중 발생한 원본 에러. 없으면 기본 Error를 생성한다.
+ */
+export const reportSseNotificationError = (
+  reason: SseNotificationErrorReason,
+  error?: unknown,
+) => {
+  Sentry.captureException(normalizeError(error), {
+    level: 'warning',
+    tags: {
+      domain: 'notification',
+      source: 'sse',
+      reason,
+    },
+  });
+};

--- a/client/src/features/notification/utils/sseNotificationError.ts
+++ b/client/src/features/notification/utils/sseNotificationError.ts
@@ -14,10 +14,7 @@ const normalizeError = (error: unknown): Error => {
  * @param reason - SSE 알림 데이터 처리 실패 원인
  * @param error - 후처리 중 발생한 원본 에러. 없으면 기본 Error를 생성한다.
  */
-export const reportSseNotificationError = (
-  reason: SseNotificationErrorReason,
-  error?: unknown,
-) => {
+export const reportSseNotificationError = (reason: SseNotificationErrorReason, error?: unknown) => {
   Sentry.captureException(normalizeError(error), {
     level: 'warning',
     tags: {

--- a/client/src/features/notification/utils/sseNotificationPayload.test.ts
+++ b/client/src/features/notification/utils/sseNotificationPayload.test.ts
@@ -1,0 +1,196 @@
+import {
+  getGroupIdFromLink,
+  getNotificationInvalidationTargets,
+  mapSsePayloadToNotificationItem,
+  parseSsePayload,
+  prependNotificationToCache,
+} from './sseNotificationPayload';
+import { queryKeys } from '@/shared/lib/queryKeys';
+import { NotificationItem, NotificationResponse } from '../types/notifications';
+import { SSENotification } from '../types/sseNotification';
+
+describe('SSE 알림 payload 파싱', () => {
+  it('JSON 형식이 아닌 SSE 이벤트 데이터는 parse-error로 분류한다', () => {
+    const result = parseSsePayload('{invalid-json');
+
+    expect(result).toEqual({ ok: false, reason: 'parse-error' });
+  });
+});
+
+describe('SSE payload를 알림 목록 cache item으로 변환', () => {
+  it('현재 서버 SSE payload를 내부 알림 item 형태로 변환한다', () => {
+    const payload: SSENotification = {
+      notificationId: 10,
+      notificationType: 'COMMENT_LIKED',
+      message: '코멘트에 좋아요가 달렸습니다.',
+      link: '/groups/3/collection/my-comment',
+    };
+
+    const result = mapSsePayloadToNotificationItem(payload);
+
+    expect(result).toEqual({
+      id: 10,
+      notificationType: 'COMMENT_LIKED',
+      message: '코멘트에 좋아요가 달렸습니다.',
+      isRead: false,
+      link: '/groups/3/collection/my-comment',
+    });
+  });
+
+  it('link가 null인 SSE payload는 내부 알림 item에도 null link로 유지한다', () => {
+    const payload: SSENotification = {
+      notificationId: 11,
+      notificationType: 'GROUP_KICKED',
+      message: '그룹에서 강퇴되었습니다.',
+      link: null,
+    };
+
+    const result = mapSsePayloadToNotificationItem(payload);
+
+    expect(result).toEqual({
+      id: 11,
+      notificationType: 'GROUP_KICKED',
+      message: '그룹에서 강퇴되었습니다.',
+      isRead: false,
+      link: null,
+    });
+  });
+});
+
+describe('SSE 알림 link에서 groupId 추출', () => {
+  it('link가 null이면 groupId를 추출하지 않는다', () => {
+    const result = getGroupIdFromLink(null);
+
+    expect(result).toBeNull();
+  });
+
+  it('group link에서 groupId를 추출한다', () => {
+    const result = getGroupIdFromLink('/groups/3/collection/my-moment');
+
+    expect(result).toBe(3);
+  });
+
+  it('group 경로가 아닌 link에서는 groupId를 추출하지 않는다', () => {
+    const result = getGroupIdFromLink('/moments/10');
+
+    expect(result).toBeNull();
+  });
+});
+
+describe('SSE 알림 item cache prepend', () => {
+  const newNotification: NotificationItem = {
+    id: 10,
+    notificationType: 'NEW_COMMENT_ON_MOMENT',
+    message: '내 모멘트에 새로운 코멘트가 달렸습니다.',
+    isRead: false,
+    link: '/groups/3/collection/my-moment',
+  };
+
+  it('notifications.all cache가 없으면 새 알림 1개를 담은 cache 응답을 만든다', () => {
+    const result = prependNotificationToCache(undefined, newNotification);
+
+    expect(result).toEqual({
+      status: 200,
+      data: [newNotification],
+    });
+  });
+
+  it('기존 알림 목록 앞에 새 알림을 추가한다', () => {
+    const existingNotification: NotificationItem = {
+      id: 9,
+      notificationType: 'MOMENT_LIKED',
+      message: '모멘트에 좋아요가 달렸습니다.',
+      isRead: false,
+      link: '/groups/3/collection/my-moment',
+    };
+    const currentData: NotificationResponse = {
+      status: 200,
+      data: [existingNotification],
+    };
+
+    const result = prependNotificationToCache(currentData, newNotification);
+
+    expect(result.data).toEqual([newNotification, existingNotification]);
+  });
+
+  it('기존 알림 배열을 직접 변경하지 않는다', () => {
+    const existingNotification: NotificationItem = {
+      id: 9,
+      notificationType: 'MOMENT_LIKED',
+      message: '모멘트에 좋아요가 달렸습니다.',
+      isRead: false,
+      link: '/groups/3/collection/my-moment',
+    };
+    const currentNotifications = [existingNotification];
+    const currentData: NotificationResponse = {
+      status: 200,
+      data: currentNotifications,
+    };
+
+    prependNotificationToCache(currentData, newNotification);
+
+    expect(currentNotifications).toEqual([existingNotification]);
+  });
+});
+
+describe('SSE 알림 invalidate target 계산', () => {
+  it('정상 SSE 알림은 notifications.all을 invalidate 대상으로 포함한다', () => {
+    const payload: SSENotification = {
+      notificationId: 10,
+      notificationType: 'GROUP_KICKED',
+      message: '그룹에서 강퇴되었습니다.',
+      link: null,
+    };
+
+    const result = getNotificationInvalidationTargets(payload);
+
+    expect(result).toEqual([queryKeys.notifications.all]);
+  });
+
+  it('NEW_COMMENT_ON_MOMENT 알림의 group link는 모멘트 모음집 관련 query key를 포함한다', () => {
+    const payload: SSENotification = {
+      notificationId: 10,
+      notificationType: 'NEW_COMMENT_ON_MOMENT',
+      message: '내 모멘트에 새로운 코멘트가 달렸습니다.',
+      link: '/groups/3/collection/my-moment',
+    };
+
+    const result = getNotificationInvalidationTargets(payload);
+
+    expect(result).toEqual([
+      queryKeys.notifications.all,
+      queryKeys.group.myMoments(3),
+      queryKeys.group.momentsUnread(3),
+    ]);
+  });
+
+  it('COMMENT_LIKED 알림의 group link는 코멘트 모음집 관련 query key를 포함한다', () => {
+    const payload: SSENotification = {
+      notificationId: 11,
+      notificationType: 'COMMENT_LIKED',
+      message: '코멘트에 좋아요가 달렸습니다.',
+      link: '/groups/3/collection/my-comment',
+    };
+
+    const result = getNotificationInvalidationTargets(payload);
+
+    expect(result).toEqual([
+      queryKeys.notifications.all,
+      queryKeys.group.comments(3),
+      queryKeys.group.commentsUnread(3),
+    ]);
+  });
+
+  it('groupId를 추출할 수 없으면 group-specific query key를 포함하지 않는다', () => {
+    const payload: SSENotification = {
+      notificationId: 12,
+      notificationType: 'NEW_COMMENT_ON_MOMENT',
+      message: '내 모멘트에 새로운 코멘트가 달렸습니다.',
+      link: null,
+    };
+
+    const result = getNotificationInvalidationTargets(payload);
+
+    expect(result).toEqual([queryKeys.notifications.all]);
+  });
+});

--- a/client/src/features/notification/utils/sseNotificationPayload.test.ts
+++ b/client/src/features/notification/utils/sseNotificationPayload.test.ts
@@ -2,6 +2,7 @@ import {
   getGroupIdFromLink,
   getNotificationInvalidationTargets,
   getSseNotificationToast,
+  isSseNotificationPayload,
   mapSsePayloadToNotificationItem,
   parseSsePayload,
   prependNotificationToCache,
@@ -15,6 +16,76 @@ describe('SSE 알림 payload 파싱', () => {
     const result = parseSsePayload('{invalid-json');
 
     expect(result).toEqual({ ok: false, reason: 'parse-error' });
+  });
+});
+
+describe('SSE payload 런타임 검증', () => {
+  it('필수 필드가 모두 유효하면 SSE 알림 payload로 본다', () => {
+    const payload = {
+      notificationId: 10,
+      notificationType: 'COMMENT_LIKED',
+      message: '코멘트에 좋아요가 달렸습니다.',
+      link: '/groups/3/collection/my-comment',
+    };
+
+    const result = isSseNotificationPayload(payload);
+
+    expect(result).toBe(true);
+  });
+
+  it('link가 null이어도 유효 payload로 본다', () => {
+    const payload = {
+      notificationId: 11,
+      notificationType: 'GROUP_KICKED',
+      message: '그룹에서 강퇴되었습니다.',
+      link: null,
+    };
+
+    const result = isSseNotificationPayload(payload);
+
+    expect(result).toBe(true);
+  });
+
+  it.each([
+    [
+      'notificationId가 없으면',
+      {
+        notificationType: 'COMMENT_LIKED',
+        message: '코멘트에 좋아요가 달렸습니다.',
+        link: '/groups/3/collection/my-comment',
+      },
+    ],
+    [
+      '지원하지 않는 notificationType이면',
+      {
+        notificationId: 12,
+        notificationType: 'UNKNOWN_TYPE',
+        message: '알 수 없는 알림입니다.',
+        link: '/groups/3/collection/my-comment',
+      },
+    ],
+    [
+      'message가 문자열이 아니면',
+      {
+        notificationId: 13,
+        notificationType: 'COMMENT_LIKED',
+        message: null,
+        link: '/groups/3/collection/my-comment',
+      },
+    ],
+    [
+      'link가 문자열이나 null이 아니면',
+      {
+        notificationId: 14,
+        notificationType: 'COMMENT_LIKED',
+        message: '코멘트에 좋아요가 달렸습니다.',
+        link: 3,
+      },
+    ],
+  ])('%s 유효 payload로 보지 않는다', (_description, payload) => {
+    const result = isSseNotificationPayload(payload);
+
+    expect(result).toBe(false);
   });
 });
 

--- a/client/src/features/notification/utils/sseNotificationPayload.test.ts
+++ b/client/src/features/notification/utils/sseNotificationPayload.test.ts
@@ -135,7 +135,7 @@ describe('SSE 알림 item cache prepend', () => {
 });
 
 describe('SSE 알림 invalidate target 계산', () => {
-  it('정상 SSE 알림은 notifications.all을 invalidate 대상으로 포함한다', () => {
+  it('정상 SSE 알림은 알림 목록 갱신 대상으로 계산한다', () => {
     const payload: SSENotification = {
       notificationId: 10,
       notificationType: 'GROUP_KICKED',
@@ -148,7 +148,7 @@ describe('SSE 알림 invalidate target 계산', () => {
     expect(result).toEqual([queryKeys.notifications.all]);
   });
 
-  it('NEW_COMMENT_ON_MOMENT 알림의 group link는 모멘트 모음집 관련 query key를 포함한다', () => {
+  it('NEW_COMMENT_ON_MOMENT 알림은 모멘트 모음집 갱신 대상으로 계산한다', () => {
     const payload: SSENotification = {
       notificationId: 10,
       notificationType: 'NEW_COMMENT_ON_MOMENT',
@@ -165,7 +165,24 @@ describe('SSE 알림 invalidate target 계산', () => {
     ]);
   });
 
-  it('COMMENT_LIKED 알림의 group link는 코멘트 모음집 관련 query key를 포함한다', () => {
+  it('MOMENT_LIKED 알림은 모멘트 모음집 갱신 대상으로 계산한다', () => {
+    const payload: SSENotification = {
+      notificationId: 13,
+      notificationType: 'MOMENT_LIKED',
+      message: '모멘트에 좋아요가 달렸습니다.',
+      link: '/groups/3/collection/my-moment',
+    };
+
+    const result = getNotificationInvalidationTargets(payload);
+
+    expect(result).toEqual([
+      queryKeys.notifications.all,
+      queryKeys.group.myMoments(3),
+      queryKeys.group.momentsUnread(3),
+    ]);
+  });
+
+  it('COMMENT_LIKED 알림은 코멘트 모음집 갱신 대상으로 계산한다', () => {
     const payload: SSENotification = {
       notificationId: 11,
       notificationType: 'COMMENT_LIKED',
@@ -182,7 +199,7 @@ describe('SSE 알림 invalidate target 계산', () => {
     ]);
   });
 
-  it('groupId를 추출할 수 없으면 group-specific query key를 포함하지 않는다', () => {
+  it('groupId를 추출할 수 없으면 그룹 화면 갱신 대상으로 계산하지 않는다', () => {
     const payload: SSENotification = {
       notificationId: 12,
       notificationType: 'NEW_COMMENT_ON_MOMENT',

--- a/client/src/features/notification/utils/sseNotificationPayload.test.ts
+++ b/client/src/features/notification/utils/sseNotificationPayload.test.ts
@@ -1,6 +1,7 @@
 import {
   getGroupIdFromLink,
   getNotificationInvalidationTargets,
+  getSseNotificationToast,
   mapSsePayloadToNotificationItem,
   parseSsePayload,
   prependNotificationToCache,
@@ -192,5 +193,72 @@ describe('SSE 알림 invalidate target 계산', () => {
     const result = getNotificationInvalidationTargets(payload);
 
     expect(result).toEqual([queryKeys.notifications.all]);
+  });
+});
+
+describe('SSE 알림 toast 표시 정책', () => {
+  it('NEW_COMMENT_ON_MOMENT 알림은 모멘트 toast 대상이다', () => {
+    const payload: SSENotification = {
+      notificationId: 20,
+      notificationType: 'NEW_COMMENT_ON_MOMENT',
+      message: '내 모멘트에 새로운 코멘트가 달렸습니다.',
+      link: '/groups/3/collection/my-moment',
+    };
+
+    const result = getSseNotificationToast(payload);
+
+    expect(result).toEqual({
+      message: '나의 모멘트에 코멘트가 달렸습니다!',
+      routeType: 'moment',
+    });
+  });
+
+  it('MOMENT_LIKED 알림은 모멘트 toast 대상이다', () => {
+    const payload: SSENotification = {
+      notificationId: 21,
+      notificationType: 'MOMENT_LIKED',
+      message: '모멘트에 좋아요가 달렸습니다.',
+      link: '/groups/3/collection/my-moment',
+    };
+
+    const result = getSseNotificationToast(payload);
+
+    expect(result).toEqual({
+      message: '나의 모멘트에 좋아요가 달렸습니다!',
+      routeType: 'moment',
+    });
+  });
+
+  it('COMMENT_LIKED 알림은 코멘트 toast 대상이다', () => {
+    const payload: SSENotification = {
+      notificationId: 22,
+      notificationType: 'COMMENT_LIKED',
+      message: '코멘트에 좋아요가 달렸습니다.',
+      link: '/groups/3/collection/my-comment',
+    };
+
+    const result = getSseNotificationToast(payload);
+
+    expect(result).toEqual({
+      message: '나의 코멘트에 좋아요가 달렸습니다!',
+      routeType: 'comment',
+    });
+  });
+
+  it.each([
+    ['GROUP_JOIN_REQUEST', '그룹 가입 요청이 왔습니다.'],
+    ['GROUP_JOIN_APPROVED', '그룹 가입이 승인되었습니다.'],
+    ['GROUP_KICKED', '그룹에서 강퇴되었습니다.'],
+  ] as const)('%s 알림은 이동 없는 toast 대상이다', (notificationType, message) => {
+    const payload: SSENotification = {
+      notificationId: 23,
+      notificationType,
+      message,
+      link: notificationType === 'GROUP_KICKED' ? null : '/groups/3/today-moment',
+    };
+
+    const result = getSseNotificationToast(payload);
+
+    expect(result).toEqual({ message });
   });
 });

--- a/client/src/features/notification/utils/sseNotificationPayload.ts
+++ b/client/src/features/notification/utils/sseNotificationPayload.ts
@@ -1,0 +1,136 @@
+import type { QueryKey } from '@tanstack/react-query';
+import { queryKeys } from '@/shared/lib/queryKeys';
+import { NotificationItem, NotificationResponse, NotificationType } from '../types/notifications';
+import { SSENotification } from '../types/sseNotification';
+
+type ParseSsePayloadResult =
+  | {
+      ok: true;
+      value: unknown;
+    }
+  | {
+      ok: false;
+      reason: 'parse-error';
+    };
+
+export type NotificationInvalidationTarget = QueryKey;
+
+export const NOTIFICATION_TYPES = [
+  'NEW_COMMENT_ON_MOMENT',
+  'GROUP_JOIN_REQUEST',
+  'GROUP_JOIN_APPROVED',
+  'GROUP_KICKED',
+  'MOMENT_LIKED',
+  'COMMENT_LIKED',
+] as const satisfies readonly NotificationType[];
+
+/**
+ * SSE notification 이벤트 문자열을 JSON payload로 파싱한다.
+ *
+ * @param raw - EventSource notification 이벤트의 event.data 문자열
+ * @returns 파싱 성공 시 payload, 실패 시 parse-error 결과
+ */
+export const parseSsePayload = (raw: string): ParseSsePayloadResult => {
+  try {
+    return { ok: true, value: JSON.parse(raw) };
+  } catch {
+    return { ok: false, reason: 'parse-error' };
+  }
+};
+
+/**
+ * 현재 서버 NotificationSseResponse 계약을 런타임에서 확인한다.
+ *
+ * @param payload - JSON 파싱 이후 아직 신뢰할 수 없는 SSE payload
+ * @returns 클라이언트가 처리 가능한 SSE 알림 payload인지 여부
+ */
+export const isSseNotificationPayload = (payload: unknown): payload is SSENotification => {
+  if (!payload || typeof payload !== 'object') return false;
+
+  const candidate = payload as Record<string, unknown>;
+
+  return (
+    typeof candidate.notificationId === 'number' &&
+    NOTIFICATION_TYPES.includes(candidate.notificationType as NotificationType) &&
+    typeof candidate.message === 'string' &&
+    (typeof candidate.link === 'string' || candidate.link === null)
+  );
+};
+
+/**
+ * 서버 SSE DTO를 알림 목록 cache가 사용하는 내부 item shape으로 변환한다.
+ *
+ * @param payload - 현재 서버 NotificationSseResponse 형태의 SSE payload
+ * @returns notifications.all cache에 넣을 수 있는 NotificationItem
+ */
+export const mapSsePayloadToNotificationItem = (payload: SSENotification): NotificationItem => ({
+  id: payload.notificationId,
+  notificationType: payload.notificationType,
+  message: payload.message,
+  isRead: false,
+  link: payload.link,
+});
+
+/**
+ * group-scoped query invalidation에 사용할 groupId를 link에서 추출한다.
+ *
+ * @param link - 서버가 내려준 딥링크. 이동 대상이 없으면 null일 수 있다.
+ * @returns group 경로에서 추출한 groupId, 추출할 수 없으면 null
+ */
+export const getGroupIdFromLink = (link: string | null): number | null => {
+  if (link === null) return null;
+
+  const match = link.match(/\/groups\/(\d+)/);
+  return match ? Number(match[1]) : null;
+};
+
+/**
+ * 정상 처리된 SSE 알림 이후 stale 처리할 React Query query key 목록을 계산한다.
+ *
+ * 반환값은 invalidateQueries에 각각 넘길 query key들의 목록이다.
+ * 기본으로 notifications.all을 포함하고, groupId와 알림 타입이 확인되면 관련 group cache key를 추가한다.
+ *
+ * @param payload - 현재 서버 NotificationSseResponse 형태의 SSE payload
+ * @returns invalidateQueries에 사용할 React Query query key 목록
+ */
+export const getNotificationInvalidationTargets = (
+  payload: SSENotification,
+): NotificationInvalidationTarget[] => {
+  const queryKeysToInvalidate: NotificationInvalidationTarget[] = [queryKeys.notifications.all];
+  const groupId = getGroupIdFromLink(payload.link);
+
+  if (!groupId) return queryKeysToInvalidate;
+
+  if (payload.notificationType === 'NEW_COMMENT_ON_MOMENT') {
+    return [
+      ...queryKeysToInvalidate,
+      queryKeys.group.myMoments(groupId),
+      queryKeys.group.momentsUnread(groupId),
+    ];
+  }
+
+  if (payload.notificationType === 'COMMENT_LIKED') {
+    return [
+      ...queryKeysToInvalidate,
+      queryKeys.group.comments(groupId),
+      queryKeys.group.commentsUnread(groupId),
+    ];
+  }
+
+  return queryKeysToInvalidate;
+};
+
+/**
+ * 유효한 SSE 알림 item을 notifications.all cache 앞에 추가한다.
+ *
+ * @param currentData - 현재 React Query notifications.all cache 값
+ * @param newNotification - SSE payload에서 변환된 클라이언트 알림 item
+ * @returns 새 알림이 앞에 추가된 다음 notifications.all cache 값
+ */
+export const prependNotificationToCache = (
+  currentData: NotificationResponse | undefined,
+  newNotification: NotificationItem,
+): NotificationResponse => ({
+  status: currentData?.status ?? 200,
+  data: [newNotification, ...(currentData?.data ?? [])],
+});

--- a/client/src/features/notification/utils/sseNotificationPayload.ts
+++ b/client/src/features/notification/utils/sseNotificationPayload.ts
@@ -133,9 +133,7 @@ export const getNotificationInvalidationTargets = (
  * @param payload - 현재 서버 NotificationSseResponse 형태의 SSE payload
  * @returns toast로 노출할 알림 내용. toast 대상이 아니면 null
  */
-export const getSseNotificationToast = (
-  payload: SSENotification,
-): SseNotificationToast | null => {
+export const getSseNotificationToast = (payload: SSENotification): SseNotificationToast | null => {
   if (payload.notificationType === 'NEW_COMMENT_ON_MOMENT') {
     return {
       message: '나의 모멘트에 코멘트가 달렸습니다!',

--- a/client/src/features/notification/utils/sseNotificationPayload.ts
+++ b/client/src/features/notification/utils/sseNotificationPayload.ts
@@ -2,6 +2,7 @@ import type { QueryKey } from '@tanstack/react-query';
 import { queryKeys } from '@/shared/lib/queryKeys';
 import { NotificationItem, NotificationResponse, NotificationType } from '../types/notifications';
 import { SSENotification } from '../types/sseNotification';
+import { SseNotificationErrorReason } from './sseNotificationError';
 
 type ParseSsePayloadResult =
   | {
@@ -10,7 +11,7 @@ type ParseSsePayloadResult =
     }
   | {
       ok: false;
-      reason: 'parse-error';
+      reason: SseNotificationErrorReason;
     };
 
 export type NotificationInvalidationTarget = QueryKey;

--- a/client/src/features/notification/utils/sseNotificationPayload.ts
+++ b/client/src/features/notification/utils/sseNotificationPayload.ts
@@ -1,4 +1,5 @@
 import type { QueryKey } from '@tanstack/react-query';
+import type { ToastRouteType } from '@/shared/types/toast';
 import { queryKeys } from '@/shared/lib/queryKeys';
 import { NotificationItem, NotificationResponse, NotificationType } from '../types/notifications';
 import { SSENotification } from '../types/sseNotification';
@@ -15,6 +16,11 @@ type ParseSsePayloadResult =
     };
 
 export type NotificationInvalidationTarget = QueryKey;
+
+export interface SseNotificationToast {
+  message: string;
+  routeType?: ToastRouteType;
+}
 
 export const NOTIFICATION_TYPES = [
   'NEW_COMMENT_ON_MOMENT',
@@ -119,6 +125,49 @@ export const getNotificationInvalidationTargets = (
   }
 
   return queryKeysToInvalidate;
+};
+
+/**
+ * SSE 알림 타입에 따라 사용자에게 보여줄 toast 내용을 계산한다.
+ *
+ * @param payload - 현재 서버 NotificationSseResponse 형태의 SSE payload
+ * @returns toast로 노출할 알림 내용. toast 대상이 아니면 null
+ */
+export const getSseNotificationToast = (
+  payload: SSENotification,
+): SseNotificationToast | null => {
+  if (payload.notificationType === 'NEW_COMMENT_ON_MOMENT') {
+    return {
+      message: '나의 모멘트에 코멘트가 달렸습니다!',
+      routeType: 'moment',
+    };
+  }
+
+  if (payload.notificationType === 'MOMENT_LIKED') {
+    return {
+      message: '나의 모멘트에 좋아요가 달렸습니다!',
+      routeType: 'moment',
+    };
+  }
+
+  if (payload.notificationType === 'COMMENT_LIKED') {
+    return {
+      message: '나의 코멘트에 좋아요가 달렸습니다!',
+      routeType: 'comment',
+    };
+  }
+
+  if (
+    payload.notificationType === 'GROUP_JOIN_REQUEST' ||
+    payload.notificationType === 'GROUP_JOIN_APPROVED' ||
+    payload.notificationType === 'GROUP_KICKED'
+  ) {
+    return {
+      message: payload.message,
+    };
+  }
+
+  return null;
 };
 
 /**

--- a/client/src/features/notification/utils/sseNotificationPayload.ts
+++ b/client/src/features/notification/utils/sseNotificationPayload.ts
@@ -108,7 +108,10 @@ export const getNotificationInvalidationTargets = (
 
   if (!groupId) return queryKeysToInvalidate;
 
-  if (payload.notificationType === 'NEW_COMMENT_ON_MOMENT') {
+  if (
+    payload.notificationType === 'NEW_COMMENT_ON_MOMENT' ||
+    payload.notificationType === 'MOMENT_LIKED'
+  ) {
     return [
       ...queryKeysToInvalidate,
       queryKeys.group.myMoments(groupId),

--- a/client/src/pages/collection/CollectionHeader.tsx
+++ b/client/src/pages/collection/CollectionHeader.tsx
@@ -1,7 +1,11 @@
 import { ROUTES } from '@/app/routes/routes';
 import { useReadNotificationsQuery } from '@/features/notification/api/useReadNotificationsQuery';
+import { NotificationType } from '@/features/notification/types/notifications';
 import { useLocation, useParams } from 'react-router';
 import * as S from './index.styles';
+
+const MOMENT_NOTIFICATION_TYPES: NotificationType[] = ['NEW_COMMENT_ON_MOMENT', 'MOMENT_LIKED'];
+const COMMENT_NOTIFICATION_TYPES: NotificationType[] = ['COMMENT_LIKED'];
 
 export const CollectionHeader = () => {
   const { groupId } = useParams<{ groupId: string }>();
@@ -9,10 +13,10 @@ export const CollectionHeader = () => {
   const { data: notifications } = useReadNotificationsQuery();
 
   const isMomentNotificationExisting = notifications?.data.some(
-    notification => notification.targetType === 'MOMENT',
+    notification => MOMENT_NOTIFICATION_TYPES.includes(notification.notificationType),
   );
   const isCommentNotificationExisting = notifications?.data.some(
-    notification => notification.targetType === 'COMMENT',
+    notification => COMMENT_NOTIFICATION_TYPES.includes(notification.notificationType),
   );
 
   const momentCollectionPath = ROUTES.COLLECTION_MYMOMENT.replace(':groupId', groupId || '');

--- a/client/src/pages/collection/CollectionHeader.tsx
+++ b/client/src/pages/collection/CollectionHeader.tsx
@@ -12,11 +12,11 @@ export const CollectionHeader = () => {
   const currentpath = useLocation().pathname;
   const { data: notifications } = useReadNotificationsQuery();
 
-  const isMomentNotificationExisting = notifications?.data.some(
-    notification => MOMENT_NOTIFICATION_TYPES.includes(notification.notificationType),
+  const isMomentNotificationExisting = notifications?.data.some(notification =>
+    MOMENT_NOTIFICATION_TYPES.includes(notification.notificationType),
   );
-  const isCommentNotificationExisting = notifications?.data.some(
-    notification => COMMENT_NOTIFICATION_TYPES.includes(notification.notificationType),
+  const isCommentNotificationExisting = notifications?.data.some(notification =>
+    COMMENT_NOTIFICATION_TYPES.includes(notification.notificationType),
   );
 
   const momentCollectionPath = ROUTES.COLLECTION_MYMOMENT.replace(':groupId', groupId || '');


### PR DESCRIPTION
# 📋 연관 이슈

close #1147  

# 📝 작업 요약

SSE 수신 이후의 데이터 해석, cache 반영, query invalidate, toast 표시 기준을 `useSSENotifications` 훅에서 분리하고, 현재 서버 SSE payload 기준으로 알림 처리 흐름을 정리했습니다.

기존의 알림 목록 cache 즉시 반영 흐름은 유지하되, 서버가 내려주지 않는 값을 클라이언트에서 임의로 보완하던 부분과 알림 타입별 후처리 기준이 훅 내부에 섞여 있던 부분을 개선했습니다.


# 🚀 작업 내용
## 1️⃣ SSE 알림 수신 후 데이터 처리 경계 분리

### What

`useSSENotifications` 안에 있던 SSE 알림 후처리 로직을 작은 순수 함수로 분리했습니다.

- `parseSsePayload`
- `isSseNotificationPayload`
- `mapSsePayloadToNotificationItem`
- `prependNotificationToCache`
- `getNotificationInvalidationTargets`
- `getGroupIdFromLink`
- `getSseNotificationToast`

### Why

SSE 알림 수신 후 일부 Toast 표시와 관련 화면 갱신이 누락되는 흐름을 확인했습니다.

기존 훅에는 JSON 파싱, payload 검증, 알림 모델 변환, cache 갱신, query invalidate, toast 표시가 함께 들어 있어 실패 지점을 나누어 확인하기 어려웠습니다.

또한 현재 서버 SSE 응답에는 `targetType`, `targetId`가 포함되지 않는데, 클라이언트에서 기본값을 만들어 알림 cache에 넣고 있었습니다. 이는 서버가 제공하지 않은 값을 클라이언트가 임의로 해석하는 구조라, 실제 payload와 클라이언트 알림 모델 사이의 기준이 어긋날 수 있다고 판단했습니다.


### How

- `notificationId`를 클라이언트 `NotificationItem.id`로 매핑
- 서버가 내려주지 않는 `targetType`, `targetId` 기본값 제거
- `link: null`도 유효한 payload로 처리
- 알림 타입/link 기준으로 invalidate할 query key를 `getNotificationInvalidationTargets`에서 계산하도록 분리
- 실제 화면 조회에 사용되는 `queryKeys`와 맞는 key를 invalidate하도록 정리
- 알림 타입별 toast 표시 내용을 `getSseNotificationToast`에서 계산
- 분리한 데이터 처리/표시 정책 함수는 순수 함수 단위 테스트로 검증

## 2️⃣ SSE 데이터 처리 에러 보고 정리

### What

SSE 데이터 처리 실패를 사용자 toast로 바로 노출하지 않고, Sentry 보고 함수로 넘기도록 변경했습니다.

### Why

invalid JSON, payload shape 불일치, 후처리 중 예외는 사용자가 직접 해결하기 어려운 백그라운드 처리 오류에 가깝다고 판단했습니다.

이런 오류를 사용자 toast로 노출하면 사용자는 조치할 수 없는 오류 메시지를 보게 되고, 실제 문제 원인과 무관하게 서비스가 불안정하다고 느낄 수 있습니다.

따라서 이번 범위에서는 사용자 노출보다 개발자 추적이 더 적절하다고 보고, 실패 원인을 `parse-error`, `invalid-payload`, `unknown`으로 나누어 Sentry에 보고하도록 정리했습니다.

### How

- `parse-error`, `invalid-payload`, `unknown` reason으로 실패 원인 분류
- 데이터 처리 실패 시 기존 `toast.error` 제거
- `reportSseNotificationError(reason, error?)` 추가
- raw payload/event.data는 사용자 정보나 불필요한 원본 데이터가 포함될 수 있어 Sentry 보고 인자에서 제외

## 3️⃣ 알림 타입별 toast 표시 누락 보완

### What

일부 SSE 알림이 수신되어도 toast가 표시되지 않던 흐름을 보완했습니다.

### Why

두 계정으로 테스트하던 중, `COMMENT_LIKED` SSE 스트림은 수신됐지만 toast가 표시되지 않는 것을 확인했습니다.

기존 toast 분기는 `NEW_COMMENT_ON_MOMENT`만 처리하고 있어, 좋아요 알림이나 그룹 상태 알림은 수신되더라도 toast 표시 대상이 아니었습니다.

### How

- `getSseNotificationToast`로 알림 타입별 toast 표시 내용을 계산
- `NEW_COMMENT_ON_MOMENT`, `MOMENT_LIKED`는 모멘트 이동 toast로 표시
- `COMMENT_LIKED`는 코멘트 이동 toast로 표시
- `GROUP_JOIN_REQUEST`, `GROUP_JOIN_APPROVED`, `GROUP_KICKED`는 이동 없는 toast로 표시

## 4️⃣ 코멘트 알림 읽음 처리 보완

### What

코멘트 알림 확인 시 해당 코멘트에 연결된 `notificationIds` 전체를 읽음 처리하도록 변경했습니다.

### Why

기존에는 `notificationIds[0]`만 읽음 처리하고 있었습니다.

따라서 동일 코멘트에 대해 여러 알림이 누적된 경우, 첫 번째 알림만 읽음 처리되고 나머지 알림이 미읽음 상태로 남아 댓글 미읽음 상태가 계속 표시될 수 있었습니다.


### How

- `useMyCommentsCard`에서 `notificationIds[0]`만 읽음 처리하던 흐름을 `notificationIds` 전체 읽음 처리로 변경
read-all 성공 후 `commentsUnread`, `momentsUnread` query invalidate 추가

# 🧪 Test

이번 변경은 SSE 연결 자체가 아니라, SSE 수신 이후의 데이터 해석과 후처리 정책을 수정하는 작업입니다.

기존에는 이 로직이 `useSSENotifications` 훅 내부에 섞여 있어 개별 케이스를 확인하기 어려웠기 때문에, payload 파싱/검증/매핑, cache prepend, invalidate target 계산, toast 표시 정책을 순수 함수로 분리하고 단위 테스트로 검증했습니다.

단, 실제 EventSource 연결/재연결 동작은 이번 테스트 범위에 포함하지 않았고, SSE 수신 이후의 데이터 해석과 후처리 정책을 단위 테스트 대상으로 삼았습니다.

```bash
pnpm test -- sseNotificationPayload.test.ts --runInBand
pnpm exec tsc --noEmit
pnpm exec eslint src/features/notification/hooks/useSSENotifications.ts src/features/notification/utils/sseNotificationPayload.ts src/features/notification/utils/sseNotificationError.ts src/features/notification/utils/sseNotificationPayload.test.ts
pnpm exec eslint src/features/comment/hooks/useMyCommentsCard.ts src/features/notification/api/useReadAllNotificationsMutation.ts
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 그룹 초대/승인, 게시물·댓글 좋아요 알림 지원 추가

* **Bug Fixes**
  * 알림 배지 표시 로직 개선 및 안정성 강화
  * 알림 처리 오류 추적 및 보고 기능 추가

* **Tests**
  * SSE 알림 유틸리티 단위 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->